### PR TITLE
WIP Adding service discovery endpoint for prometheus

### DIFF
--- a/src/main/java/io/prometheus/common/ConfigVals.java
+++ b/src/main/java/io/prometheus/common/ConfigVals.java
@@ -218,6 +218,7 @@ public class ConfigVals {
       public final int recentRequestsQueueSize;
       public final java.lang.String threadDumpPath;
       public final java.lang.String versionPath;
+      public final java.lang.String discoverUrl;
 
       public Admin2(com.typesafe.config.Config c, java.lang.String parentPath, $TsCfgValidator $tsCfgValidator) {
         this.debugEnabled = c.hasPathOrNull("debugEnabled") && c.getBoolean("debugEnabled");
@@ -228,6 +229,7 @@ public class ConfigVals {
         this.recentRequestsQueueSize = c.hasPathOrNull("recentRequestsQueueSize") ? c.getInt("recentRequestsQueueSize") : 50;
         this.threadDumpPath = c.hasPathOrNull("threadDumpPath") ? c.getString("threadDumpPath") : "threaddump";
         this.versionPath = c.hasPathOrNull("versionPath") ? c.getString("versionPath") : "version";
+        this.discoverUrl = c.hasPathOrNull("discoverUrl") ? c.getString("discoverUrl") : ("http://localhost:8080/");
       }
     }
 

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -31,6 +31,7 @@ import com.github.pambrose.common.util.getBanner
 import com.google.common.base.Joiner
 import com.google.common.collect.EvictingQueue
 import io.prometheus.common.BaseOptions.Companion.DEBUG
+import io.prometheus.common.BaseOptions.Companion.DISCOVER
 import io.prometheus.common.ConfigVals
 import io.prometheus.common.ConfigWrappers.newAdminConfig
 import io.prometheus.common.ConfigWrappers.newMetricsConfig
@@ -117,6 +118,10 @@ class Proxy(
                        .joinToString("\n")
                    })
       }
+      addServlet(DISCOVER,
+                 LambdaServlet("application/json") {
+                   "[{\"targets\":[" + pathManager.getPaths().map { "\"${options.discoverUrl + it}\"" }.joinToString(",") + "]}]"
+                 })
     }
 
     initBlock?.invoke(this)

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -258,6 +258,7 @@ abstract class BaseOptions protected constructor(
   companion object : KLogging() {
     private val PROPS = ConfigParseOptions.defaults().setSyntax(ConfigSyntax.PROPERTIES)
     const val DEBUG = "debug"
+    const val DISCOVER = "discover"
     const val HTTP_PREFIX = "http://"
     const val HTTPS_PREFIX = "https://"
   }

--- a/src/main/kotlin/io/prometheus/common/EnvVars.kt
+++ b/src/main/kotlin/io/prometheus/common/EnvVars.kt
@@ -26,6 +26,7 @@ enum class EnvVars {
   PROXY_CONFIG,
   PROXY_PORT,
   AGENT_PORT,
+  DISCOVER_URL,
 
   // Agent
   AGENT_CONFIG,

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -37,6 +37,16 @@ class ProxyOptions(argv: Array<String>) : BaseOptions(Proxy::class.java.simpleNa
   var proxyAgentPort = -1
     private set
 
+  @Parameter(names = ["--discoverUrl"], description = "URL of this service")
+  var discoverUrl = ""
+    private set
+
+  protected fun assignDiscoverUrl(defaultVal: String) {
+    if (discoverUrl.isEmpty())
+      discoverUrl = DISCOVER_URL.getEnv(defaultVal)
+    logger.info { "discoverUrl: $privateKeyFilePath" }
+  }
+
   init {
     parseOptions()
   }
@@ -58,6 +68,7 @@ class ProxyOptions(argv: Array<String>) : BaseOptions(Proxy::class.java.simpleNa
         assignMetricsEnabled(proxyConfigVals.metrics.enabled)
         assignMetricsPort(proxyConfigVals.metrics.port)
         assignDebugEnabled(proxyConfigVals.admin.debugEnabled)
+        assignDiscoverUrl(proxyConfigVals.admin.discoverUrl)
 
         assignCertChainFilePath(proxyConfigVals.tls.certChainFilePath)
         assignPrivateKeyFilePath(proxyConfigVals.tls.privateKeyFilePath)

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -43,6 +43,12 @@ internal class ProxyPathManager(private val proxy: Proxy, private val isTestMode
   val pathMapSize: Int
     get() = pathMap.size
 
+  fun getPaths(): List<String> {
+    synchronized(pathMap) {
+      return pathMap.keys.toList()
+    }
+  }
+
   fun addPath(path: String, agentContext: AgentContext) {
     require(path.isNotEmpty()) { EMPTY_PATH_MSG }
 


### PR DESCRIPTION
Added a quick implementation of https://prometheus.io/docs/prometheus/latest/http_sd/ to scrape all known agents automatically via the endpoint `http://localhost:8092/discover`. The proxy-paths were prefixed with the value of `discoverUrl`, under which the prometheus instance could query the proxied agents.

Not sure, if the option/default/env-handling is consistent with the configuration-handling of the `AdminService`/`AdminConfig`. Should the endpoint `/discover` also configurable?