### PR TITLE
fix(service-discovery): fix service discovery format problem

### DIFF
--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
@@ -108,13 +108,17 @@ internal object ProxyHttpConfig : KLogging() {
 
         get(proxy.options.sdPath) {
           val json = buildJsonArray {
-            proxy.pathManager.allPaths.forEach {
+            proxy.pathManager.allPaths.forEach { path ->
               addJsonObject {
                 putJsonArray("targets") {
                   add(JsonPrimitive(proxy.options.sdTargetPrefix))
                 }
                 putJsonObject("labels") {
-                  put("__metrics_path__", JsonPrimitive(it))
+                  put("__metrics_path__", JsonPrimitive(path))
+
+                  val agentContexts = proxy.pathManager.getAgentContextInfo(path)?.agentContexts
+                  put("agentName",  JsonPrimitive(agentContexts?.map { it.agentName }?.joinToString()))
+                  put("hostName",  JsonPrimitive(agentContexts?.map { it.hostName }?.joinToString()))
                 }
               }
             }


### PR DESCRIPTION
This fix the service discovery format explain in issue https://github.com/pambrose/prometheus-proxy/issues/82
the file generated looks like
```json
[
    {
        "targets": [
            "prometheus-proxy:8080"
        ],
        "labels": {
            "__metrics_path__": "my1_metrics"
        }
    },
   {
        "targets": [
            "prometheus-proxy:8080"
        ],
        "labels": {
            "__metrics_path__": "my2_metrics"
        }
    },
]
```
