### PR TITLE
Adds Authorization Header to proxied requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ then the *prometheus.yml* scrape_config would target the three apps with:
 * http://mymachine.local:8080/app2_metrics
 * http://mymachine.local:8080/app3_metrics
 
-If the endpoints use basic auth, then include the credentials in the URL with: `http://user:pass@hostname/metrics`
+If the endpoints were restricted with basic auth/bearer authentication, you could either include the basic-auth credentials in the URL with: `http://user:pass@hostname/metrics` or they could be configured with `basic_auth`/`bearer_token` in the scrape-config.
 
 The `prometheus.yml` file would include:
 
@@ -91,10 +91,14 @@ The `prometheus.yml` file would include:
 scrape_configs:
   - job_name: 'app1 metrics'
     metrics_path: '/app1_metrics'
+    bearer_token: 'eyJ....hH9rloA'
     static_configs:
       - targets: [ 'mymachine.local:8080' ]
   - job_name: 'app2 metrics'
     metrics_path: '/app2_metrics'
+    basic_auth:
+        username: 'user'
+        password: 's3cr3t'
     static_configs:
       - targets: [ 'mymachine.local:8080' ]
   - job_name: 'app3 metrics'

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -56,6 +56,11 @@ internal class AgentHttpService(val agent: Agent) {
       val scrapeMsg = AtomicReference("")
       val path = request.path
       val encodedQueryParams = request.encodedQueryParams
+      val authHeader = when {
+        request.authHeader.isNullOrBlank() -> null
+        else -> request.authHeader
+      }
+
       val pathContext = agent.pathManager[path]
 
       if (pathContext.isNull()) {
@@ -106,6 +111,7 @@ internal class AgentHttpService(val agent: Agent) {
                       val scrapeTimeout = agent.options.scrapeTimeoutSecs.seconds
                       logger.debug { "Setting scrapeTimeoutSecs = $scrapeTimeout" }
                       timeout { requestTimeoutMillis = scrapeTimeout.inWholeMilliseconds }
+                      authHeader?.also { header(io.ktor.http.HttpHeaders.Authorization, it) }
                     },
                     getBlock(url, scrapeResults, scrapeMsg, request.debugEnabled)
                   )

--- a/src/main/kotlin/io/prometheus/common/GrpcObjects.kt
+++ b/src/main/kotlin/io/prometheus/common/GrpcObjects.kt
@@ -98,6 +98,7 @@ internal object GrpcObjects {
     scrapeId: Long,
     path: String,
     encodedQueryParams: String,
+    authHeader: String,
     accept: String?,
     debugEnabled: Boolean
   ): ScrapeRequest {
@@ -107,6 +108,7 @@ internal object GrpcObjects {
       this.scrapeId = scrapeId
       this.path = path
       this.encodedQueryParams = encodedQueryParams
+      this.authHeader = authHeader
       this.debugEnabled = debugEnabled
       if (!accept.isNullOrBlank())
         this.accept = accept

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
@@ -207,6 +207,7 @@ internal object ProxyHttpConfig : KLogging() {
       proxy,
       path,
       encodedQueryParams,
+      request.header(HttpHeaders.Authorization) ?: "",
       request.header(HttpHeaders.Accept),
       proxy.options.debugEnabled
     )

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
@@ -36,6 +36,7 @@ internal class ScrapeRequestWrapper(
   proxy: Proxy,
   path: String,
   encodedQueryParams: String,
+  authHeader: String,
   accept: String?,
   debugEnabled: Boolean
 ) {
@@ -50,6 +51,7 @@ internal class ScrapeRequestWrapper(
       SCRAPE_ID_GENERATOR.getAndIncrement(),
       path,
       encodedQueryParams,
+      authHeader,
       accept,
       debugEnabled
     )

--- a/src/main/proto/proxy_service.proto
+++ b/src/main/proto/proxy_service.proto
@@ -61,6 +61,7 @@ message ScrapeRequest {
   string accept = 4;
   bool debug_enabled = 5;
   string encodedQueryParams = 6;
+  string authHeader = 7;
 }
 
 message ScrapeResponse {


### PR DESCRIPTION
For retrieving password/JWT-protected endpoints with the default prometheus mechanisms, the Authorization-Header is passed transparently from the request to the proxy-endpoint to the http call made by the agent.