### PR TITLE
Update Prometheus Proxy link to documentation site (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 collecting metrics. The pull model is problematic when a firewall separates a Prometheus server and its metrics
 endpoints.
 
-[Prometheus Proxy](https://github.com/pambrose/prometheus-proxy) enables Prometheus to scrape metrics endpoints running
+[Prometheus Proxy](https://pambrose.github.io/prometheus-proxy/) enables Prometheus to scrape metrics endpoints running
 behind a firewall and preserves the native pull-based model architecture.
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
- Point the main README "Prometheus Proxy" link to the GitHub Pages documentation site instead of the GitHub repository

## Test plan
- [ ] Verify the link in README.md points to https://pambrose.github.io/prometheus-proxy/

🤖 Generated with [Claude Code](https://claude.com/claude-code)