### PR TITLE
Docs enhancements: grid cards, compilable examples, markdown extensions (#125)

### DIFF
--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -17,6 +17,7 @@
 package io.prometheus
 
 import com.codahale.metrics.health.HealthCheck
+import com.google.common.util.concurrent.RateLimiter
 import com.pambrose.common.delegate.AtomicDelegates.nonNullableReference
 import com.pambrose.common.dsl.GuavaDsl.toStringElements
 import com.pambrose.common.dsl.MetricsDsl.healthCheck
@@ -29,7 +30,6 @@ import com.pambrose.common.util.hostInfo
 import com.pambrose.common.util.randomId
 import com.pambrose.common.util.runCatchingCancellable
 import com.pambrose.common.util.simpleClassName
-import com.google.common.util.concurrent.RateLimiter
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.grpc.Status
 import io.grpc.StatusException
@@ -499,6 +499,12 @@ class Agent(
     super.shutDown()
   }
 
+  // This is called from EmbeddedAgentInfo to allow external callers to shutdown
+  // the agent without needing access to the full Agent instance.
+  fun stop() {
+    shutDown()
+  }
+
   override fun toString() =
     toStringElements {
       add("agentId", agentId)
@@ -541,7 +547,7 @@ class Agent(
           info { getVersionDesc() }
         }
       val agent = Agent(options = AgentOptions(configFilename, exitOnMissingConfig)) { startAsync() }
-      return EmbeddedAgentInfo(agent.launchId, agent.agentName)
+      return EmbeddedAgentInfo(agent)
     }
   }
 }

--- a/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
+++ b/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
@@ -16,7 +16,15 @@
 
 package io.prometheus.agent
 
+import io.prometheus.Agent
+
 data class EmbeddedAgentInfo(
-  val launchId: String,
-  val agentName: String,
-)
+  private val agent: Agent,
+) {
+  val launchId: String get() = agent.launchId
+  val agentName: String get() = agent.agentName
+
+  fun shutdown() {
+    agent.stop()
+  }
+}

--- a/src/test/java/website/EmbeddedAgentJavaExample.java
+++ b/src/test/java/website/EmbeddedAgentJavaExample.java
@@ -1,0 +1,22 @@
+package website;
+
+// --8<-- [start:embedded-java]
+import io.prometheus.Agent;
+import io.prometheus.agent.EmbeddedAgentInfo;
+
+public class EmbeddedAgentJavaExample {
+  public static void main(String[] args) {
+    // Start the agent in the background
+    EmbeddedAgentInfo agentInfo =
+      Agent.startAsyncAgent("agent-config.conf", true, true);
+
+    System.out.println("Agent started: " + agentInfo.getAgentName());
+
+    // Your application code runs here...
+    // The agent runs in background threads
+
+    // Stop the agent when your application exits
+    agentInfo.shutdown();
+  }
+}
+// --8<-- [end:embedded-java]

--- a/src/test/kotlin/io/prometheus/agent/EmbeddedAgentInfoTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/EmbeddedAgentInfoTest.kt
@@ -20,55 +20,39 @@ package io.prometheus.agent
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.prometheus.Agent
 
 class EmbeddedAgentInfoTest : StringSpec() {
   init {
-    "should store launchId and agentName" {
-      val info = EmbeddedAgentInfo(launchId = "launch-123", agentName = "test-agent")
+    "should expose launchId from agent" {
+      val agent = mockk<Agent>()
+      every { agent.launchId } returns "launch-123"
+      every { agent.agentName } returns "test-agent"
+
+      val info = EmbeddedAgentInfo(agent)
 
       info.launchId shouldBe "launch-123"
+    }
+
+    "should expose agentName from agent" {
+      val agent = mockk<Agent>()
+      every { agent.agentName } returns "test-agent"
+
+      val info = EmbeddedAgentInfo(agent)
+
       info.agentName shouldBe "test-agent"
     }
 
-    "should handle empty values" {
-      val info = EmbeddedAgentInfo(launchId = "", agentName = "")
+    "shutdown should call agent stop" {
+      val agent = mockk<Agent>(relaxed = true)
 
-      info.launchId shouldBe ""
-      info.agentName shouldBe ""
-    }
+      val info = EmbeddedAgentInfo(agent)
+      info.shutdown()
 
-    "equals should compare by field values" {
-      val info1 = EmbeddedAgentInfo(launchId = "launch-1", agentName = "agent-1")
-      val info2 = EmbeddedAgentInfo(launchId = "launch-1", agentName = "agent-1")
-      val info3 = EmbeddedAgentInfo(launchId = "launch-2", agentName = "agent-1")
-
-      info1 shouldBe info2
-      info1 shouldNotBe info3
-    }
-
-    "hashCode should be consistent with equals" {
-      val info1 = EmbeddedAgentInfo(launchId = "launch-1", agentName = "agent-1")
-      val info2 = EmbeddedAgentInfo(launchId = "launch-1", agentName = "agent-1")
-
-      info1.hashCode() shouldBe info2.hashCode()
-    }
-
-    "copy should create independent instance" {
-      val original = EmbeddedAgentInfo(launchId = "launch-1", agentName = "agent-1")
-      val copied = original.copy(agentName = "agent-2")
-
-      original.agentName shouldBe "agent-1"
-      copied.agentName shouldBe "agent-2"
-      copied.launchId shouldBe "launch-1"
-    }
-
-    "toString should include field values" {
-      val info = EmbeddedAgentInfo(launchId = "launch-123", agentName = "my-agent")
-      val str = info.toString()
-
-      str.contains("launch-123") shouldBe true
-      str.contains("my-agent") shouldBe true
+      verify { agent.stop() }
     }
   }
 }

--- a/src/test/kotlin/website/EmbeddedAgentExamples.txt
+++ b/src/test/kotlin/website/EmbeddedAgentExamples.txt
@@ -1,39 +1,4 @@
-; --8<-- [start:embedded-java]
-import io.prometheus.Agent;
-import io.prometheus.agent.EmbeddedAgentInfo;
-
-public class MyApp {
-  public static void main(String[] args) {
-    // Start the agent in the background
-    EmbeddedAgentInfo agentInfo =
-      Agent.startAsyncAgent("agent-config.conf", true);
-
-    System.out.println("Agent started: " + agentInfo.getAgentName());
-
-    // Your application code runs here...
-    // The agent runs in background threads
-  }
-}
-; --8<-- [end:embedded-java]
-
-; --8<-- [start:embedded-kotlin]
-import io.prometheus.Agent
-
-fun main() {
-  // Start the agent in the background
-  val agentInfo = Agent.startAsyncAgent(
-    configFilename = "agent-config.conf",
-    exitOnMissingConfig = true,
-  )
-
-  println("Agent started: ${agentInfo.agentName}")
-
-  // Your application code runs here...
-  // The agent runs in background coroutines
-}
-; --8<-- [end:embedded-kotlin]
-
-; --8<-- [start:gradle-dependency]
+// --8<-- [start:gradle-dependency]
 // build.gradle.kts
 repositories {
   mavenCentral()
@@ -42,9 +7,9 @@ repositories {
 dependencies {
   implementation("com.pambrose:prometheus-proxy:3.1.0")
 }
-; --8<-- [end:gradle-dependency]
+// --8<-- [end:gradle-dependency]
 
-; --8<-- [start:maven-dependency]
+<!-- --8<-- [start:maven-dependency] -->
 <!-- pom.xml -->
 <dependencies>
   <dependency>
@@ -53,9 +18,9 @@ dependencies {
     <version>3.1.0</version>
   </dependency>
 </dependencies>
-; --8<-- [end:maven-dependency]
+<!-- --8<-- [end:maven-dependency] -->
 
-; --8<-- [start:embedded-agent-config]
+// --8<-- [start:embedded-agent-config]
 // Minimal config for an embedded agent:
 agent {
   proxy.hostname = "proxy-host.example.com"
@@ -68,4 +33,4 @@ agent {
     }
   ]
 }
-; --8<-- [end:embedded-agent-config]
+// --8<-- [end:embedded-agent-config]

--- a/src/test/kotlin/website/EmbeddedAgentKotlinExample.kt
+++ b/src/test/kotlin/website/EmbeddedAgentKotlinExample.kt
@@ -1,0 +1,21 @@
+package website
+
+// --8<-- [start:embedded-kotlin]
+import io.prometheus.Agent
+
+fun main() {
+  // Start the agent in the background
+  val agentInfo = Agent.startAsyncAgent(
+    configFilename = "agent-config.conf",
+    exitOnMissingConfig = true,
+  )
+
+  println("Agent started: ${agentInfo.agentName}")
+
+  // Your application code runs here...
+  // The agent runs in background coroutines
+
+  // Stop the agent when your application exits
+  agentInfo.shutdown()
+}
+// --8<-- [end:embedded-kotlin]

--- a/website/prometheus-proxy/docs/configuration/index.md
+++ b/website/prometheus-proxy/docs/configuration/index.md
@@ -95,6 +95,30 @@ For the complete configuration schema, see the reference file:
 
 ## Next Steps
 
-- [Agent Configuration](agent.md) -- path configs, HTTP client, scrape settings
-- [Proxy Configuration](proxy.md) -- HTTP service, gRPC, service discovery
-- [CLI Reference](../cli-reference.md) -- all CLI options and environment variables
+<div class="grid cards" markdown>
+
+-   :material-robot:{ .lg .middle } __Agent Configuration__
+
+    ---
+
+    Path configs, HTTP client, and scrape settings
+
+    [:octicons-arrow-right-24: Agent Configuration](agent.md)
+
+-   :material-server:{ .lg .middle } __Proxy Configuration__
+
+    ---
+
+    HTTP service, gRPC, and service discovery settings
+
+    [:octicons-arrow-right-24: Proxy Configuration](proxy.md)
+
+-   :material-console:{ .lg .middle } __CLI Reference__
+
+    ---
+
+    All CLI options and environment variables
+
+    [:octicons-arrow-right-24: CLI Reference](../cli-reference.md)
+
+</div>

--- a/website/prometheus-proxy/docs/embedded-agent.md
+++ b/website/prometheus-proxy/docs/embedded-agent.md
@@ -32,13 +32,13 @@ instead of running a separate agent process.
 === "Java"
 
     ```java
-    --8<-- "EmbeddedAgentExamples.txt:embedded-java"
+    --8<-- "EmbeddedAgentJavaExample.java:embedded-java"
     ```
 
 === "Kotlin"
 
     ```kotlin
-    --8<-- "EmbeddedAgentExamples.txt:embedded-kotlin"
+    --8<-- "EmbeddedAgentKotlinExample.kt:embedded-kotlin"
     ```
 
 ## Agent Configuration

--- a/website/prometheus-proxy/docs/getting-started.md
+++ b/website/prometheus-proxy/docs/getting-started.md
@@ -173,7 +173,38 @@ When Prometheus scrape configs include `basic_auth` or `bearer_token`, the proxy
 
 ## Next Steps
 
-- [Agent Configuration](configuration/agent.md) -- all agent settings
-- [Proxy Configuration](configuration/proxy.md) -- all proxy settings
-- [Docker Usage](docker.md) -- production Docker setups
-- [Security & TLS](security/index.md) -- secure the proxy-agent connection
+<div class="grid cards" markdown>
+
+-   :material-robot:{ .lg .middle } __Agent Configuration__
+
+    ---
+
+    All agent settings including path configs, HTTP client, and scrape options
+
+    [:octicons-arrow-right-24: Agent Configuration](configuration/agent.md)
+
+-   :material-server:{ .lg .middle } __Proxy Configuration__
+
+    ---
+
+    All proxy settings including HTTP service, gRPC, and service discovery
+
+    [:octicons-arrow-right-24: Proxy Configuration](configuration/proxy.md)
+
+-   :material-docker:{ .lg .middle } __Docker Usage__
+
+    ---
+
+    Production Docker setups and docker-compose examples
+
+    [:octicons-arrow-right-24: Docker](docker.md)
+
+-   :material-shield-lock:{ .lg .middle } __Security & TLS__
+
+    ---
+
+    Secure the proxy-agent connection with TLS and mutual authentication
+
+    [:octicons-arrow-right-24: Security](security/index.md)
+
+</div>

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -90,10 +90,44 @@ See the [Quick Start Guide](getting-started.md) for detailed instructions.
 | **Federation** | Scrape existing Prometheus instances via `/federate` endpoint |
 | **Kubernetes** | Monitor services across clusters or namespaces |
 
-## Learn More
+## API Reference
 
-- [Architecture](architecture.md) -- detailed component and protocol descriptions
-- [Configuration](configuration/index.md) -- HOCON config format and options
-- [Security & TLS](security/index.md) -- TLS setup and auth header forwarding
-- [Monitoring](monitoring.md) -- built-in metrics and Grafana dashboards
-- [KDoc API Reference](kdocs/) -- generated API documentation
+Full API documentation (KDocs) is available at [KDocs](kdocs/).
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :material-sitemap:{ .lg .middle } __Architecture__
+
+    ---
+
+    Understand the proxy/agent components, gRPC protocol, and request flow
+
+    [:octicons-arrow-right-24: Architecture](architecture.md)
+
+-   :material-cog:{ .lg .middle } __Configuration__
+
+    ---
+
+    Configure the application with HOCON and environment variables
+
+    [:octicons-arrow-right-24: Configuration](configuration/index.md)
+
+-   :material-shield-lock:{ .lg .middle } __Security & TLS__
+
+    ---
+
+    Set up TLS encryption and mutual authentication
+
+    [:octicons-arrow-right-24: Security](security/index.md)
+
+-   :material-chart-line:{ .lg .middle } __Monitoring__
+
+    ---
+
+    Built-in metrics and Grafana dashboards
+
+    [:octicons-arrow-right-24: Monitoring](monitoring.md)
+
+</div>

--- a/website/prometheus-proxy/zensical.toml
+++ b/website/prometheus-proxy/zensical.toml
@@ -99,9 +99,26 @@ link = "https://github.com/pambrose/prometheus-proxy"
 # Markdown extensions
 # ----------------------------------------------------------------------------
 
+# attr_list - add HTML attributes to Markdown elements
+[project.markdown_extensions.attr_list]
+
+# md_in_html - render Markdown inside HTML blocks (needed for grid cards)
+[project.markdown_extensions.md_in_html]
+
+# admonition - callout blocks (!!!)
+[project.markdown_extensions.admonition]
+
+# pymdownx.details - collapsible admonitions (???)
+[project.markdown_extensions.pymdownx.details]
+
+# pymdownx.emoji - inline icons (:material-*:, :octicons-*:, :fontawesome-*:)
+[project.markdown_extensions.pymdownx.emoji]
+emoji_index = "material.extensions.emoji.twemoji"
+emoji_generator = "material.extensions.emoji.to_svg"
+
 # pymdownx.snippets - import code from external files
 [project.markdown_extensions.pymdownx.snippets]
-base_path = ["../../src/test/kotlin/website", "../.."]
+base_path = ["../../src/test/kotlin/website", "../../src/test/java/website", "../.."]
 check_paths = true
 
 # pymdownx.superfences - fenced code blocks with Mermaid support (Mermaid is built-in)


### PR DESCRIPTION
## Summary
- Converted "Next Steps" bullet lists to mkdocs-material grid cards on index, getting-started, and configuration overview pages
- Added API Reference section with KDocs link above Next Steps on index page
- Extracted Java/Kotlin code examples into compilable source files (`EmbeddedAgentJavaExample.java`, `EmbeddedAgentKotlinExample.kt`) so API changes are caught by the compiler
- Updated `EmbeddedAgentInfo` to accept `Agent` argument; rewrote tests with MockK
- Added markdown extensions: `admonition`, `pymdownx.details`, `attr_list`, `md_in_html`, `pymdownx.emoji` (with material icon support)

## Test plan
- [ ] Verify grid cards render correctly on index, getting-started, and configuration pages
- [ ] Verify admonitions (`!!! tip`) render correctly
- [ ] Verify material/octicons icons render in grid cards
- [ ] Verify KDocs link works from API Reference section
- [ ] Verify `./gradlew build` compiles the new Java/Kotlin example files
- [ ] Verify `EmbeddedAgentInfoTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)