### PR TITLE
Fix KDocs nav redirect 404 (#124)

### DIFF
--- a/website/prometheus-proxy/docs/api.md
+++ b/website/prometheus-proxy/docs/api.md
@@ -5,7 +5,7 @@ icon: material/book-open-page-variant
 # API Documentation (KDocs)
 
 <script>
-  window.location.href = "kdocs/index.html";
+  window.location.href = "../kdocs/index.html";
 </script>
 
-Redirecting to [KDocs](kdocs/index.html)...
+Redirecting to [KDocs](../kdocs/index.html)...

--- a/website/prometheus-proxy/zensical.toml
+++ b/website/prometheus-proxy/zensical.toml
@@ -43,7 +43,7 @@ nav = [
   { "Advanced" = [
     { "Advanced Topics" = "advanced.md" },
   ]},
-  { "KDocs" = "kdocs.md" },
+  { "KDocs" = "api.md" },
 ]
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Renamed `kdocs.md` to `api.md` to avoid path conflict with the Dokka output at `site/kdocs/`
- Fixed redirect URL from `kdocs/index.html` to `../kdocs/index.html`
- Updated nav reference in `zensical.toml`

## Test plan
- [ ] Verify KDocs nav link no longer leads to a 404
- [ ] Verify redirect lands on the Dokka API documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)