### PR TITLE
Bump to 3.1.1: dependency updates, build cleanup, public-API docs (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## [3.1.1] - 2026-04-25
+
+### New Features
+
+- Add `-PoverrideReleaseDate` and `-PoverrideBuildTime` Gradle properties for reproducible builds (`BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` now accept overrides instead of always reading the local clock)
+
+### Build & Tooling
+
+- Centralize repository declarations in `settings.gradle.kts` via `dependencyResolutionManagement(FAIL_ON_PROJECT_REPOS)`; opt into `mavenLocal()` with `-PuseMavenLocal=true`
+- Replace the `agentJar` / `proxyJar` zipTree-rewrap pattern with two `ShadowJar` tasks for configuration-cache safety on Gradle 9.x and one fewer redundant fat jar
+- Drop the redundant `java` plugin (already applied transitively by `kotlin.jvm`)
+- Use `tasks.named("generateProto")` instead of the `:generateProto` path string
+- Mark internal `Utils` object as `internal` so it no longer leaks into the public API surface
+- Add Claude Code GitHub workflow
+
+### Documentation
+
+- Add KDoc to every `@Parameter` field on `BaseOptions`, `AgentOptions`, and `ProxyOptions`, every value of the `EnvVars` enum, the `Agent` and `Proxy` companion entry points, and `EmbeddedAgentInfo` — the supported public API now has full Dokka coverage with resolution-precedence, sentinel-value, and validation notes
+- Trim `docs/packages.md` to advertise only the genuinely-public surface (`Agent`, `Proxy`, `AgentOptions`, `ProxyOptions`, `BaseOptions`, `EnvVars`, `EmbeddedAgentInfo`); remove dangling cross-references to internal types
+- Refresh website docs and metrics-and-grafana reference
+
+### Dependency Updates
+
+| Dependency     | Old    | New    |
+|----------------|--------|--------|
+| Kotlin         | 2.3.20 | 2.3.21 |
+| Ktor           | 3.4.2  | 3.4.3  |
+| serialization  | 1.10.0 | 1.11.0 |
+| tcnative       | 2.0.74.Final | 2.0.77.Final |
+| utils          | 2.7.1  | 2.8.1  |
+| gradle-plugins | 1.0.12 | 1.0.14 |
+| protobuf       | 0.9.6  | 0.10.0 |
+| taskinfo       | 3.0.1  | 3.0.2  |
+
+---
+
 ## [3.1.0] - 2026-04-04
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,22 @@ Prometheus → Proxy HTTP (:8080) → AgentContext lookup → ScrapeRequest via 
    - `HttpClientCache` — caches HTTP clients keyed by auth credentials (TTL/idle eviction)
 
 3. **Common (`io.prometheus.common/`)** — shared between proxy and agent
-   - `BaseOptions` — CLI argument parsing and config loading
+   - `BaseOptions` — CLI argument parsing and config loading (parent of `AgentOptions` / `ProxyOptions`)
    - `ConfigVals` — type-safe config wrapper (auto-generated from HOCON via tscfg; see `make tsconfig`)
    - `ScrapeResults` — scrape response data model
    - `EnvVars` — environment variable mappings
+
+### Public API Surface (Dokka)
+
+Only these types are part of the supported, documented public API. Everything else is `internal`:
+
+- `io.prometheus.Agent` (entry point + companion `main` / `startSyncAgent` / `startAsyncAgent`)
+- `io.prometheus.Proxy` (entry point + companion `main`)
+- `io.prometheus.agent.AgentOptions` / `io.prometheus.proxy.ProxyOptions` / `io.prometheus.common.BaseOptions`
+- `io.prometheus.agent.EmbeddedAgentInfo` (handle returned by `Agent.startAsyncAgent`)
+- `io.prometheus.common.EnvVars`
+
+When promoting a type from `internal` to `public`, also add a cross-reference to it in `docs/packages.md` (the Dokka `includes.from` file). When demoting, remove the link to avoid dangling references in the generated site.
 
 ### gRPC Service Definition
 
@@ -92,9 +104,20 @@ Defined in `src/main/proto/proxy_service.proto`. Key RPCs:
 
 ## Configuration
 
-Uses Typesafe Config (HOCON). Precedence: CLI args → env vars → config file. Reference schema: `config/config.conf`. Example configs in `examples/`.
+Uses Typesafe Config (HOCON). Precedence: CLI args → env vars → config file → built-in defaults. Reference schema: `config/config.conf`. Example configs in `examples/`.
 
 The `ConfigVals` class is auto-generated from the HOCON schema using tscfg (`make tsconfig`).
+
+## Reproducible Builds
+
+`BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` default to the local clock at build time, but can be overridden:
+
+```bash
+./gradlew build -PoverrideReleaseDate=04/25/2026 -PoverrideBuildTime=1745558400000
+./gradlew build -PoverrideVersion=3.1.2-SNAPSHOT
+```
+
+Use these for CI snapshot publishing and bit-identical artifact reproduction.
 
 ## Testing
 
@@ -126,6 +149,8 @@ Snippets use dual `base_path` in zensical.toml: first resolves `.txt` files from
 ## Publishing
 
 Published to Maven Central as `com.pambrose:prometheus-proxy`. No JitPack.
+
+Repository declarations are centralized in `settings.gradle.kts` via `dependencyResolutionManagement(FAIL_ON_PROJECT_REPOS)`. Opt into `mavenLocal()` for local snapshot testing with `-PuseMavenLocal=true`.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ stubs:
 	./gradlew generateProto
 
 build: clean stubs
-	./gradlew build -xtest
+	./gradlew build -PreleaseDate=2026-04-25 -xtest
+
+local-build: clean stubs
+	./gradlew build -PuseMavenLocal=true -PreleaseDate=2026-04-25 -xtest
 
 tibuild: clean stubs
 	./gradlew tiTree build -xtest

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ tsconfig:
 
 distro: build jars
 
-#PLATFORMS := linux/amd64,linux/arm64/v8,linux/s390x,linux/ppc64le
-PLATFORMS := linux/amd64,linux/arm64/v8,linux/s390x
+PLATFORMS := linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+#PLATFORMS := linux/amd64,linux/arm64,linux/s390x
 IMAGE_PREFIX := pambrose/prometheus
 
 docker-push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/prometheus-proxy)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/prometheus-proxy)](https://central.sonatype.com/artifact/com.pambrose/prometheus-proxy)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/422df508473443df9fbd8ea00fdee973)](https://app.codacy.com/gh/pambrose/prometheus-proxy/dashboard)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ If you prefer to build the project from source:
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.0
+  pambrose/prometheus-agent:3.1.1
 ```
 
 ## 📋 Configuration Examples
@@ -215,8 +215,8 @@ scrape_configs:
 The docker images support multiple architectures (amd64, arm64, s390x):
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.1.0
-docker pull pambrose/prometheus-agent:3.1.0
+docker pull pambrose/prometheus-proxy:3.1.1
+docker pull pambrose/prometheus-agent:3.1.1
 ```
 
 ### Production Docker Setup
@@ -229,7 +229,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50051:50051 -p 8080:8080 \
         --env ADMIN_ENABLED=true \
         --env METRICS_ENABLED=true \
         --restart unless-stopped \
-        pambrose/prometheus-proxy:3.1.0
+        pambrose/prometheus-proxy:3.1.1
 ```
 
 Start an agent container with:
@@ -239,7 +239,7 @@ Start an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
         --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
         --restart unless-stopped \
-        pambrose/prometheus-agent:3.1.0
+        pambrose/prometheus-agent:3.1.1
 ```
 
 Or use docker-compose: see `etc/compose/proxy.yml` for a working example.
@@ -260,7 +260,7 @@ is in your current directory, run an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
     --env AGENT_CONFIG=prom-agent.conf \
-    pambrose/prometheus-agent:3.1.0
+    pambrose/prometheus-agent:3.1.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -484,7 +484,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50440:50440 -p 8080:8080 \
     --env PROXY_CONFIG=tls-no-mutual-auth.conf \
     --env ADMIN_ENABLED=true \
     --env METRICS_ENABLED=true \
-    pambrose/prometheus-proxy:3.1.0
+    pambrose/prometheus-proxy:3.1.1
 
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/testing/certs,target=/app/testing/certs \
@@ -492,7 +492,7 @@ docker run --rm -p 8083:8083 -p 8093:8093 \
     --env AGENT_CONFIG=tls-no-mutual-auth.conf \
     --env PROXY_HOSTNAME=mymachine.lan:50440 \
     --name docker-agent \
-    pambrose/prometheus-agent:3.1.0
+    pambrose/prometheus-agent:3.1.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -579,7 +579,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.0")
+  implementation("com.pambrose:prometheus-proxy:3.1.1")
 }
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,50 @@
 
 ---
 
+## 3.1.1
+
+_Released 2026-04-25_
+
+### Highlights
+
+- **Documented public API** — Every `@Parameter` field on `BaseOptions` / `AgentOptions` / `ProxyOptions`, every value of `EnvVars`, the `Agent` and `Proxy` companion entry points, and `EmbeddedAgentInfo` now ship with full KDoc covering resolution precedence (CLI → env → config → default), sentinel values, and validation rules.
+- **Reproducible builds** — `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` accept `-PoverrideReleaseDate` / `-PoverrideBuildTime` Gradle properties so CI can produce bit-identical artifacts.
+- **Cleaner build script** — Centralized repositories in `settings.gradle.kts`, dropped the redundant fat-jar rewrap, removed the redundant `java` plugin alias, and aligned `dependsOn` calls on `tasks.named()`.
+
+### New Features
+
+- `-PoverrideReleaseDate` and `-PoverrideBuildTime` properties for reproducible builds
+
+### Build & Tooling
+
+- Centralize repository declarations in `settings.gradle.kts` via `dependencyResolutionManagement(FAIL_ON_PROJECT_REPOS)`; `mavenLocal()` is opt-in with `-PuseMavenLocal=true`
+- Replace the `agentJar`/`proxyJar` zipTree-rewrap with two `ShadowJar` tasks (configuration-cache safe; one fewer redundant fat jar on disk)
+- Drop the redundant `java` plugin (applied transitively by `kotlin.jvm`)
+- Switch `compileKotlin.dependsOn(":generateProto")` to `tasks.named("generateProto")` for type-safe task references
+- Mark the internal `Utils` object as `internal`
+- Add Claude Code GitHub workflow
+
+### Documentation
+
+- Full KDoc on the public API surface — `BaseOptions`, `AgentOptions`, `ProxyOptions`, `EnvVars`, `Agent.Companion`, `Proxy.Companion`, `EmbeddedAgentInfo` — with resolution precedence, sentinel-value, and validation notes
+- Trim `docs/packages.md` to the genuinely-public types so Dokka has no dangling cross-references; internal plumbing (HTTP routing, gRPC services, agent registries, etc.) is documented in source but intentionally omitted from the published site
+- Refresh metrics-and-grafana reference and the Zensical website docs
+
+### Dependency Updates
+
+| Dependency     | Old          | New          |
+|----------------|--------------|--------------|
+| Kotlin         | 2.3.20       | 2.3.21       |
+| Ktor           | 3.4.2        | 3.4.3        |
+| serialization  | 1.10.0       | 1.11.0       |
+| tcnative       | 2.0.74.Final | 2.0.77.Final |
+| utils          | 2.7.1        | 2.8.1        |
+| gradle-plugins | 1.0.12       | 1.0.14       |
+| protobuf       | 0.9.6        | 0.10.0       |
+| taskinfo       | 3.0.1        | 3.0.2        |
+
+---
+
 ## 3.1.0
 
 ### Highlights

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,12 +24,9 @@ plugins {
   alias(libs.plugins.dokka)
   alias(libs.plugins.maven.publish)
   alias(libs.plugins.taskinfo) apply false
-  // Turn these off until jacoco fixes their kotlin 1.5.0 SMAP issue
-  // id("jacoco")
-  // id("com.github.kt3k.coveralls") version "2.12.0"
 }
 
-version = findProperty("overrideVersion")?.toString() ?: "3.1.0"
+version = findProperty("overrideVersion")?.toString() ?: "3.1.1"
 group = "com.pambrose"
 
 buildConfig {
@@ -37,13 +34,10 @@ buildConfig {
   buildConfigField("String", "APP_NAME", "\"${project.name}\"")
   buildConfigField("String", "APP_VERSION", "\"${project.version}\"")
   val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-  buildConfigField("String", "APP_RELEASE_DATE", "\"${LocalDate.now().format(formatter)}\"")
-  buildConfigField("long", "BUILD_TIME", "${System.currentTimeMillis()}L")
-}
-
-repositories {
-  // mavenLocal()
-  mavenCentral()
+  val releaseDate = (findProperty("overrideReleaseDate") as String?) ?: LocalDate.now().format(formatter)
+  val buildTime = (findProperty("overrideBuildTime") as String?)?.toLong() ?: System.currentTimeMillis()
+  buildConfigField("String", "APP_RELEASE_DATE", "\"$releaseDate\"")
+  buildConfigField("long", "BUILD_TIME", "${buildTime}L")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.google.protobuf.gradle.id
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SourcesJar
@@ -9,7 +10,6 @@ import java.time.format.DateTimeFormatter
 
 plugins {
   idea
-  java
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.protobuf)   // Keep in sync with grpc
@@ -126,7 +126,7 @@ fun Project.configureKotlin() {
 
 fun Project.configureGrpc() {
   tasks.compileKotlin {
-    dependsOn(":generateProto")
+    dependsOn(tasks.named("generateProto"))
   }
 
   protobuf {
@@ -155,27 +155,33 @@ fun Project.configureGrpc() {
 }
 
 fun Project.configureJars() {
-  // Required for multiple uberjar targets
+  // Disable the default shadowJar; we publish the standard Maven jar and
+  // ship the two named fat jars below.
   tasks.shadowJar {
-    mergeServiceFiles()
+    enabled = false
   }
 
-  val agentJar by tasks.registering(Jar::class) {
-    dependsOn(tasks.shadowJar)
+  val mainOutput = sourceSets.main.get().output
+  val runtimeClasspath = configurations.runtimeClasspath
+
+  val agentJar by tasks.registering(ShadowJar::class) {
     archiveFileName.set("prometheus-agent.jar")
-    manifest {
-      attributes("Main-Class" to "io.prometheus.Agent")
-    }
-    from(zipTree(tasks.shadowJar.get().archiveFile))
+    manifest { attributes("Main-Class" to "io.prometheus.Agent") }
+    mergeServiceFiles()
+    from(mainOutput)
+    configurations = listOf(runtimeClasspath.get())
   }
 
-  val proxyJar by tasks.registering(Jar::class) {
-    dependsOn(tasks.shadowJar)
+  val proxyJar by tasks.registering(ShadowJar::class) {
     archiveFileName.set("prometheus-proxy.jar")
-    manifest {
-      attributes("Main-Class" to "io.prometheus.Proxy")
-    }
-    from(zipTree(tasks.shadowJar.get().archiveFile))
+    manifest { attributes("Main-Class" to "io.prometheus.Proxy") }
+    mergeServiceFiles()
+    from(mainOutput)
+    configurations = listOf(runtimeClasspath.get())
+  }
+
+  tasks.named("assemble") {
+    dependsOn(agentJar, proxyJar)
   }
 }
 
@@ -202,7 +208,6 @@ fun Project.configureDokka() {
       }
 
       suppressedFiles.from("src/main/java/io/prometheus/common/ConfigVals.java")
-      suppressedFiles.from("src/main/kotlin/io/prometheus/common/BaseOptions.kt")
 
       sourceLink {
         localDirectory.set(file("src/main/kotlin"))
@@ -221,7 +226,6 @@ fun Project.configurePublishing() {
         sourcesJar = SourcesJar.Sources(),
       ),
     )
-    coordinates("com.pambrose", "prometheus-proxy", version.toString())
 
     pom {
       name.set("prometheus-proxy")
@@ -248,12 +252,10 @@ fun Project.configurePublishing() {
     }
 
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
-  }
-
-  // Skip signing when no GPG key is provided (e.g., local publishing)
-  tasks.withType<Sign>().configureEach {
-    isEnabled = project.findProperty("signingInMemoryKey") != null
+    // Skip signing when no GPG key is provided (e.g., local publishing)
+    if (project.findProperty("signingInMemoryKey") != null) {
+      signAllPublications()
+    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ buildConfig {
 }
 
 repositories {
-  google()
+  // mavenLocal()
   mavenCentral()
 }
 
@@ -80,10 +80,10 @@ dependencies {
 configureKotlin()
 configureGrpc()
 configureJars()
+configureDokka()
 configurePublishing()
 configureKotlinter()
 configureDetekt()
-configureDokka()
 configureCoverage()
 
 fun Project.configureKotlin() {
@@ -185,15 +185,41 @@ fun Project.configureJars() {
   }
 }
 
-fun Project.configurePublishing() {
+fun Project.configureDokka() {
   dokka {
-    moduleName.set("prometheus-proxy")
+    moduleName.set("Prometheus Proxy")
+
+    dokkaPublications.html {
+      outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
+      includes.from("docs/packages.md")
+    }
+
     pluginsConfiguration.html {
       homepageLink.set("https://github.com/pambrose/prometheus-proxy")
-      footerMessage.set("prometheus-proxy")
+      footerMessage.set("Prometheus Proxy")
+    }
+
+    dokkaSourceSets.main {
+      documentedVisibilities(VisibilityModifier.Public)
+
+      perPackageOption {
+        matchingRegex.set("io\\.prometheus\\.grpc.*")
+        suppress.set(true)
+      }
+
+      suppressedFiles.from("src/main/java/io/prometheus/common/ConfigVals.java")
+      suppressedFiles.from("src/main/kotlin/io/prometheus/common/BaseOptions.kt")
+
+      sourceLink {
+        localDirectory.set(file("src/main/kotlin"))
+        remoteUrl("https://github.com/pambrose/prometheus-proxy/tree/master/src/main/kotlin")
+        remoteLineSuffix.set("#L")
+      }
     }
   }
+}
 
+fun Project.configurePublishing() {
   mavenPublishing {
     configure(
       com.vanniktech.maven.publish.KotlinJvm(
@@ -205,7 +231,7 @@ fun Project.configurePublishing() {
 
     pom {
       name.set("prometheus-proxy")
-      description.set("Dynamic Line-Specific GitHub Permalinks")
+      description.set("Enables Prometheus to scrape metrics from endpoints behind a firewall via a proxy/agent pair connected over gRPC.")
       url.set("https://github.com/pambrose/prometheus-proxy")
       licenses {
         license {
@@ -259,36 +285,6 @@ fun Project.configureDetekt() {
     allRules = false
     config.setFrom("$projectDir/etc/detekt/detekt.yml")
     baseline = file("$projectDir/etc/detekt/baseline.xml")
-  }
-}
-
-fun Project.configureDokka() {
-  dokka {
-    moduleName.set("Prometheus Proxy")
-
-    dokkaPublications.html {
-      outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
-      includes.from("docs/packages.md")
-    }
-
-    pluginsConfiguration.html {
-      homepageLink.set("https://github.com/pambrose/prometheus-proxy")
-    }
-
-    dokkaSourceSets.main {
-      documentedVisibilities(VisibilityModifier.Public, VisibilityModifier.Internal)
-
-      perPackageOption {
-        matchingRegex.set("io\\.prometheus\\.grpc.*")
-        suppress.set(true)
-      }
-
-      sourceLink {
-        localDirectory.set(file("src/main/kotlin"))
-        remoteUrl("https://github.com/pambrose/prometheus-proxy/tree/master/src/main/kotlin")
-        remoteLineSuffix.set("#L")
-      }
-    }
   }
 }
 

--- a/docs/metrics-and-grafana.md
+++ b/docs/metrics-and-grafana.md
@@ -9,10 +9,10 @@ Metrics are disabled by default. Enable them via CLI flags, environment variable
 
 ### Proxy
 
-| Method | Example |
-|--------|---------|
-| CLI | `--metrics` or `-e` |
-| Env | `METRICS_ENABLED=true` |
+| Method | Example                        |
+|--------|--------------------------------|
+| CLI    | `--metrics` or `-e`            |
+| Env    | `METRICS_ENABLED=true`         |
 | Config | `proxy.metrics.enabled = true` |
 
 Default endpoint: `http://proxy-host:8082/metrics`
@@ -29,10 +29,10 @@ proxy.metrics {
 
 ### Agent
 
-| Method | Example |
-|--------|---------|
-| CLI | `--metrics` or `-e` |
-| Env | `METRICS_ENABLED=true` |
+| Method | Example                        |
+|--------|--------------------------------|
+| CLI    | `--metrics` or `-e`            |
+| Env    | `METRICS_ENABLED=true`         |
 | Config | `agent.metrics.enabled = true` |
 
 Default endpoint: `http://agent-host:8083/metrics`
@@ -65,38 +65,38 @@ The same options are available under `agent.metrics`.
 
 ### Counters
 
-| Metric | Labels | Description |
-|--------|--------|-------------|
-| `proxy_scrape_requests` | `type` | Scrape request outcomes. See label values below. |
-| `proxy_connect_count` | — | Agent connection count |
-| `proxy_eviction_count` | — | Stale agent evictions |
-| `proxy_heartbeat_count` | — | Heartbeats received from agents |
-| `proxy_chunk_validation_failures_total` | `stage` | Chunk integrity failures (`chunk` or `summary`) |
-| `proxy_chunked_transfers_abandoned_total` | — | Chunked transfers abandoned mid-stream |
-| `proxy_agent_displacement_total` | — | Path registrations that displaced another agent |
+| Metric                                    | Labels  | Description                                      |
+|-------------------------------------------|---------|--------------------------------------------------|
+| `proxy_scrape_requests`                   | `type`  | Scrape request outcomes. See label values below. |
+| `proxy_connect_count`                     | —       | Agent connection count                           |
+| `proxy_eviction_count`                    | —       | Stale agent evictions                            |
+| `proxy_heartbeat_count`                   | —       | Heartbeats received from agents                  |
+| `proxy_chunk_validation_failures_total`   | `stage` | Chunk integrity failures (`chunk` or `summary`)  |
+| `proxy_chunked_transfers_abandoned_total` | —       | Chunked transfers abandoned mid-stream           |
+| `proxy_agent_displacement_total`          | —       | Path registrations that displaced another agent  |
 
 **`proxy_scrape_requests` type labels:**
 
-| Value | Meaning |
-|-------|---------|
-| `success` | Scrape completed successfully |
-| `timed_out` | Agent did not respond within `scrapeRequestTimeoutSecs` |
-| `no_agents` | No agents registered for the requested path |
-| `invalid_path` | Requested path is empty or unrecognized |
-| `agent_disconnected` | Agent stream closed before response was received |
-| `missing_results` | Internal error: results object was null |
-| `path_not_found` | Agent returned a non-200 status for the target |
-| `payload_too_large` | Unzipped content exceeded `maxUnzippedContentSizeMBytes` |
-| `invalid_gzip` | Gzip decompression failed |
-| `proxy_not_running` | Proxy is shutting down |
-| `invalid_agent_context` | All agents for the path are in an invalid state |
+| Value                   | Meaning                                                  |
+|-------------------------|----------------------------------------------------------|
+| `success`               | Scrape completed successfully                            |
+| `timed_out`             | Agent did not respond within `scrapeRequestTimeoutSecs`  |
+| `no_agents`             | No agents registered for the requested path              |
+| `invalid_path`          | Requested path is empty or unrecognized                  |
+| `agent_disconnected`    | Agent stream closed before response was received         |
+| `missing_results`       | Internal error: results object was null                  |
+| `path_not_found`        | Agent returned a non-200 status for the target           |
+| `payload_too_large`     | Unzipped content exceeded `maxUnzippedContentSizeMBytes` |
+| `invalid_gzip`          | Gzip decompression failed                                |
+| `proxy_not_running`     | Proxy is shutting down                                   |
+| `invalid_agent_context` | All agents for the path are in an invalid state          |
 
 ### Histograms
 
-| Metric | Labels | Buckets | Description |
-|--------|--------|---------|-------------|
-| `proxy_scrape_request_latency_seconds` | `path` | 5ms–10s | End-to-end scrape latency from request creation to response |
-| `proxy_scrape_response_bytes` | `path`, `encoding` | 1KB–10MB | Response payload size after decompression |
+| Metric                                 | Labels             | Buckets  | Description                                                 |
+|----------------------------------------|--------------------|----------|-------------------------------------------------------------|
+| `proxy_scrape_request_latency_seconds` | `path`             | 5ms–10s  | End-to-end scrape latency from request creation to response |
+| `proxy_scrape_response_bytes`          | `path`, `encoding` | 1KB–10MB | Response payload size after decompression                   |
 
 The `encoding` label is `gzipped` or `plain`.
 
@@ -106,13 +106,13 @@ Response size buckets: `1KB, 10KB, 100KB, 500KB, 1MB, 5MB, 10MB`.
 
 ### Gauges
 
-| Metric | Description |
-|--------|-------------|
-| `proxy_start_time_seconds` | Proxy start time (Unix epoch) |
-| `proxy_agent_map_size` | Number of connected agents |
-| `proxy_path_map_size` | Number of registered scrape paths |
-| `proxy_scrape_map_size` | Number of in-flight scrape requests |
-| `proxy_chunk_context_map_size` | Number of in-flight chunked transfers |
+| Metric                                | Description                                    |
+|---------------------------------------|------------------------------------------------|
+| `proxy_start_time_seconds`            | Proxy start time (Unix epoch)                  |
+| `proxy_agent_map_size`                | Number of connected agents                     |
+| `proxy_path_map_size`                 | Number of registered scrape paths              |
+| `proxy_scrape_map_size`               | Number of in-flight scrape requests            |
+| `proxy_chunk_context_map_size`        | Number of in-flight chunked transfers          |
 | `proxy_cumulative_agent_backlog_size` | Total queued scrape requests across all agents |
 
 Gauges use lazy sampling (`SamplerGaugeCollector`) — values are read from
@@ -124,11 +124,11 @@ live data structures on each Prometheus scrape, not pushed on every state change
 
 ### Counters
 
-| Metric | Labels | Description |
-|--------|--------|-------------|
+| Metric                       | Labels              | Description                             |
+|------------------------------|---------------------|-----------------------------------------|
 | `agent_scrape_request_count` | `launch_id`, `type` | Scrape requests processed by this agent |
-| `agent_scrape_result_count` | `launch_id`, `type` | Scrape results sent to proxy |
-| `agent_connect_count` | `launch_id`, `type` | Connection attempts to the proxy |
+| `agent_scrape_result_count`  | `launch_id`, `type` | Scrape results sent to proxy            |
+| `agent_connect_count`        | `launch_id`, `type` | Connection attempts to the proxy        |
 
 **`agent_scrape_result_count` type labels:** `non-gzipped`, `gzipped`, `chunked`
 
@@ -139,19 +139,19 @@ you to distinguish metrics from agent restarts.
 
 ### Histograms
 
-| Metric | Labels | Buckets | Description |
-|--------|--------|---------|-------------|
+| Metric                                 | Labels                    | Buckets | Description                                    |
+|----------------------------------------|---------------------------|---------|------------------------------------------------|
 | `agent_scrape_request_latency_seconds` | `launch_id`, `agent_name` | 5ms–10s | Time to fetch metrics from the target endpoint |
 
 Same bucket boundaries as the proxy latency histogram.
 
 ### Gauges
 
-| Metric | Labels | Description |
-|--------|--------|-------------|
-| `agent_start_time_seconds` | `launch_id` | Agent start time (Unix epoch) |
+| Metric                      | Labels      | Description                                  |
+|-----------------------------|-------------|----------------------------------------------|
+| `agent_start_time_seconds`  | `launch_id` | Agent start time (Unix epoch)                |
 | `agent_scrape_backlog_size` | `launch_id` | Pending scrape requests queued at this agent |
-| `agent_client_cache_size` | `launch_id` | Number of cached HTTP clients |
+| `agent_client_cache_size`   | `launch_id` | Number of cached HTTP clients                |
 
 ---
 
@@ -217,9 +217,9 @@ claiming the same exclusive path) or deliberate failover.
 
 Two dashboards are included in `grafana/`:
 
-| File | Dashboard | Purpose |
-|------|-----------|---------|
-| `prometheus-proxy.json` | Prometheus Proxy | Proxy health, throughput, latency, errors |
+| File                     | Dashboard         | Purpose                                          |
+|--------------------------|-------------------|--------------------------------------------------|
+| `prometheus-proxy.json`  | Prometheus Proxy  | Proxy health, throughput, latency, errors        |
 | `prometheus-agents.json` | Prometheus Agents | Agent health, scrape activity, per-agent latency |
 
 ### Requirements
@@ -237,33 +237,33 @@ Two dashboards are included in `grafana/`:
 
 Both dashboards use template variables:
 
-| Variable | Dashboard | Purpose |
-|----------|-----------|---------|
-| `datasource` | Both | Prometheus datasource selector |
-| `path` | Proxy | Filter panels by registered scrape path |
-| `agent` | Agents | Filter panels by agent job name |
+| Variable     | Dashboard | Purpose                                 |
+|--------------|-----------|-----------------------------------------|
+| `datasource` | Both      | Prometheus datasource selector          |
+| `path`       | Proxy     | Filter panels by registered scrape path |
+| `agent`      | Agents    | Filter panels by agent job name         |
 
 ### Proxy Dashboard Panels
 
-| Section | Panels | What to Watch |
-|---------|--------|---------------|
-| **Overview** | Uptime, Connected Agents, Registered Paths, Success Rate, Error Count | Success rate dropping below 99% or error count spiking |
-| **Throughput** | Requests/sec by outcome (stacked), Success vs Error rate | Sudden changes in request volume or error ratio |
-| **Latency** | P50/P90/P99 percentiles, Per-path P99 | P99 creeping up indicates a slow target or network issue |
-| **Payload** | Response size percentiles, Encoding distribution | Unexpectedly large responses; shift between gzip and plain |
-| **Internal State** | Backlog, Scrape map, Chunk context map, Heartbeat rate | Growing backlog means agents can't keep up; zero heartbeats means agents are disconnected |
-| **Errors** | Error breakdown by type, Agent events (connect/evict/displace) | Which error types dominate; frequent evictions indicate connectivity problems |
-| **Chunk Health** | Chunk validation failures, Abandoned transfers | Any non-zero value warrants investigation |
+| Section            | Panels                                                                | What to Watch                                                                             |
+|--------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| **Overview**       | Uptime, Connected Agents, Registered Paths, Success Rate, Error Count | Success rate dropping below 99% or error count spiking                                    |
+| **Throughput**     | Requests/sec by outcome (stacked), Success vs Error rate              | Sudden changes in request volume or error ratio                                           |
+| **Latency**        | P50/P90/P99 percentiles, Per-path P99                                 | P99 creeping up indicates a slow target or network issue                                  |
+| **Payload**        | Response size percentiles, Encoding distribution                      | Unexpectedly large responses; shift between gzip and plain                                |
+| **Internal State** | Backlog, Scrape map, Chunk context map, Heartbeat rate                | Growing backlog means agents can't keep up; zero heartbeats means agents are disconnected |
+| **Errors**         | Error breakdown by type, Agent events (connect/evict/displace)        | Which error types dominate; frequent evictions indicate connectivity problems             |
+| **Chunk Health**   | Chunk validation failures, Abandoned transfers                        | Any non-zero value warrants investigation                                                 |
 
 ### Agents Dashboard Panels
 
-| Section | Panels | What to Watch |
-|---------|--------|---------------|
-| **Overview** | Agent count, Total scrape rate, Uptime table | Unexpected agent count changes |
-| **Connections** | Connection success/failure rate per agent | Failure spikes indicate proxy or network issues |
+| Section             | Panels                                                   | What to Watch                                      |
+|---------------------|----------------------------------------------------------|----------------------------------------------------|
+| **Overview**        | Agent count, Total scrape rate, Uptime table             | Unexpected agent count changes                     |
+| **Connections**     | Connection success/failure rate per agent                | Failure spikes indicate proxy or network issues    |
 | **Scrape Activity** | Request rate by agent, Result types (gzip/plain/chunked) | Imbalanced load across agents; unexpected chunking |
-| **Latency** | P50/P90/P99 overall, P99 per agent | Per-agent latency outliers point to slow targets |
-| **Internals** | Backlog size, HTTP client cache size | Growing backlog means the agent is falling behind |
+| **Latency**         | P50/P90/P99 overall, P99 per agent                       | Per-agent latency outliers point to slow targets   |
+| **Internals**       | Backlog size, HTTP client cache size                     | Growing backlog means the agent is falling behind  |
 
 ---
 
@@ -276,12 +276,12 @@ scrape_configs:
   - job_name: 'prometheus-proxy'
     metrics_path: /metrics
     static_configs:
-      - targets: ['proxy-host:8082']
+      - targets: [ 'proxy-host:8082' ]
 
   - job_name: 'prometheus-agent'
     metrics_path: /metrics
     static_configs:
-      - targets: ['agent-host:8083']
+      - targets: [ 'agent-host:8083' ]
 ```
 
 Adjust hostnames and ports to match your deployment.
@@ -291,12 +291,14 @@ Adjust hostnames and ports to match your deployment.
 ## Useful PromQL Queries
 
 **Scrape success rate (last 5 minutes):**
+
 ```promql
 sum(rate(proxy_scrape_requests{type="success"}[5m]))
   / sum(rate(proxy_scrape_requests[5m])) * 100
 ```
 
 **P99 scrape latency:**
+
 ```promql
 histogram_quantile(0.99,
   sum by (le) (rate(proxy_scrape_request_latency_seconds_bucket[5m]))
@@ -304,6 +306,7 @@ histogram_quantile(0.99,
 ```
 
 **P99 latency per path:**
+
 ```promql
 histogram_quantile(0.99,
   sum by (le, path) (rate(proxy_scrape_request_latency_seconds_bucket[5m]))
@@ -311,6 +314,7 @@ histogram_quantile(0.99,
 ```
 
 **Median response size:**
+
 ```promql
 histogram_quantile(0.5,
   sum by (le) (rate(proxy_scrape_response_bytes_bucket[5m]))
@@ -318,11 +322,13 @@ histogram_quantile(0.5,
 ```
 
 **Error rate by type:**
+
 ```promql
 sum by (type) (rate(proxy_scrape_requests{type!="success"}[5m]))
 ```
 
 **Agent scrape latency by agent name:**
+
 ```promql
 histogram_quantile(0.99,
   sum by (le, agent_name) (rate(agent_scrape_request_latency_seconds_bucket[5m]))
@@ -330,6 +336,7 @@ histogram_quantile(0.99,
 ```
 
 **Proxy uptime:**
+
 ```promql
 time() - proxy_start_time_seconds
 ```

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -12,11 +12,33 @@ Prometheus → Proxy HTTP (:8080) → AgentContext lookup → ScrapeRequest via 
     → Agent scrapes actual endpoint → ScrapeResponse via gRPC stream → Proxy → Prometheus
 ```
 
+## Public API
+
+These are the entry points intended for embedders and integrators:
+
+- [Agent][io.prometheus.Agent] — the in-firewall component. Construct directly or use
+  [Agent.startSyncAgent][io.prometheus.Agent.Companion.startSyncAgent] /
+  [Agent.startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent].
+- [Proxy][io.prometheus.Proxy] — the outside-firewall component.
+- [AgentOptions][io.prometheus.agent.AgentOptions] /
+  [ProxyOptions][io.prometheus.proxy.ProxyOptions] —
+  CLI argument parsing and config loading; subclasses of
+  [BaseOptions][io.prometheus.common.BaseOptions].
+- [EmbeddedAgentInfo][io.prometheus.agent.EmbeddedAgentInfo] — lifecycle handle returned by
+  [Agent.startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent] when running an Agent
+  inside a host JVM.
+- [EnvVars][io.prometheus.common.EnvVars] — typed enum of every recognized environment variable.
+
+Everything else (gRPC service implementations, agent registries, HTTP clients, request
+managers, transport filters, interceptors) is `internal` to the module: it is documented in
+source but not part of the supported API surface, and is intentionally omitted from these
+generated docs.
+
 ## Configuration
 
-Uses Typesafe Config (HOCON). Precedence: CLI args → env vars → config file.
-See [EnvVars][io.prometheus.common.EnvVars] for environment variable mappings and
-[BaseOptions][io.prometheus.common.BaseOptions] for CLI argument handling.
+Uses Typesafe Config (HOCON). Resolution precedence is **CLI args → env vars → config file →
+built-in defaults**. See [BaseOptions][io.prometheus.common.BaseOptions] for the shared CLI
+flag set and [EnvVars][io.prometheus.common.EnvVars] for the env-var mappings.
 
 # Package io.prometheus
 
@@ -24,8 +46,9 @@ Top-level entry points for the system.
 
 [Agent][io.prometheus.Agent] is the in-firewall component that connects outbound to the proxy,
 registers metrics endpoints, and responds to scrape requests by fetching from local HTTP targets.
-It extends `GenericService` and supports synchronous startup via `startSyncAgent()` or
-asynchronous embedded usage via `startAsyncAgent()`, which returns an
+It extends `GenericService` and supports synchronous startup via
+[startSyncAgent][io.prometheus.Agent.Companion.startSyncAgent] or asynchronous embedded usage
+via [startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent], which returns an
 [EmbeddedAgentInfo][io.prometheus.agent.EmbeddedAgentInfo].
 
 [Proxy][io.prometheus.Proxy] is the outside-firewall component that receives Prometheus scrape
@@ -38,130 +61,39 @@ and HOCON-based config files.
 
 # Package io.prometheus.proxy
 
-Proxy-side services and managers that handle agent connections, HTTP scrape routing, and
-scrape request lifecycle.
-
-## HTTP Layer
-
-- [ProxyHttpService][io.prometheus.proxy.ProxyHttpService] manages the lifecycle of the Ktor
-  CIO embedded HTTP server that Prometheus scrapes.
-- [ProxyHttpRoutes][io.prometheus.proxy.ProxyHttpRoutes] defines the Ktor routing tree, resolving
-  paths to agent contexts, dispatching scrape requests, and merging consolidated multi-agent
-  responses (including OpenMetrics `# EOF` deduplication).
-- [ProxyHttpConfig][io.prometheus.proxy.ProxyHttpConfig] configures the Ktor application with
-  `DefaultHeaders`, `CallLogging`, `Compression`, and `StatusPages` plugins.
-
-## gRPC Layer
-
-- [ProxyGrpcService][io.prometheus.proxy.ProxyGrpcService] is the lifecycle wrapper around the
-  gRPC server that agents connect to. Configures TLS, interceptors, transport filters, keepalive
-  settings, and optional proto reflection.
-- [ProxyServiceImpl][io.prometheus.proxy.ProxyServiceImpl] implements all gRPC RPCs defined in
-  `proxy_service.proto`, including agent registration, path management, heartbeats, and the
-  scrape request/response streaming protocol.
-- [ProxyServerInterceptor][io.prometheus.proxy.ProxyServerInterceptor] injects the agent ID into
-  gRPC response headers.
-- [ProxyServerTransportFilter][io.prometheus.proxy.ProxyServerTransportFilter] creates an
-  [AgentContext][io.prometheus.proxy.AgentContext] on transport connect and triggers cleanup
-  on disconnect.
-
-## State Management
-
-- [AgentContext][io.prometheus.proxy.AgentContext] is the proxy-side representation of one
-  connected agent. Holds identity fields, validity state, activity timestamps, and a queue of
-  pending scrape requests.
-- [AgentContextManager][io.prometheus.proxy.AgentContextManager] is a dual-map registry of
-  agent ID to [AgentContext][io.prometheus.proxy.AgentContext] and scrape ID to
-  [ChunkedContext][io.prometheus.proxy.ChunkedContext]. Provides CRUD operations, stale-agent
-  detection, and bulk invalidation.
-- [ProxyPathManager][io.prometheus.proxy.ProxyPathManager] maps path strings to agent contexts,
-  supporting both exclusive (single agent) and consolidated (multiple agent) registration.
-- [ScrapeRequestManager][io.prometheus.proxy.ScrapeRequestManager] tracks in-flight scrape
-  requests by scrape ID, routes incoming results to waiting callers, and handles failure on
-  agent disconnect or proxy shutdown.
-- [ScrapeRequestWrapper][io.prometheus.proxy.ScrapeRequestWrapper] wraps a single `ScrapeRequest`
-  protobuf with lifecycle state: a completion channel, latency timer, and the eventual results.
-- [ChunkedContext][io.prometheus.proxy.ChunkedContext] reassembles chunked scrape responses
-  (header + N chunks + summary) into a single result with running CRC32 validation.
-- [AgentContextCleanupService][io.prometheus.proxy.AgentContextCleanupService] is a background
-  thread that periodically evicts agents exceeding `maxAgentInactivitySecs`.
-
-## Configuration and Metrics
+Proxy-side configuration. The Proxy's HTTP routing, gRPC service implementation, agent registry,
+scrape-request manager, chunked-response reassembly, transport filter, and stale-agent cleanup
+are all `internal` and not surfaced here.
 
 - [ProxyOptions][io.prometheus.proxy.ProxyOptions] parses CLI arguments and HOCON config for
-  proxy-specific settings (HTTP port, gRPC port, service discovery, TLS handshake, keepalive).
-- [ProxyMetrics][io.prometheus.proxy.ProxyMetrics] declares Prometheus metrics for scrape
-  requests, agent connections, evictions, heartbeats, and latency.
+  proxy-specific settings (HTTP port, gRPC agent port, service-discovery endpoint, gRPC handshake
+  and connection-management timeouts).
 
 # Package io.prometheus.agent
 
-Agent-side services for gRPC communication, HTTP scraping, and path management.
-
-## Core Services
-
-- [AgentGrpcService][io.prometheus.agent.AgentGrpcService] manages the agent's entire gRPC
-  lifecycle: channel creation, TLS setup, stub management, reconnection, and all RPC calls
-  to the proxy (connect, register, heartbeat, scrape streaming).
-- [AgentHttpService][io.prometheus.agent.AgentHttpService] executes HTTP scrapes against
-  registered endpoints using a cached Ktor `HttpClient`, applying size limits and gzip
-  compression, and returning results as [ScrapeResults][io.prometheus.common.ScrapeResults].
-- [AgentPathManager][io.prometheus.agent.AgentPathManager] maintains the agent-side path
-  registry. Loads path configs from HOCON, registers each with the proxy, and supports
-  dynamic registration/unregistration at runtime.
-- [AgentConnectionContext][io.prometheus.agent.AgentConnectionContext] holds the bidirectional
-  channel pair for one agent-to-proxy connection: a bounded inbound channel for scrape request
-  actions and an unbounded outbound channel for scrape results.
-
-## HTTP Client Caching
-
-- [HttpClientCache][io.prometheus.agent.HttpClientCache] is an LRU cache for Ktor `HttpClient`
-  instances keyed by authentication credentials. Tracks per-entry in-use counts to avoid
-  closing a client mid-request. A background coroutine periodically evicts expired entries.
-
-## TLS and Security
-
-- [SslSettings][io.prometheus.agent.SslSettings] builds `KeyStore`, `TrustManagerFactory`,
-  `SSLContext`, and `X509TrustManager` from keystore files for mutual TLS configuration.
-- [TrustAllX509TrustManager][io.prometheus.agent.TrustAllX509TrustManager] is a no-op trust
-  manager that accepts all certificates. Intended for development use only.
-- [AgentClientInterceptor][io.prometheus.agent.AgentClientInterceptor] is a gRPC client
-  interceptor that reads the `agent-id` header from proxy response metadata.
-
-## Configuration and Metrics
+Agent-side configuration and embedded-lifecycle handle. The Agent's gRPC client service, HTTP
+scrape executor, path manager, HTTP-client cache, TLS helpers, and gRPC interceptors are all
+`internal` and not surfaced here.
 
 - [AgentOptions][io.prometheus.agent.AgentOptions] parses CLI arguments and HOCON config for
-  agent-specific settings (proxy hostname, scrape timeout, chunking threshold, gzip size,
-  HTTP client cache, TLS, and keepalive).
-- [AgentMetrics][io.prometheus.agent.AgentMetrics] declares Prometheus metrics for scrape
-  requests, scrape results (non-gzipped/gzipped/chunked), connections, and latency.
+  agent-specific settings (proxy hostname, scrape timeout, chunking threshold, gzip threshold,
+  HTTP-client cache sizing, TLS, and keepalive).
 - [EmbeddedAgentInfo][io.prometheus.agent.EmbeddedAgentInfo] is the return value of
-  `Agent.startAsyncAgent()`, carrying the `launchId` and `agentName` of the started agent.
+  [Agent.startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent], carrying the
+  `launchId` and `agentName` of the started agent and a `shutdown()` method for graceful stop.
 
 # Package io.prometheus.common
 
-Shared utilities, configuration, and data models used by both proxy and agent.
-
-## Configuration
+Shared configuration types used by both Proxy and Agent. The `ScrapeResults` data model, the
+auto-generated `ConfigVals` HOCON wrapper, and the assorted internal utility/constant objects are
+all `internal` (or, in the case of `ConfigVals`, explicitly suppressed from these docs because
+of its size).
 
 - [BaseOptions][io.prometheus.common.BaseOptions] is the abstract base class for
   [AgentOptions][io.prometheus.agent.AgentOptions] and
   [ProxyOptions][io.prometheus.proxy.ProxyOptions]. Handles JCommander argument parsing,
-  HOCON config loading (from file or URL), and provides shared fields for TLS, keepalive,
-  admin, metrics, and log-level options with CLI > env > config precedence.
-- [ConfigVals][io.prometheus.common.ConfigVals] is the auto-generated type-safe HOCON
-  configuration wrapper (generated via tscfg from the reference schema).
+  HOCON config loading from file or URL, and provides shared fields for TLS, keepalive,
+  admin-servlet, metrics-endpoint, and log-level options with CLI > env > config precedence.
 - [EnvVars][io.prometheus.common.EnvVars] is a typed enumeration of all environment variable
-  names with `getEnv()` overloads for `String`, `Boolean`, `Int`, and `Long`.
-
-## Data Models
-
-- [ScrapeResults][io.prometheus.common.ScrapeResults] is an immutable data holder for one
-  completed scrape, carrying status code, content type, content (as text or gzipped bytes),
-  failure reason, and URL. Provides conversion to gRPC `ScrapeResponse` and chunked header
-  messages.
-
-## Utilities
-
-- [Utils][io.prometheus.common.Utils] provides miscellaneous functions including URL
-  sanitization, query parameter encoding, JSON parsing, log level configuration, gRPC
-  status formatting, and host:port parsing.
+  names recognized by the Proxy and Agent, with `getEnv()` overloads for `String`, `Boolean`,
+  `Int`, and `Long` that reject malformed values.

--- a/etc/compose/proxy.yml
+++ b/etc/compose/proxy.yml
@@ -1,6 +1,6 @@
 prometheus-proxy:
   autoredeploy: true
-  image: 'pambrose/prometheus-proxy:3.1.0'
+  image: 'pambrose/prometheus-proxy:3.1.1'
   ports:
     - '8080:8080'
     - '8082:8082'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # Plugins
 config = "6.0.9"
 detekt = "1.23.8"
-gradle-plugins = "1.0.13"
+gradle-plugins = "1.0.14"
 dokka = "2.2.0"
 maven-publish = "0.36.0"
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 kover = "0.9.8"
 protobuf = "0.10.0"
 shadow = "8.3.7"
@@ -31,9 +31,9 @@ protoc = "4.34.1"
 serialization = "1.11.0"
 slf4j = "2.0.17"
 # Keep in sync with grpc
-tcnative = "2.0.76.Final"
+tcnative = "2.0.77.Final"
 typesafe = "1.4.6"
-utils = "2.8.0"
+utils = "2.8.1"
 zipkin = "6.3.1"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,14 +2,14 @@
 # Plugins
 config = "6.0.9"
 detekt = "1.23.8"
-gradle-plugins = "1.0.12"
+gradle-plugins = "1.0.13"
 dokka = "2.2.0"
 maven-publish = "0.36.0"
 kotlin = "2.3.20"
 kover = "0.9.8"
-protobuf = "0.9.6"
+protobuf = "0.10.0"
 shadow = "8.3.7"
-taskinfo = "3.0.1"
+taskinfo = "3.0.2"
 
 # Libraries
 annotation = "1.3.2"
@@ -21,19 +21,19 @@ jakartaServlet = "6.1.0"
 jcommander = "3.0"
 jetty = "11.0.26"
 kotest = "6.1.11"
-ktor = "3.4.2"
+ktor = "3.4.3"
 logback = "1.5.32"
 logging = "8.0.01"
 mockk = "1.14.9"
 prometheus = "0.16.0"
 # Keep in sync with grpc
 protoc = "4.34.1"
-serialization = "1.10.0"
+serialization = "1.11.0"
 slf4j = "2.0.17"
 # Keep in sync with grpc
-tcnative = "2.0.74.Final"
+tcnative = "2.0.76.Final"
 typesafe = "1.4.6"
-utils = "2.7.1"
+utils = "2.8.0"
 zipkin = "6.3.1"
 
 [libraries]
@@ -151,7 +151,6 @@ common-utils = [
   "common-utils-jetty",
   "common-utils-ktor-client",
   "common-utils-prometheus",
-  "common-utils-jetty",
   "common-utils-service",
   "common-utils-zipkin"
 ]

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,10 @@ The system has two components: a **proxy** that runs alongside Prometheus (outsi
 - [Documentation](https://pambrose.github.io/prometheus-proxy/)
 - [GitHub Repository](https://github.com/pambrose/prometheus-proxy)
 - [README](https://github.com/pambrose/prometheus-proxy/blob/master/README.md)
+- [Changelog](https://github.com/pambrose/prometheus-proxy/blob/master/CHANGELOG.md)
+- [Release Notes](https://github.com/pambrose/prometheus-proxy/blob/master/RELEASE_NOTES.md)
 - [KDoc API Reference](https://pambrose.github.io/prometheus-proxy/kdocs/)
-- [CLI Options & Environment Variables](https://github.com/pambrose/prometheus-proxy/blob/master/docs/cli-args.md)
+- [CLI Reference](https://pambrose.github.io/prometheus-proxy/cli-reference/)
 - [Maven Central](https://central.sonatype.com/artifact/com.pambrose/prometheus-proxy)
 - [Docker Images: pambrose/prometheus-proxy](https://hub.docker.com/r/pambrose/prometheus-proxy)
 - [Docker Images: pambrose/prometheus-agent](https://hub.docker.com/r/pambrose/prometheus-agent)
@@ -56,7 +58,16 @@ Key RPCs:
 - **Stale agent cleanup**: `AgentContextCleanupService` evicts inactive agents after `maxAgentInactivitySecs` (default 60s)
 - **Consolidated mode**: Multiple agents can register the same path for redundancy
 - **Auth forwarding**: Proxy forwards `Authorization` headers (basic auth / bearer token) from Prometheus scrape configs to agents over gRPC
-- **Embedded agent**: Agents can run inside other JVM apps via `startAsyncAgent()`
+- **Embedded agent**: Agents can run inside other JVM apps via `Agent.startAsyncAgent()`, returning an `EmbeddedAgentInfo` lifecycle handle
+
+### Public API Surface
+
+These are the only types intended for external consumption (everything else is `internal`):
+
+- `io.prometheus.Agent` and `io.prometheus.Proxy` (entry points)
+- `io.prometheus.agent.AgentOptions`, `io.prometheus.proxy.ProxyOptions`, `io.prometheus.common.BaseOptions` (config/CLI parsing)
+- `io.prometheus.agent.EmbeddedAgentInfo` (returned by `Agent.startAsyncAgent`)
+- `io.prometheus.common.EnvVars` (typed env-var enum)
 
 ## Quick Start
 
@@ -145,10 +156,13 @@ TLS with mutual auth additionally requires:
 ```bash
 git clone https://github.com/pambrose/prometheus-proxy.git
 cd prometheus-proxy
-./gradlew build          # Build with tests
-./gradlew shadowJar      # Build fat JARs
-./gradlew agentJar proxyJar  # Named JARs in build/libs/
+./gradlew build                              # Build with tests
+./gradlew agentJar proxyJar                  # Named fat JARs in build/libs/
+./gradlew build -PoverrideVersion=X.Y.Z      # Build with a custom version
+./gradlew build -PuseMavenLocal=true         # Resolve from ~/.m2 in addition to Maven Central
 ```
+
+`agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled to avoid producing a third redundant fat jar. Repository declarations are centralized in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`).
 
 ## Tech Stack
 

--- a/llms.txt
+++ b/llms.txt
@@ -76,12 +76,12 @@ java -jar prometheus-agent.jar --proxy mymachine.local --config myapps.conf
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.0
+  pambrose/prometheus-agent:3.1.1
 ```
 
 ## Configuration
@@ -173,7 +173,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.0")
+  implementation("com.pambrose:prometheus-proxy:3.1.1")
 }
 ```
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,22 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenCentral()
+    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
+      mavenLocal()
+    }
+  }
 }
 
 rootProject.name = "prometheus-proxy"

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -517,11 +517,35 @@ class Agent(
   companion object {
     private val logger = logger {}
 
+    /**
+     * JVM entry point for the standalone Agent process.
+     *
+     * Equivalent to calling [startSyncAgent] with `exitOnMissingConfig = true`, meaning the process
+     * terminates with a non-zero exit code if no config file or URL is provided via `--config`/`-c` or
+     * the `AGENT_CONFIG` environment variable. Used as the `Main-Class` of `prometheus-agent.jar`.
+     *
+     * @param args Raw command-line arguments forwarded to [AgentOptions] for parsing.
+     */
     @JvmStatic
     fun main(args: Array<String>) {
       startSyncAgent(args, exitOnMissingConfig = true)
     }
 
+    /**
+     * Starts an Agent in the calling thread and blocks until shutdown.
+     *
+     * Logs the agent banner and version, parses [args] into an [AgentOptions], constructs an [Agent], and
+     * immediately calls `startSync()` from the constructor's `initBlock`. Control returns to the caller only
+     * after the Agent terminates (e.g. process signal, fatal error, or explicit [stop]).
+     *
+     * Use this from `main()` or any code that wants to run the Agent as the foreground task. For embedded
+     * usage inside another running JVM, use [startAsyncAgent] instead.
+     *
+     * @param args Raw command-line arguments forwarded to [AgentOptions] for parsing.
+     * @param exitOnMissingConfig When `true`, the process exits with a non-zero status if no config file/URL
+     *   is supplied. When `false`, the Agent falls back to the built-in reference config (mostly useful in
+     *   tests where defaults are sufficient).
+     */
     @JvmStatic
     fun startSyncAgent(
       args: Array<String>,
@@ -534,6 +558,23 @@ class Agent(
       Agent(options = AgentOptions(args, exitOnMissingConfig)) { startSync() }
     }
 
+    /**
+     * Starts an Agent on a background thread and returns immediately, suitable for embedding inside another
+     * JVM application.
+     *
+     * Unlike [startSyncAgent], this does not block — the Agent's lifecycle is owned by the caller via the
+     * returned [EmbeddedAgentInfo], which exposes the agent's `launchId` and `agentName` and a `stop()` method
+     * for graceful shutdown.
+     *
+     * @param configFilename Path or URL to the HOCON config file. Forwarded to the
+     *   [AgentOptions] config-filename constructor so it follows the same resolution rules as the
+     *   `--config` CLI flag.
+     * @param exitOnMissingConfig When `true`, terminates the calling process if the config cannot be located.
+     *   For embedded usage where the host application should handle config errors itself, pass `false`.
+     * @param logBanner When `true` (default), logs the Agent ASCII banner and version on startup. Pass `false`
+     *   to suppress banner output when embedding inside an app that owns its own logging surface.
+     * @return An [EmbeddedAgentInfo] handle for inspecting and shutting down the launched Agent.
+     */
     @Suppress("unused")
     @JvmStatic
     fun startAsyncAgent(

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -17,6 +17,7 @@
 package io.prometheus
 
 import com.codahale.metrics.health.HealthCheck
+import com.google.common.collect.EvictingQueue
 import com.pambrose.common.dsl.GuavaDsl.toStringElements
 import com.pambrose.common.dsl.MetricsDsl.healthCheck
 import com.pambrose.common.service.GenericService
@@ -26,7 +27,6 @@ import com.pambrose.common.util.MetricsUtils.newMapHealthCheck
 import com.pambrose.common.util.Version
 import com.pambrose.common.util.getBanner
 import com.pambrose.common.util.simpleClassName
-import com.google.common.collect.EvictingQueue
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.prometheus.common.BaseOptions.Companion.DEBUG
 import io.prometheus.common.ConfigVals
@@ -448,6 +448,22 @@ class Proxy(
   companion object {
     private val logger = logger {}
 
+    /**
+     * JVM entry point for the standalone Proxy process.
+     *
+     * Logs the Proxy ASCII banner and version, parses [args] into a [ProxyOptions], constructs a [Proxy],
+     * and immediately calls `startSync()` from the constructor's `initBlock`. Control returns to the JVM only
+     * after the Proxy terminates (e.g. process signal, fatal error, or explicit shutdown).
+     *
+     * Used as the `Main-Class` of `prometheus-proxy.jar`. Unlike [Agent.main], the Proxy always loads its
+     * built-in reference config when no `--config`/`PROXY_CONFIG` is supplied, so there is no
+     * `exitOnMissingConfig` flag to plumb through here.
+     *
+     * For embedded use inside another JVM (mirroring [Agent.startAsyncAgent]), construct a [Proxy] directly
+     * and call `startAsync()` rather than using this method.
+     *
+     * @param args Raw command-line arguments forwarded to [ProxyOptions] for parsing.
+     */
     @JvmStatic
     fun main(args: Array<String>) {
       logger.apply {

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -56,50 +56,108 @@ class AgentOptions(
   constructor(configFilename: String, exitOnMissingConfig: Boolean) :
     this(listOf("--config", configFilename), exitOnMissingConfig)
 
+  /**
+   * Proxy address the Agent connects to. Accepts either `hostname` (port defaults to `agent.proxy.port` from
+   * config, normally `50051`) or `hostname:port`.
+   * Empty means "fall back to [PROXY_HOSTNAME] env var, then `agent.proxy.hostname[:port]` from config".
+   */
   @Parameter(names = ["-p", "--proxy"], description = "Proxy hostname")
   var proxyHostname = ""
     private set
 
+  /**
+   * Friendly name for this Agent. Surfaces in metrics labels and log lines on both Proxy and Agent.
+   * Empty means "fall back to [AGENT_NAME] env var, then `agent.name` from config".
+   */
   @Parameter(names = ["-n", "--name"], description = "Agent name")
   var agentName = ""
     private set
 
+  /**
+   * Run the Agent in *consolidated* mode, allowing multiple agents to register the same path on the Proxy
+   * for redundancy/load-spreading. Resolved from CLI → [CONSOLIDATED] env var → `agent.consolidated` config.
+   */
   @Parameter(names = ["-o", "--consolidated"], description = "Consolidated Agent")
   var consolidated = false
     private set
 
+  /**
+   * TLS authority override for the Agent's outbound gRPC channel — useful when the Proxy hostname does not
+   * match its certificate SAN (e.g. connecting through a reverse proxy or load balancer using a private DNS name).
+   * Empty disables the override and gRPC validates against the Proxy hostname.
+   */
   @Parameter(names = ["--over", "--override"], description = "Override Authority")
   var overrideAuthority = ""
     private set
 
+  /**
+   * Per-scrape timeout when the Agent fetches the underlying metrics endpoint, in seconds.
+   * `-1` means "fall back to [SCRAPE_TIMEOUT_SECS] env var, then `agent.scrapeTimeoutSecs` config (default `15`)".
+   */
   @Parameter(names = ["--timeout"], description = "Scrape timeout time (seconds)")
   var scrapeTimeoutSecs = -1
     private set
 
+  /**
+   * Maximum number of retries on a failed scrape before reporting failure to the Proxy.
+   * `0` disables retries entirely. `-1` means "fall back to [SCRAPE_MAX_RETRIES] env var, then config (default `0`)".
+   */
   @Parameter(names = ["--max_retries"], description = "Scrape max retries")
   var scrapeMaxRetries = -1
     private set
 
+  /**
+   * Threshold above which a scrape response is split into chunked gRPC messages, expressed in **kilobytes**
+   * on input. After resolution, the field is converted in-place to **bytes** for runtime use; the
+   * `chunkContentSizeBytes` name reflects that final unit.
+   *
+   * `-1` means "fall back to [CHUNK_CONTENT_SIZE_KBS] env var, then `agent.chunkContentSizeKbs` (default `32` KB)".
+   * Validated `> 0` and that the resulting byte value fits in [Int].
+   */
   @Parameter(names = ["--chunk"], description = "Threshold for chunking content to Proxy and buffer size (KBs)")
   var chunkContentSizeBytes = -1
     private set
 
+  /**
+   * Scrape responses larger than this size are gzipped before being streamed to the Proxy, in bytes.
+   * `-1` means "fall back to [MIN_GZIP_SIZE_BYTES] env var, then `agent.minGzipSizeBytes` (default `512`)".
+   */
   @Parameter(names = ["--gzip"], description = "Minimum size for content to be gzipped (bytes)")
   var minGzipSizeBytes = -1
     private set
 
+  /**
+   * **Insecure.** When `true`, the Agent's HTTP client trusts every X.509 certificate presented by HTTPS
+   * scrape targets — no hostname or chain validation. Intended only for self-signed internal endpoints during
+   * development; logs a warning at startup. Resolved from CLI → [TRUST_ALL_X509_CERTIFICATES] env var →
+   * `agent.http.enableTrustAllX509Certificates` config.
+   */
   @Parameter(names = ["--trust_all_x509"], description = "Disable SSL verification for https agent endpoints")
   var trustAllX509Certificates = false
     private set
 
+  /**
+   * Maximum number of concurrent HTTP scrape requests the Agent will issue across all targets.
+   * `-1` means "fall back to [MAX_CONCURRENT_CLIENTS] env var, then `agent.http.maxConcurrentClients` (default `1`)".
+   * Validated `> 0`.
+   */
   @Parameter(names = ["--max_concurrent_clients"], description = "Maximum number of concurrent HTTP clients")
   var maxConcurrentHttpClients = -1
     private set
 
+  /**
+   * HTTP client request timeout used by the Agent when scraping endpoints, in seconds.
+   * `-1` means "fall back to [CLIENT_TIMEOUT_SECS] env var, then `agent.http.clientTimeoutSecs` (default `90`)".
+   * Validated `> 0`.
+   */
   @Parameter(names = ["--client_timeout_secs"], description = "HTTP client timeout (seconds)")
   var httpClientTimeoutSecs = -1
     private set
 
+  /**
+   * Maximum allowed size of a scrape response, in megabytes. Larger payloads are rejected by the Agent.
+   * `-1` falls back to `agent.http.maxContentLengthMBytes` from config (default `10`). Validated `> 0`.
+   */
   @Parameter(
     names = ["--max_content_length_mbytes"],
     description = "Maximum allowed size of scrape response (megabytes)",
@@ -107,14 +165,29 @@ class AgentOptions(
   var maxContentLengthMBytes = -1
     private set
 
+  /**
+   * Maximum number of pooled HTTP clients the Agent caches (keyed by target/auth credentials).
+   * `-1` means "fall back to [MAX_CLIENT_CACHE_SIZE] env var, then `agent.http.clientCache.maxSize`
+   * (default `100`)". Validated `> 0`.
+   */
   @Parameter(names = ["--max_cache_size"], description = "Maximum number of HTTP clients to cache")
   var maxCacheSize = -1
     private set
 
+  /**
+   * Maximum age before a cached HTTP client is evicted, in minutes (regardless of activity).
+   * `-1` means "fall back to [MAX_CLIENT_CACHE_AGE_MINS] env var, then `agent.http.clientCache.maxAgeMins`
+   * (default `30`)". Validated `> 0`.
+   */
   @Parameter(names = ["--max_cache_age_mins"], description = "Maximum age of cached HTTP clients (minutes)")
   var maxCacheAgeMins = -1
     private set
 
+  /**
+   * Maximum idle time before a cached HTTP client is evicted, in minutes.
+   * `-1` means "fall back to [MAX_CLIENT_CACHE_IDLE_MINS] env var, then `agent.http.clientCache.maxIdleMins`
+   * (default `10`)". Validated `> 0`.
+   */
   @Parameter(
     names = ["--max_cache_idle_mins"],
     description = "Maximum idle time before HTTP client is evicted (minutes)",
@@ -122,6 +195,11 @@ class AgentOptions(
   var maxCacheIdleMins = -1
     private set
 
+  /**
+   * Interval between HTTP-client-cache cleanup sweeps, in minutes.
+   * `-1` means "fall back to [CLIENT_CACHE_CLEANUP_INTERVAL_MINS] env var, then
+   * `agent.http.clientCache.cleanupIntervalMins` (default `5`)". Validated `> 0`.
+   */
   @Parameter(
     names = ["--cache_cleanup_interval_mins"],
     description = "Interval between HTTP client cache cleanup runs (minutes)",
@@ -129,10 +207,20 @@ class AgentOptions(
   var cacheCleanupIntervalMins = -1
     private set
 
+  /**
+   * If `true`, the Agent sends gRPC keepalive pings to the Proxy even when no RPCs are in-flight — useful when
+   * the connection traverses a load balancer or NAT that idles out silent TCP sessions. The Proxy must permit
+   * this via `--permit_keepalive_without_calls` or it will reject the pings as a protocol violation.
+   */
   @Parameter(names = ["--keepalive_without_calls"], description = "gRPC KeepAlive without calls")
   var keepAliveWithoutCalls = false
     private set
 
+  /**
+   * Per-call deadline applied to unary gRPC calls (e.g. `registerAgent`, `registerPath`) from Agent to Proxy,
+   * in seconds. Streaming RPCs are not affected.
+   * `-1` means "fall back to [UNARY_DEADLINE_SECS] env var, then `agent.grpc.unaryDeadlineSecs` (default `30`)".
+   */
   @Parameter(names = ["--unary_deadline_secs"], description = "gRPC Unary deadline (seconds)")
   var unaryDeadlineSecs = -1
     private set
@@ -294,7 +382,7 @@ class AgentOptions(
     }
   }
 
-  companion object {
+  internal companion object {
     private val logger = logger {}
   }
 }

--- a/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
+++ b/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
@@ -18,12 +18,56 @@ package io.prometheus.agent
 
 import io.prometheus.Agent
 
+/**
+ * Lifecycle handle for an [Agent] started in the background of a host JVM.
+ *
+ * Returned by [Agent.startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent], this is the
+ * supported way for embedders to interact with an Agent they did not construct directly. The
+ * underlying [Agent] instance is intentionally hidden so consumers depend only on this stable,
+ * minimal surface — identity (for logging and metrics correlation) and shutdown.
+ *
+ * The handle is a Kotlin `data class` purely to inherit value-equality and `toString()`; do not
+ * `copy()` or destructure it. The `private val agent` is the canonical owner of the running Agent,
+ * and holding multiple `EmbeddedAgentInfo` instances pointing at the same Agent is supported but
+ * not idiomatic.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * val info = Agent.startAsyncAgent("/etc/prom-proxy/agent.conf", exitOnMissingConfig = false)
+ * logger.info { "Started agent ${info.agentName} (launchId=${info.launchId})" }
+ * // ... later, during host-app shutdown:
+ * info.shutdown()
+ * ```
+ *
+ * @property launchId Random 15-character identifier generated when the [Agent] was constructed.
+ *   Stable for the lifetime of the running process; rotates on every restart, so it is the right
+ *   key for distinguishing this run from prior runs of the same `agentName` in metrics labels and
+ *   log correlation.
+ * @property agentName Human-readable name from [AgentOptions.agentName], falling back to
+ *   `Unnamed-<hostname>` when no name is configured. Surfaces in Prometheus metric labels and the
+ *   Agent's log output. Unlike [launchId], this is intended to be stable across restarts.
+ */
 data class EmbeddedAgentInfo(
   private val agent: Agent,
 ) {
+  /** See class-level KDoc. */
   val launchId: String get() = agent.launchId
+
+  /** See class-level KDoc. */
   val agentName: String get() = agent.agentName
 
+  /**
+   * Gracefully stops the embedded [Agent].
+   *
+   * Closes the gRPC channel to the Proxy, shuts down the cached HTTP scrape clients, drains
+   * in-flight scrape requests, and releases the admin/metrics servlets. Idempotent at the
+   * `GenericService` level — calling twice is safe but only the first invocation does work.
+   *
+   * Blocks the calling thread until the Agent has finished shutting down. Call this from your
+   * host application's shutdown hook (or equivalent) to avoid leaking the gRPC connection and
+   * background scrape coroutines past process exit.
+   */
   fun shutdown() {
     agent.stop()
   }

--- a/src/main/kotlin/io/prometheus/agent/SslSettings.kt
+++ b/src/main/kotlin/io/prometheus/agent/SslSettings.kt
@@ -25,7 +25,7 @@ import javax.net.ssl.X509TrustManager
 // https://github.com/Hakky54/mutual-tls-ssl/blob/master/client/src/main/java/nl/altindag/client/service/KtorCIOHttpClientService.kt
 
 @Suppress("unused")
-object SslSettings {
+internal object SslSettings {
   fun getKeyStore(
     fileName: String,
     password: String,

--- a/src/main/kotlin/io/prometheus/agent/TrustAllX509TrustManager.kt
+++ b/src/main/kotlin/io/prometheus/agent/TrustAllX509TrustManager.kt
@@ -21,7 +21,7 @@ import javax.net.ssl.X509TrustManager
 
 // https://stackoverflow.com/questions/66490928/how-can-i-disable-ktor-client-ssl-verification
 
-object TrustAllX509TrustManager : X509TrustManager {
+internal object TrustAllX509TrustManager : X509TrustManager {
   private val EMPTY_CERTIFICATES: Array<X509Certificate?> = arrayOfNulls(0)
 
   override fun getAcceptedIssuers(): Array<X509Certificate?> = EMPTY_CERTIFICATES

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -30,6 +30,7 @@ import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.ConfigResolveOptions
 import com.typesafe.config.ConfigSyntax
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
+import io.prometheus.common.BaseOptions.Companion.DEBUG
 import io.prometheus.common.EnvVars.ADMIN_ENABLED
 import io.prometheus.common.EnvVars.ADMIN_PORT
 import io.prometheus.common.EnvVars.CERT_CHAIN_FILE_PATH
@@ -53,64 +54,142 @@ abstract class BaseOptions protected constructor(
   private val envConfig: String,
   private val exitOnMissingConfig: Boolean = false,
 ) {
+  /**
+   * Path or URL to the HOCON config file. Accepts a local filesystem path, an `http://`/`https://` URL, or a
+   * `.json`/`.properties` file (syntax inferred from the extension).
+   * Empty falls back to the env var named by the subclass-specific `envConfig` parameter
+   * (`PROXY_CONFIG` for the Proxy, `AGENT_CONFIG` for the Agent).
+   */
   @Parameter(names = ["-c", "--conf", "--config"], description = "Configuration file or url")
   private var configSource = ""
 
+  /**
+   * Enables the admin servlets (`/ping`, `/version`, `/healthcheck`, `/threaddump`) on this process.
+   * Resolved from CLI → [ADMIN_ENABLED] env var → `<role>.admin.enabled` config (default `false`).
+   */
   @Parameter(names = ["-r", "--admin"], description = "Admin servlets enabled")
   var adminEnabled = false
     private set
 
+  /**
+   * Listen port for this process's admin servlets.
+   * `-1` means "fall back to [ADMIN_PORT] env var, then `<role>.admin.port` config (Proxy default `8092`,
+   * Agent default `8093`)".
+   */
   @Parameter(names = ["-i", "--admin_port"], description = "Admin servlets port")
   var adminPort: Int = -1
     private set
 
+  /**
+   * Enables this process's Prometheus metrics endpoint.
+   * Resolved from CLI → [METRICS_ENABLED] env var → `<role>.metrics.enabled` config (default `false`).
+   */
   @Parameter(names = ["-e", "--metrics"], description = "Metrics enabled")
   var metricsEnabled = false
     private set
 
+  /**
+   * Listen port for this process's Prometheus metrics endpoint.
+   * `-1` means "fall back to [METRICS_PORT] env var, then `<role>.metrics.port` config (Proxy default `8082`,
+   * Agent default `8083`)".
+   */
   @Parameter(names = ["-m", "--metrics_port"], description = "Metrics listen port")
   var metricsPort = -1
     private set
 
+  /**
+   * Enables the `/debug` admin servlet on this process — exposes recent activity / scrape-request introspection.
+   * Distinct from [DEBUG] (the servlet path constant). Resolved from CLI → [DEBUG_ENABLED] env var →
+   * `<role>.admin.debugEnabled` config (default `false`).
+   */
   @Parameter(names = ["-b", "--debug"], description = "Debug option enabled")
   var debugEnabled = false
     private set
 
-  // Use both options here to avoid breaking people with the typo fix
+  /**
+   * Disables the gRPC transport filter that records remote-peer information per call. Set when running behind
+   * an L7 reverse proxy (e.g. nginx) that already strips this information.
+   *
+   * Both `--tf-disabled` (current) and `--tf_disabled` (legacy typo) are accepted to preserve backwards
+   * compatibility for existing deployments.
+   */
   @Parameter(names = ["--tf-disabled", "--tf_disabled"], description = "Transport filter disabled")
   var transportFilterDisabled = false
     private set
 
+  /**
+   * Filesystem path to the TLS certificate chain (PEM). Must be paired with [privateKeyFilePath]; supplying
+   * one without the other is rejected by [validateTlsConfig]. Empty disables TLS on this side and exposes
+   * plaintext gRPC. See also [isTlsEnabled].
+   */
   @Parameter(names = ["-t", "--cert"], description = "Certificate chain file path")
   var certChainFilePath = ""
     private set
 
+  /**
+   * Filesystem path to the TLS private key (PEM) matching [certChainFilePath]. Must be paired with the cert
+   * file; supplying one without the other is rejected by [validateTlsConfig]. Empty disables TLS on this side.
+   */
   @Parameter(names = ["-k", "--key"], description = "Private key file path")
   var privateKeyFilePath = ""
     private set
 
+  /**
+   * Filesystem path to the trust-store certificate collection (PEM) used to validate the peer's certificate.
+   * Required for mTLS; for one-way TLS the JDK default trust store is used when this is empty.
+   */
   @Parameter(names = ["-s", "--trust"], description = "Trust certificate collection file path")
   var trustCertCollectionFilePath = ""
     private set
 
+  /**
+   * gRPC keepalive ping interval, in seconds — how often this side sends a keepalive ping on an idle channel.
+   * `-1L` means "fall back to [KEEPALIVE_TIME_SECS] env var, then `<role>.grpc.keepAliveTimeSecs` config;
+   * `-1L` after resolution leaves the gRPC default in place".
+   */
   @Parameter(names = ["--keepalive_time_secs"], description = "gRPC KeepAlive time (secs)")
   var keepAliveTimeSecs = -1L
     private set
 
+  /**
+   * gRPC keepalive ping timeout, in seconds — how long this side waits for a keepalive ack before considering
+   * the connection dead.
+   * `-1L` means "fall back to [KEEPALIVE_TIMEOUT_SECS] env var, then `<role>.grpc.keepAliveTimeoutSecs` config;
+   * `-1L` after resolution leaves the gRPC default in place".
+   */
   @Parameter(names = ["--keepalive_timeout_secs"], description = "gRPC KeepAlive timeout (secs)")
   var keepAliveTimeoutSecs = -1L
     private set
 
+  /**
+   * Logback log level for this process: one of `all`, `trace`, `debug`, `info`, `warn`, `error`, `off`.
+   * Empty falls back to the role-specific env var ([io.prometheus.common.EnvVars.PROXY_LOG_LEVEL] or
+   * [io.prometheus.common.EnvVars.AGENT_LOG_LEVEL]) and then `<role>.logLevel` config; if still empty,
+   * the level configured in `logback.xml` is used.
+   *
+   * Settable by subclasses (e.g. [io.prometheus.proxy.ProxyOptions], [io.prometheus.agent.AgentOptions])
+   * during [assignConfigVals].
+   */
   @Parameter(names = ["--log_level"], description = "Log level")
   var logLevel = ""
     protected set
 
+  /** When set, prints `name version (build-date)` to stdout and exits with code `0`. Not retained as state. */
   @Parameter(names = ["-v", "--version"], description = "Print version info and exit")
   private var version = false
 
+  /**
+   * When set, JCommander prints the auto-generated usage banner to stdout and the process exits with code `0`.
+   * Marked `help = true` so JCommander does not enforce required-parameter checks when this flag is present.
+   */
   @Parameter(names = ["-u", "--usage"], help = true)
   private var usage = false
 
+  /**
+   * Dynamic HOCON property overrides accepted as `-Dkey=value` (multiple `-D` flags allowed). Each pair is
+   * merged into the resolved config with highest precedence over the loaded config file, and any surrounding
+   * double-quotes on the value are stripped. Useful for one-off overrides that don't have a dedicated flag.
+   */
   @DynamicParameter(names = ["-D"], description = "Dynamic property assignment")
   var dynamicParams = mutableMapOf<String, String>()
     private set
@@ -312,7 +391,7 @@ abstract class BaseOptions protected constructor(
     when {
       configName.isBlank() -> {
         if (exitOnMissingConfig) {
-          logger.error { "A configuration file or url must be specified with --config or \$$envConfig" }
+          logger.error { $$"A configuration file or url must be specified with --config or $$$envConfig" }
           exitProcess(1)
         }
         return fallback
@@ -347,7 +426,7 @@ abstract class BaseOptions protected constructor(
     exitProcess(1)
   }
 
-  companion object {
+  internal companion object {
     private val logger = logger {}
     private val PROPS = ConfigParseOptions.defaults().setSyntax(ConfigSyntax.PROPERTIES)
     const val DEBUG = "debug"

--- a/src/main/kotlin/io/prometheus/common/EnvVars.kt
+++ b/src/main/kotlin/io/prometheus/common/EnvVars.kt
@@ -14,67 +14,180 @@
  * limitations under the License.
  */
 
-@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+@file:Suppress("UndocumentedPublicFunction")
 
 package io.prometheus.common
 
 import java.lang.System.getenv
 
+/**
+ * Environment variables recognized by the Proxy and Agent processes.
+ *
+ * Values are resolved with the precedence: CLI argument → environment variable → config file → built-in default.
+ * Use [getEnv] to read a variable with a typed default; missing values fall through to the supplied default,
+ * and malformed numeric or boolean values raise [IllegalArgumentException].
+ */
 enum class EnvVars {
-  // Proxy
+  // ---- Proxy ----
+
+  /** Path or URL to the Proxy HOCON config file. Equivalent to the `--config`/`-c` CLI flag. */
   PROXY_CONFIG,
+
+  /** TCP port the Proxy serves proxied scrape requests on (the port Prometheus connects to). Default `8080`. */
   PROXY_PORT,
+
+  /** TCP port the Proxy listens on for incoming gRPC connections from agents. Default `50051`. */
   AGENT_PORT,
+
+  /**
+   * Enable Prometheus HTTP service-discovery on the Proxy. When `true` the Proxy serves a discovery document
+   * listing currently registered agent paths. Default `false`.
+   */
   SD_ENABLED,
+
+  /** HTTP path the Proxy exposes the service-discovery document on (relative to the Proxy HTTP port). */
   SD_PATH,
+
+  /** Base URL used to build per-target entries in the service-discovery document (e.g. `http://proxy:8080/`). */
   SD_TARGET_PREFIX,
+
+  /** Disable the gRPC server reflection service on the Proxy. Default `false` (reflection enabled). */
   REFLECTION_DISABLED,
 
+  /** gRPC handshake timeout for the Proxy server, in seconds. `-1` uses the gRPC default. */
   HANDSHAKE_TIMEOUT_SECS,
+
+  /** If `true`, allow gRPC keepalive pings from agents even when no RPCs are in-flight. Default `false`. */
   PERMIT_KEEPALIVE_WITHOUT_CALLS,
+
+  /** Minimum interval the Proxy will accept gRPC keepalive pings from agents, in seconds. */
   PERMIT_KEEPALIVE_TIME_SECS,
+
+  /** gRPC server `MAX_CONNECTION_IDLE` in seconds — idle connections are closed after this period. `-1` disables. */
   MAX_CONNECTION_IDLE_SECS,
+
+  /** gRPC server `MAX_CONNECTION_AGE` in seconds — connections older than this are gracefully closed. `-1` disables. */
   MAX_CONNECTION_AGE_SECS,
+
+  /** Grace period after [MAX_CONNECTION_AGE_SECS] before forced close, in seconds. `-1` disables. */
   MAX_CONNECTION_AGE_GRACE_SECS,
+
+  /**
+   * Proxy log level: one of `all`, `trace`, `debug`, `info`, `warn`, `error`, `off`.
+   * Empty leaves the configured level unchanged.
+   */
   PROXY_LOG_LEVEL,
 
-  // Agent
+  // ---- Agent ----
+
+  /** Path or URL to the Agent HOCON config file. Equivalent to the `--config`/`-c` CLI flag. */
   AGENT_CONFIG,
+
+  /** Hostname (or `host:port`) of the Proxy the Agent should connect to. */
   PROXY_HOSTNAME,
+
+  /** Friendly name for this Agent reported in metrics and logs. */
   AGENT_NAME,
+
+  /**
+   * Run the Agent in *consolidated* mode, allowing multiple agents to register the same path for redundancy.
+   * Default `false`.
+   */
   CONSOLIDATED,
+
+  /** Per-scrape timeout when the Agent fetches the underlying metrics endpoint, in seconds. */
   SCRAPE_TIMEOUT_SECS,
+
+  /** Maximum number of retries the Agent attempts on a failed scrape before giving up. `0` disables retries. */
   SCRAPE_MAX_RETRIES,
+
+  /**
+   * Threshold above which a scrape response is split into chunked gRPC messages, in kilobytes.
+   * Also doubles as the chunk buffer size. Default `32`.
+   */
   CHUNK_CONTENT_SIZE_KBS,
+
+  /** Scrape responses larger than this size are gzipped before being streamed to the Proxy, in bytes. */
   MIN_GZIP_SIZE_BYTES,
 
+  /**
+   * Disable X.509 certificate verification for HTTPS scrape targets. Insecure — only enable for self-signed
+   * internal endpoints. Default `false`.
+   */
   TRUST_ALL_X509_CERTIFICATES,
+
+  /** Maximum number of concurrent HTTP scrape requests the Agent will issue. */
   MAX_CONCURRENT_CLIENTS,
+
+  /** HTTP client request timeout used by the Agent when scraping endpoints, in seconds. */
   CLIENT_TIMEOUT_SECS,
+
+  /** Maximum number of pooled HTTP clients the Agent caches (keyed by auth credentials / target). */
   MAX_CLIENT_CACHE_SIZE,
+
+  /** Maximum age before a cached HTTP client is evicted, in minutes. */
   MAX_CLIENT_CACHE_AGE_MINS,
+
+  /** Maximum idle time before a cached HTTP client is evicted, in minutes. */
   MAX_CLIENT_CACHE_IDLE_MINS,
+
+  /** Interval between HTTP-client-cache cleanup sweeps, in minutes. */
   CLIENT_CACHE_CLEANUP_INTERVAL_MINS,
 
+  /** If `true`, the Agent sends gRPC keepalive pings even when no RPCs are in-flight. Default `false`. */
   KEEPALIVE_WITHOUT_CALLS,
+
+  /** Per-call deadline applied to unary gRPC calls from the Agent to the Proxy, in seconds. */
   UNARY_DEADLINE_SECS,
 
+  /**
+   * Agent log level: one of `all`, `trace`, `debug`, `info`, `warn`, `error`, `off`.
+   * Empty leaves the configured level unchanged.
+   */
   AGENT_LOG_LEVEL,
 
-  // Common
+  // ---- Common (apply to both Proxy and Agent) ----
+
+  /** Enable the `/debug` admin servlet on whichever process this variable is read by. Default `false`. */
   DEBUG_ENABLED,
+
+  /** Enable the Prometheus metrics endpoint on this process. Default `false`. */
   METRICS_ENABLED,
+
+  /** Listen port for this process's Prometheus metrics endpoint. */
   METRICS_PORT,
+
+  /** Enable the admin servlets (ping, version, healthcheck, threaddump) on this process. Default `false`. */
   ADMIN_ENABLED,
+
+  /** Listen port for this process's admin servlets. */
   ADMIN_PORT,
+
+  /**
+   * Disable the gRPC transport filter that records remote-peer information per call. Set `true` when running
+   * behind an L7 reverse proxy (e.g. nginx) that strips this information. Default `false`.
+   */
   TRANSPORT_FILTER_DISABLED,
 
+  /** Filesystem path to the TLS certificate chain file (PEM). Empty disables TLS on this side. */
   CERT_CHAIN_FILE_PATH,
+
+  /** Filesystem path to the TLS private key file (PEM). Empty disables TLS on this side. */
   PRIVATE_KEY_FILE_PATH,
+
+  /** Filesystem path to the trust-store certificate collection (PEM) used to validate the peer. */
   TRUST_CERT_COLLECTION_FILE_PATH,
+
+  /**
+   * TLS authority override for the Agent's gRPC channel.
+   * Useful when the Proxy hostname does not match its certificate SAN.
+   */
   OVERRIDE_AUTHORITY,
 
+  /** gRPC keepalive ping interval, in seconds. `-1` uses the gRPC default. */
   KEEPALIVE_TIME_SECS,
+
+  /** gRPC keepalive ping timeout, in seconds. `-1` uses the gRPC default. */
   KEEPALIVE_TIMEOUT_SECS,
   ;
 
@@ -97,7 +210,7 @@ enum class EnvVars {
       ?: throw IllegalArgumentException("Environment variable $name has invalid long value: '$value'")
   }
 
-  companion object {
+  internal companion object {
     internal fun parseBooleanStrict(
       envName: String,
       value: String,

--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory
 import java.net.URLDecoder
 import kotlin.text.Charsets.UTF_8
 
-object Utils {
+internal object Utils {
   internal fun getVersionDesc(asJson: Boolean = false): String = Proxy::class.versionDesc(asJson)
 
   fun decodeParams(encodedQueryParams: String): String =

--- a/src/main/kotlin/io/prometheus/proxy/ProxyConstants.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyConstants.kt
@@ -16,7 +16,7 @@
 
 package io.prometheus.proxy
 
-object ProxyConstants {
+internal object ProxyConstants {
   const val MISSING_PATH_MSG = "Request missing path"
   const val CACHE_CONTROL_VALUE = "must-revalidate,no-store"
   const val FAVICON_FILENAME = "favicon.ico"

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -61,7 +61,7 @@ import kotlin.time.Duration.Companion.seconds
  * @see ProxyPathManager
  * @see AgentContext
  */
-object ProxyHttpRoutes {
+internal object ProxyHttpRoutes {
   private val logger = logger {}
   private val format = Json { prettyPrint = true }
   private val authHeaderWithoutTlsWarned = AtomicBoolean(false)
@@ -370,7 +370,7 @@ object ProxyHttpRoutes {
   }
 }
 
-data class ScrapeRequestResponse(
+internal data class ScrapeRequestResponse(
   val statusCode: HttpStatusCode,
   val updateMsg: String,
   val contentType: ContentType = Text.Plain.withCharset(Charsets.UTF_8),
@@ -380,7 +380,7 @@ data class ScrapeRequestResponse(
   val fetchDuration: Duration,
 )
 
-data class ResponseResults(
+internal data class ResponseResults(
   val statusCode: HttpStatusCode = HttpStatusCode.OK,
   val contentType: ContentType = Text.Plain.withCharset(Charsets.UTF_8),
   val contentText: String = "",

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -43,51 +43,105 @@ class ProxyOptions(
 ) : BaseOptions(Proxy::class.java.simpleName, args, PROXY_CONFIG.name) {
   constructor(args: List<String>) : this(args.toTypedArray())
 
+  /**
+   * TCP port the Proxy serves proxied scrape requests on (the port Prometheus connects to).
+   * `-1` means "fall back to [PROXY_PORT] env var, then `proxy.http.port` from config (default `8080`)".
+   */
   @Parameter(names = ["-p", "--port"], description = "Proxy listen port")
   var proxyPort = -1
     private set
 
+  /**
+   * TCP port the Proxy listens on for incoming gRPC connections from agents.
+   * `-1` means "fall back to [AGENT_PORT] env var, then `proxy.agent.port` from config (default `50051`)".
+   */
   @Parameter(names = ["-a", "--agent_port"], description = "gRPC listen port for Agents")
   var proxyAgentPort = -1
     private set
 
+  /**
+   * Enables the Prometheus HTTP service-discovery endpoint on the Proxy.
+   * When `true`, the Proxy serves a discovery document listing currently registered agent paths
+   * at [sdPath]. Resolved from CLI → [SD_ENABLED] env var → `proxy.service.discovery.enabled` config.
+   */
   @Parameter(names = ["--sd_enabled"], description = "Service discovery endpoint enabled")
   var sdEnabled = false
     private set
 
+  /**
+   * HTTP path (relative to the Proxy HTTP port) at which the service-discovery document is served.
+   * Required and validated to be non-empty when [sdEnabled] is `true`.
+   */
   @Parameter(names = ["--sd_path"], description = "Service discovery endpoint path")
   var sdPath = ""
     private set
 
+  /**
+   * Base URL used to build per-target entries in the service-discovery document
+   * (e.g. `http://proxy.example.com:8080/`).
+   * Required and validated to be non-empty when [sdEnabled] is `true`.
+   */
   @Parameter(names = ["--sd_target_prefix"], description = "Service discovery target prefix")
   var sdTargetPrefix = ""
     private set
 
-  // Use both options here to avoid breaking people with the typo fix
+  /**
+   * Disables the gRPC server reflection service on the Proxy.
+   *
+   * Both `--ref-disabled` (current) and `--ref_disabled` (legacy typo) are accepted to preserve
+   * backwards compatibility for existing deployments.
+   */
   @Parameter(names = ["--ref-disabled", "--ref_disabled"], description = "gRPC Reflection disabled")
   var reflectionDisabled = false
     private set
 
+  /**
+   * gRPC handshake timeout for the Proxy server, in seconds.
+   * `-1L` means "use the gRPC default (120s)".
+   */
   @Parameter(names = ["--handshake_timeout_secs"], description = "gRPC Handshake timeout (secs)")
   var handshakeTimeoutSecs = -1L
     private set
 
+  /**
+   * If `true`, the Proxy permits gRPC keepalive pings from agents even when no RPCs are in-flight.
+   * Pair with [permitKeepAliveTimeSecs] to control the minimum allowed ping interval.
+   */
   @Parameter(names = ["--permit_keepalive_without_calls"], description = "Permit gRPC KeepAlive without calls")
   var permitKeepAliveWithoutCalls = false
     private set
 
+  /**
+   * Minimum interval, in seconds, that the Proxy will accept gRPC keepalive pings from agents.
+   * Pings arriving more frequently than this are treated as a protocol violation by gRPC.
+   * `-1L` means "use the gRPC default (300s)".
+   */
   @Parameter(names = ["--permit_keepalive_time_secs"], description = "Permit gRPC KeepAlive time (secs)")
   var permitKeepAliveTimeSecs = -1L
     private set
 
+  /**
+   * gRPC server `MAX_CONNECTION_IDLE` in seconds — connections idle longer than this are closed.
+   * `-1L` means "use the gRPC default (`INT_MAX`, effectively no idle timeout)".
+   */
   @Parameter(names = ["--max_connection_idle_secs"], description = "Max gRPC connection idle (secs)")
   var maxConnectionIdleSecs = -1L
     private set
 
+  /**
+   * gRPC server `MAX_CONNECTION_AGE` in seconds — connections older than this are gracefully closed,
+   * forcing reconnect (useful for load-balancer rebalancing).
+   * `-1L` means "use the gRPC default (`INT_MAX`, effectively no age limit)".
+   */
   @Parameter(names = ["--max_connection_age_secs"], description = "Max gRPC connection age (secs)")
   var maxConnectionAgeSecs = -1L
     private set
 
+  /**
+   * Grace period, in seconds, after [maxConnectionAgeSecs] is reached before the Proxy forcibly
+   * closes the connection. Allows in-flight RPCs to complete cleanly.
+   * `-1L` means "use the gRPC default (`INT_MAX`)".
+   */
   @Parameter(names = ["--max_connection_age_grace_secs"], description = "Max gRPC connection age grace (secs)")
   var maxConnectionAgeGraceSecs = -1L
     private set
@@ -200,7 +254,7 @@ class ProxyOptions(
       }
   }
 
-  companion object {
+  internal companion object {
     private val logger = logger {}
   }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
@@ -32,7 +32,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPInputStream
 
-object ProxyUtils {
+internal object ProxyUtils {
   private val logger = logger {}
 
   fun ByteArray.unzip(maxSize: Long): String {

--- a/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
@@ -21,7 +21,6 @@ package io.prometheus.agent
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.prometheus.Agent
-import kotlinx.coroutines.runBlocking
 import kotlin.concurrent.atomics.minusAssign
 import kotlin.concurrent.atomics.plusAssign
 
@@ -57,19 +56,17 @@ class AgentBacklogDriftTest : StringSpec() {
       // Second one fails
       try {
         agent.scrapeRequestBacklogSize += 1
-        runBlocking {
-          try {
-            connectionContext.sendScrapeRequestAction {
-              io.prometheus.common.ScrapeResults(
-                srScrapeId = 0,
-                srAgentId = "",
-                srStatusCode = 200,
-              )
-            }
-          } catch (e: Exception) {
-            agent.scrapeRequestBacklogSize -= 1
-            throw e
+        try {
+          connectionContext.sendScrapeRequestAction {
+            io.prometheus.common.ScrapeResults(
+              srScrapeId = 0,
+              srAgentId = "",
+              srStatusCode = 200,
+            )
           }
+        } catch (e: Exception) {
+          agent.scrapeRequestBacklogSize -= 1
+          throw e
         }
       } catch (e: Exception) {
         // Expected (ClosedSendChannelException or similar)

--- a/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
 class AgentConnectionContextTest : StringSpec() {
   init {
@@ -262,7 +263,7 @@ class AgentConnectionContextTest : StringSpec() {
           launch(Dispatchers.IO) {
             try {
               // Simulate scrape work
-              delay(50)
+              delay(50.milliseconds)
               context.sendScrapeResults(
                 ScrapeResults(srAgentId = "agent-1", srScrapeId = i.toLong(), srValidResponse = true),
               )
@@ -274,7 +275,7 @@ class AgentConnectionContextTest : StringSpec() {
         }
 
         // Close the context while scrapes are in-flight
-        delay(10)
+        delay(10.milliseconds)
         context.close()
       }
 
@@ -323,7 +324,7 @@ class AgentConnectionContextTest : StringSpec() {
           launch(Dispatchers.IO) {
             backlogSize.incrementAndGet()
             try {
-              delay(20)
+              delay(20.milliseconds)
               context.sendScrapeResults(
                 ScrapeResults(srAgentId = "agent-1", srScrapeId = i.toLong(), srValidResponse = true),
               )
@@ -334,7 +335,7 @@ class AgentConnectionContextTest : StringSpec() {
         }
 
         // Close mid-flight
-        delay(5)
+        delay(5.milliseconds)
         context.close()
       }
 

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -1151,14 +1151,14 @@ class AgentGrpcServiceTest : StringSpec() {
       val service = AgentGrpcService(agent, agent.options, "test-server")
 
       // Read grpcStarted via the delegate field
-      val delegateField = service.javaClass.getDeclaredField("grpcStarted\$delegate")
+      val delegateField = service.javaClass.getDeclaredField($$"grpcStarted$delegate")
       delegateField.isAccessible = true
       val delegate = delegateField.get(service)
 
       // The delegate wraps an AtomicBoolean in a field named "atomicVal"
       val atomicValField = delegate.javaClass.getDeclaredField("atomicVal")
       atomicValField.isAccessible = true
-      val atomicBool = atomicValField.get(delegate) as java.util.concurrent.atomic.AtomicBoolean
+      val atomicBool = atomicValField.get(delegate) as AtomicBoolean
 
       // After successful construction, grpcStarted should be true
       atomicBool.get().shouldBeTrue()

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -46,6 +46,7 @@ import io.prometheus.grpc.registerPathResponse
 import io.prometheus.grpc.scrapeRequest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 import io.ktor.server.cio.CIO as ServerCIO
 
@@ -168,7 +169,7 @@ class AgentHttpServiceTest : StringSpec() {
     server.start(wait = false)
     val port = server.engine.resolvedConnectors().first().port
     // Allow the CIO server engine to fully start accepting connections
-    delay(100)
+    delay(100.milliseconds)
     return port
   }
 
@@ -669,7 +670,7 @@ class AgentHttpServiceTest : StringSpec() {
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            delay(5000) // Delay longer than timeout
+            delay(5000.milliseconds) // Delay longer than timeout
             call.respondText("too late")
           }
         }

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
 class AgentPathManagerTest : StringSpec() {
   private fun createMockAgent(): Agent {
@@ -395,7 +396,7 @@ class AgentPathManagerTest : StringSpec() {
       coEvery { agent.grpcService.registerPathOnProxy(any(), any()) } coAnswers {
         val current = concurrentCalls.incrementAndGet()
         maxConcurrent.updateAndGet { max -> maxOf(max, current) }
-        delay(100) // Simulate slow gRPC call
+        delay(100.milliseconds) // Simulate slow gRPC call
         concurrentCalls.decrementAndGet()
         registerPathResponse {
           valid = true

--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.minusAssign
@@ -359,13 +358,10 @@ class AgentTest : StringSpec() {
       val agent = createTestAgent()
       agent.scrapeRequestBacklogSize.store(50)
 
-      runBlocking {
-        // Launch 100 coroutines each decrementing by 1 — only 50 should succeed
-        coroutineScope {
-          repeat(100) {
-            launch(Dispatchers.IO) {
-              agent.decrementBacklog(1)
-            }
+      coroutineScope {
+        repeat(100) {
+          launch(Dispatchers.IO) {
+            agent.decrementBacklog(1)
           }
         }
       }
@@ -459,7 +455,7 @@ class AgentTest : StringSpec() {
     // ==================== Bug #1: Bounded Coroutine Creation Tests ====================
 
     "Bug #1: semaphore.acquire() before launch should limit waiting coroutines" {
-      runBlocking {
+      run {
         val maxConcurrency = 2
         val semaphore = kotlinx.coroutines.sync.Semaphore(maxConcurrency)
         val activeCoroutines = AtomicInt(0)

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -146,13 +146,13 @@ class HttpClientCacheTest : StringSpec() {
           val key = ClientKey("user$i", "pass$i")
           val entry = lruCache.getOrCreateClient(key) { createMockHttpClient() }
           entries.add(entry)
-          delay(2) // Ensure each entry gets a distinct timestamp
+          delay(2.milliseconds) // Ensure each entry gets a distinct timestamp
         }
 
         lruCache.currentCacheSize() shouldBe 5
 
         // Access user1 to make it most recently used (now has newest timestamp)
-        delay(2)
+        delay(2.milliseconds)
         val firstKey = ClientKey("user1", "pass1")
         val firstEntry = lruCache.getOrCreateClient(firstKey) { createMockHttpClient() }
         firstEntry.client shouldBe entries[0].client

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -277,10 +277,10 @@ class BaseOptionsTest : StringSpec() {
       try {
         val confFile = File(tempDir, "test-subst.conf")
         confFile.writeText(
-          """
+          $$"""
           proxy {
             http.port = 8888
-            admin.port = ${"$"}{proxy.http.port}
+            admin.port = ${proxy.http.port}
           }
           """.trimIndent(),
         )
@@ -333,9 +333,9 @@ class BaseOptionsTest : StringSpec() {
     // verifies the interpolation produces the expected output.
     "readConfig error message should include literal dollar sign before env var name" {
       val envConfig = "AGENT_CONFIG"
-      val message = "A configuration file or url must be specified with --config or \$$envConfig"
+      val message = $$"A configuration file or url must be specified with --config or $$$envConfig"
 
-      message shouldBe "A configuration file or url must be specified with --config or \$AGENT_CONFIG"
+      message shouldBe $$"A configuration file or url must be specified with --config or $AGENT_CONFIG"
     }
 
     // ==================== ConfigVals Tests ====================

--- a/src/test/kotlin/io/prometheus/common/ScrapeResultsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/ScrapeResultsTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import java.io.IOException
 import java.net.http.HttpConnectTimeoutException
+import kotlin.time.Duration.Companion.milliseconds
 
 class ScrapeResultsTest : StringSpec() {
   init {
@@ -263,9 +264,9 @@ class ScrapeResultsTest : StringSpec() {
     "errorCode should return RequestTimeout for TimeoutCancellationException" {
       // TimeoutCancellationException constructor is internal, so we generate it via withTimeout
       val exception = try {
-        withTimeout(1) {
+        withTimeout(1.milliseconds) {
           // Use delay instead of Thread.sleep to properly suspend and timeout
-          delay(1000)
+          delay(1000.milliseconds)
         }
         null
       } catch (e: Exception) {

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
@@ -19,7 +19,6 @@
 package io.prometheus.harness.support
 
 import io.github.oshai.kotlinlogging.KLogger
-import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.prometheus.Agent
 import io.prometheus.Proxy
 import io.prometheus.agent.AgentOptions
@@ -63,7 +62,7 @@ object CustomEnumSerializer : KSerializer<MyEnum> {
 }
 
 object TestUtils {
-  private val logger = logger {}
+//  private val logger = logger {}
 
   @JvmStatic
   fun main(args: Array<String>) {

--- a/src/test/kotlin/website/DockerExamples.txt
+++ b/src/test/kotlin/website/DockerExamples.txt
@@ -1,14 +1,14 @@
 ; --8<-- [start:docker-proxy-basic]
 # Start a proxy container:
 docker run --rm -p 8080:8080 -p 50051:50051 \
-  pambrose/prometheus-proxy:3.1.0
+  pambrose/prometheus-proxy:3.1.1
 ; --8<-- [end:docker-proxy-basic]
 
 ; --8<-- [start:docker-agent-basic]
 # Start an agent with a remote config:
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.0
+  pambrose/prometheus-agent:3.1.1
 ; --8<-- [end:docker-agent-basic]
 
 ; --8<-- [start:docker-proxy-production]
@@ -21,7 +21,7 @@ docker run --rm \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
   --restart unless-stopped \
-  pambrose/prometheus-proxy:3.1.0
+  pambrose/prometheus-proxy:3.1.1
 ; --8<-- [end:docker-proxy-production]
 
 ; --8<-- [start:docker-agent-local-config]
@@ -31,7 +31,7 @@ docker run --rm \
   -p 8093:8093 \
   --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
   --env AGENT_CONFIG=prom-agent.conf \
-  pambrose/prometheus-agent:3.1.0
+  pambrose/prometheus-agent:3.1.1
 ; --8<-- [end:docker-agent-local-config]
 
 ; --8<-- [start:docker-compose-full]
@@ -39,7 +39,7 @@ version: '3.8'
 
 services:
   proxy:
-    image: pambrose/prometheus-proxy:3.1.0
+    image: pambrose/prometheus-proxy:3.1.1
     ports:
       - "8080:8080"    # HTTP scrape port
       - "50051:50051"  # gRPC agent port
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   agent:
-    image: pambrose/prometheus-agent:3.1.0
+    image: pambrose/prometheus-agent:3.1.1
     ports:
       - "8083:8083"    # Metrics port
       - "8093:8093"    # Admin port
@@ -81,7 +81,7 @@ docker run --rm \
   --env PROXY_CONFIG=tls.conf \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
-  pambrose/prometheus-proxy:3.1.0
+  pambrose/prometheus-proxy:3.1.1
 
 # Agent with TLS (no mutual auth):
 docker run --rm \
@@ -91,7 +91,7 @@ docker run --rm \
   --mount type=bind,source="$(pwd)"/tls.conf,target=/app/tls.conf \
   --env AGENT_CONFIG=tls.conf \
   --env PROXY_HOSTNAME=proxy-host:50440 \
-  pambrose/prometheus-agent:3.1.0
+  pambrose/prometheus-agent:3.1.1
 ; --8<-- [end:docker-tls]
 
 ; --8<-- [start:docker-env-vars]

--- a/src/test/kotlin/website/EmbeddedAgentExamples.txt
+++ b/src/test/kotlin/website/EmbeddedAgentExamples.txt
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.0")
+  implementation("com.pambrose:prometheus-proxy:3.1.1")
 }
 // --8<-- [end:gradle-dependency]
 
@@ -15,7 +15,7 @@ dependencies {
   <dependency>
     <groupId>com.pambrose</groupId>
     <artifactId>prometheus-proxy</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </dependency>
 </dependencies>
 <!-- --8<-- [end:maven-dependency] -->

--- a/website/prometheus-proxy/docs/advanced.md
+++ b/website/prometheus-proxy/docs/advanced.md
@@ -96,14 +96,14 @@ Increase the number of parallel scrapes for high-throughput scenarios:
 
 ### Key Tuning Parameters
 
-| Parameter | Default | Guidance |
-|:----------|:--------|:---------|
-| `maxConcurrentClients` | 1 | Increase for many endpoints or slow targets |
-| `clientTimeoutSecs` | 90 | Lower for fast-failing scrapes |
-| `chunkContentSizeKbs` | 32 | Increase for large payloads to reduce chunk count |
-| `minGzipSizeBytes` | 512 | Lower to compress more aggressively |
-| `scrapeTimeoutSecs` | 15 | Increase for slow targets |
-| `clientCache.maxSize` | 100 | Increase if many unique auth credentials are used |
+| Parameter              | Default | Guidance                                          |
+|:-----------------------|:--------|:--------------------------------------------------|
+| `maxConcurrentClients` | 1       | Increase for many endpoints or slow targets       |
+| `clientTimeoutSecs`    | 90      | Lower for fast-failing scrapes                    |
+| `chunkContentSizeKbs`  | 32      | Increase for large payloads to reduce chunk count |
+| `minGzipSizeBytes`     | 512     | Lower to compress more aggressively               |
+| `scrapeTimeoutSecs`    | 15      | Increase for slow targets                         |
+| `clientCache.maxSize`  | 100     | Increase if many unique auth credentials are used |
 
 ## gRPC Keepalive Tuning
 

--- a/website/prometheus-proxy/docs/architecture.md
+++ b/website/prometheus-proxy/docs/architecture.md
@@ -55,16 +55,16 @@ sequenceDiagram
 The communication between Proxy and Agent uses a bidirectional gRPC protocol defined in
 `proxy_service.proto`. Key RPCs:
 
-| RPC | Type | Description |
-|:----|:-----|:------------|
-| `connectAgent` | Unary | Agent announces its presence |
-| `registerAgent` | Unary | Register agent identity and metadata |
-| `registerPath` | Unary | Register a scrape path with optional labels |
-| `unregisterPath` | Unary | Remove a previously registered path |
-| `readRequestsFromProxy` | Server-streaming | Proxy sends scrape requests to agent |
-| `writeResponsesToProxy` | Client-streaming | Agent sends scrape responses back |
+| RPC                            | Type             | Description                                      |
+|:-------------------------------|:-----------------|:-------------------------------------------------|
+| `connectAgent`                 | Unary            | Agent announces its presence                     |
+| `registerAgent`                | Unary            | Register agent identity and metadata             |
+| `registerPath`                 | Unary            | Register a scrape path with optional labels      |
+| `unregisterPath`               | Unary            | Remove a previously registered path              |
+| `readRequestsFromProxy`        | Server-streaming | Proxy sends scrape requests to agent             |
+| `writeResponsesToProxy`        | Client-streaming | Agent sends scrape responses back                |
 | `writeChunkedResponsesToProxy` | Client-streaming | Agent sends chunked responses for large payloads |
-| `sendHeartBeat` | Unary | Keep-alive during periods of inactivity |
+| `sendHeartBeat`                | Unary            | Keep-alive during periods of inactivity          |
 
 ## Chunking
 

--- a/website/prometheus-proxy/docs/cli-reference.md
+++ b/website/prometheus-proxy/docs/cli-reference.md
@@ -6,90 +6,90 @@ icon: lucide/terminal
 
 ## Proxy Options
 
-| CLI Option | Env Var | Property | Default | Description |
-|:-----------|:--------|:---------|:--------|:------------|
-| `--config, -c` | `PROXY_CONFIG` | | | Config file path or URL |
-| `--port, -p` | `PROXY_PORT` | `proxy.http.port` | 8080 | HTTP listen port |
-| `--agent_port, -a` | `AGENT_PORT` | `proxy.agent.port` | 50051 | gRPC listen port for agents |
-| `--admin, -r` | `ADMIN_ENABLED` | `proxy.admin.enabled` | false | Enable admin endpoints |
-| `--admin_port, -i` | `ADMIN_PORT` | `proxy.admin.port` | 8092 | Admin listen port |
-| `--debug, -b` | `DEBUG_ENABLED` | `proxy.admin.debugEnabled` | false | Enable debug servlet |
-| `--metrics, -e` | `METRICS_ENABLED` | `proxy.metrics.enabled` | false | Enable metrics collection |
-| `--metrics_port, -m` | `METRICS_PORT` | `proxy.metrics.port` | 8082 | Metrics listen port |
-| `--sd_enabled` | `SD_ENABLED` | `proxy.service.discovery.enabled` | false | Enable service discovery |
-| `--sd_path` | `SD_PATH` | `proxy.service.discovery.path` | "discovery" | SD endpoint path |
-| `--sd_target_prefix` | `SD_TARGET_PREFIX` | `proxy.service.discovery.targetPrefix` | "http://localhost:8080/" | SD target prefix |
-| `--tf_disabled` | `TRANSPORT_FILTER_DISABLED` | `proxy.transportFilterDisabled` | false | Disable transport filter |
-| `--ref_disabled` | `REFLECTION_DISABLED` | `proxy.reflectionDisabled` | false | Disable gRPC reflection |
-| `--log_level` | `PROXY_LOG_LEVEL` | `proxy.logLevel` | "info" | Log level |
-| `--cert, -t` | `CERT_CHAIN_FILE_PATH` | `proxy.tls.certChainFilePath` | | TLS cert chain file |
-| `--key, -k` | `PRIVATE_KEY_FILE_PATH` | `proxy.tls.privateKeyFilePath` | | TLS private key file |
-| `--trust, -s` | `TRUST_CERT_COLLECTION_FILE_PATH` | `proxy.tls.trustCertCollectionFilePath` | | TLS trust cert file |
-| `--version, -v` | | | | Print version info and exit |
-| `--usage, -u` | | | | Print usage message and exit |
-| `-D` | | | | Dynamic property assignment |
+| CLI Option           | Env Var                           | Property                                | Default                  | Description                  |
+|:---------------------|:----------------------------------|:----------------------------------------|:-------------------------|:-----------------------------|
+| `--config, -c`       | `PROXY_CONFIG`                    |                                         |                          | Config file path or URL      |
+| `--port, -p`         | `PROXY_PORT`                      | `proxy.http.port`                       | 8080                     | HTTP listen port             |
+| `--agent_port, -a`   | `AGENT_PORT`                      | `proxy.agent.port`                      | 50051                    | gRPC listen port for agents  |
+| `--admin, -r`        | `ADMIN_ENABLED`                   | `proxy.admin.enabled`                   | false                    | Enable admin endpoints       |
+| `--admin_port, -i`   | `ADMIN_PORT`                      | `proxy.admin.port`                      | 8092                     | Admin listen port            |
+| `--debug, -b`        | `DEBUG_ENABLED`                   | `proxy.admin.debugEnabled`              | false                    | Enable debug servlet         |
+| `--metrics, -e`      | `METRICS_ENABLED`                 | `proxy.metrics.enabled`                 | false                    | Enable metrics collection    |
+| `--metrics_port, -m` | `METRICS_PORT`                    | `proxy.metrics.port`                    | 8082                     | Metrics listen port          |
+| `--sd_enabled`       | `SD_ENABLED`                      | `proxy.service.discovery.enabled`       | false                    | Enable service discovery     |
+| `--sd_path`          | `SD_PATH`                         | `proxy.service.discovery.path`          | "discovery"              | SD endpoint path             |
+| `--sd_target_prefix` | `SD_TARGET_PREFIX`                | `proxy.service.discovery.targetPrefix`  | "http://localhost:8080/" | SD target prefix             |
+| `--tf_disabled`      | `TRANSPORT_FILTER_DISABLED`       | `proxy.transportFilterDisabled`         | false                    | Disable transport filter     |
+| `--ref_disabled`     | `REFLECTION_DISABLED`             | `proxy.reflectionDisabled`              | false                    | Disable gRPC reflection      |
+| `--log_level`        | `PROXY_LOG_LEVEL`                 | `proxy.logLevel`                        | "info"                   | Log level                    |
+| `--cert, -t`         | `CERT_CHAIN_FILE_PATH`            | `proxy.tls.certChainFilePath`           |                          | TLS cert chain file          |
+| `--key, -k`          | `PRIVATE_KEY_FILE_PATH`           | `proxy.tls.privateKeyFilePath`          |                          | TLS private key file         |
+| `--trust, -s`        | `TRUST_CERT_COLLECTION_FILE_PATH` | `proxy.tls.trustCertCollectionFilePath` |                          | TLS trust cert file          |
+| `--version, -v`      |                                   |                                         |                          | Print version info and exit  |
+| `--usage, -u`        |                                   |                                         |                          | Print usage message and exit |
+| `-D`                 |                                   |                                         |                          | Dynamic property assignment  |
 
 ### Proxy gRPC Options
 
-| CLI Option | Env Var | Property | Default | Description |
-|:-----------|:--------|:---------|:--------|:------------|
-| `--handshake_timeout_secs` | `HANDSHAKE_TIMEOUT_SECS` | `proxy.grpc.handshakeTimeoutSecs` | 120 | Handshake timeout (seconds) |
-| `--keepalive_time_secs` | `KEEPALIVE_TIME_SECS` | `proxy.grpc.keepAliveTimeSecs` | 7200 | Interval between PING frames (seconds) |
-| `--keepalive_timeout_secs` | `KEEPALIVE_TIMEOUT_SECS` | `proxy.grpc.keepAliveTimeoutSecs` | 20 | Timeout for PING acknowledgment (seconds) |
-| `--permit_keepalive_without_calls` | `PERMIT_KEEPALIVE_WITHOUT_CALLS` | `proxy.grpc.permitKeepAliveWithoutCalls` | false | Allow keepalive without active streams |
-| `--permit_keepalive_time_secs` | `PERMIT_KEEPALIVE_TIME_SECS` | `proxy.grpc.permitKeepAliveTimeSecs` | 300 | Min interval between client PINGs (seconds) |
-| `--max_connection_idle_secs` | `MAX_CONNECTION_IDLE_SECS` | `proxy.grpc.maxConnectionIdleSecs` | INT_MAX | Max idle time for a channel (seconds) |
-| `--max_connection_age_secs` | `MAX_CONNECTION_AGE_SECS` | `proxy.grpc.maxConnectionAgeSecs` | INT_MAX | Max lifetime for a channel (seconds) |
-| `--max_connection_age_grace_secs` | `MAX_CONNECTION_AGE_GRACE_SECS` | `proxy.grpc.maxConnectionAgeGraceSecs` | INT_MAX | Grace period after max age (seconds) |
+| CLI Option                         | Env Var                          | Property                                 | Default | Description                                 |
+|:-----------------------------------|:---------------------------------|:-----------------------------------------|:--------|:--------------------------------------------|
+| `--handshake_timeout_secs`         | `HANDSHAKE_TIMEOUT_SECS`         | `proxy.grpc.handshakeTimeoutSecs`        | 120     | Handshake timeout (seconds)                 |
+| `--keepalive_time_secs`            | `KEEPALIVE_TIME_SECS`            | `proxy.grpc.keepAliveTimeSecs`           | 7200    | Interval between PING frames (seconds)      |
+| `--keepalive_timeout_secs`         | `KEEPALIVE_TIMEOUT_SECS`         | `proxy.grpc.keepAliveTimeoutSecs`        | 20      | Timeout for PING acknowledgment (seconds)   |
+| `--permit_keepalive_without_calls` | `PERMIT_KEEPALIVE_WITHOUT_CALLS` | `proxy.grpc.permitKeepAliveWithoutCalls` | false   | Allow keepalive without active streams      |
+| `--permit_keepalive_time_secs`     | `PERMIT_KEEPALIVE_TIME_SECS`     | `proxy.grpc.permitKeepAliveTimeSecs`     | 300     | Min interval between client PINGs (seconds) |
+| `--max_connection_idle_secs`       | `MAX_CONNECTION_IDLE_SECS`       | `proxy.grpc.maxConnectionIdleSecs`       | INT_MAX | Max idle time for a channel (seconds)       |
+| `--max_connection_age_secs`        | `MAX_CONNECTION_AGE_SECS`        | `proxy.grpc.maxConnectionAgeSecs`        | INT_MAX | Max lifetime for a channel (seconds)        |
+| `--max_connection_age_grace_secs`  | `MAX_CONNECTION_AGE_GRACE_SECS`  | `proxy.grpc.maxConnectionAgeGraceSecs`   | INT_MAX | Grace period after max age (seconds)        |
 
 ## Agent Options
 
-| CLI Option | Env Var | Property | Default | Description |
-|:-----------|:--------|:---------|:--------|:------------|
-| `--config, -c` | `AGENT_CONFIG` | | | Config file path or URL (required) |
-| `--proxy, -p` | `PROXY_HOSTNAME` | `agent.proxy.hostname` | | Proxy hostname (can include :port) |
-| `--name, -n` | `AGENT_NAME` | `agent.name` | | Agent name |
-| `--admin, -r` | `ADMIN_ENABLED` | `agent.admin.enabled` | false | Enable admin endpoints |
-| `--admin_port, -i` | `ADMIN_PORT` | `agent.admin.port` | 8093 | Admin listen port |
-| `--debug, -b` | `DEBUG_ENABLED` | `agent.admin.debugEnabled` | false | Enable debug servlet |
-| `--metrics, -e` | `METRICS_ENABLED` | `agent.metrics.enabled` | false | Enable metrics collection |
-| `--metrics_port, -m` | `METRICS_PORT` | `agent.metrics.port` | 8083 | Metrics listen port |
-| `--consolidated, -o` | `CONSOLIDATED` | `agent.consolidated` | false | Allow multiple agents per path |
-| `--timeout` | `SCRAPE_TIMEOUT_SECS` | `agent.scrapeTimeoutSecs` | 15 | Scrape timeout (seconds) |
-| `--max_retries` | `SCRAPE_MAX_RETRIES` | `agent.scrapeMaxRetries` | 0 | Max scrape retries (0 = disabled) |
-| `--chunk` | `CHUNK_CONTENT_SIZE_KBS` | `agent.chunkContentSizeKbs` | 32 | Chunking threshold (KB) |
-| `--gzip` | `MIN_GZIP_SIZE_BYTES` | `agent.minGzipSizeBytes` | 1024 | Min size for gzip (bytes) |
-| `--tf_disabled` | `TRANSPORT_FILTER_DISABLED` | `agent.transportFilterDisabled` | false | Disable transport filter |
-| `--trust_all_x509` | `TRUST_ALL_X509_CERTIFICATES` | `agent.http.enableTrustAllX509Certificates` | false | Disable SSL verification |
-| `--max_concurrent_clients` | `MAX_CONCURRENT_CLIENTS` | `agent.http.maxConcurrentClients` | 1 | Max parallel scrapes |
-| `--client_timeout_secs` | `CLIENT_TIMEOUT_SECS` | `agent.http.clientTimeoutSecs` | 90 | HTTP client timeout (seconds) |
-| `--max_content_length_mbytes` | `AGENT_MAX_CONTENT_LENGTH_MBYTES` | `agent.http.maxContentLengthMBytes` | 10 | Max response size (MB) |
-| `--log_level` | `AGENT_LOG_LEVEL` | `agent.logLevel` | "info" | Log level |
-| `--cert, -t` | `CERT_CHAIN_FILE_PATH` | `agent.tls.certChainFilePath` | | TLS cert chain file |
-| `--key, -k` | `PRIVATE_KEY_FILE_PATH` | `agent.tls.privateKeyFilePath` | | TLS private key file |
-| `--trust, -s` | `TRUST_CERT_COLLECTION_FILE_PATH` | `agent.tls.trustCertCollectionFilePath` | | TLS trust cert file |
-| `--override` | `OVERRIDE_AUTHORITY` | `agent.tls.overrideAuthority` | | TLS authority override |
-| `--version, -v` | | | | Print version info and exit |
-| `--usage, -u` | | | | Print usage message and exit |
-| `-D` | | | | Dynamic property assignment |
+| CLI Option                    | Env Var                           | Property                                    | Default | Description                        |
+|:------------------------------|:----------------------------------|:--------------------------------------------|:--------|:-----------------------------------|
+| `--config, -c`                | `AGENT_CONFIG`                    |                                             |         | Config file path or URL (required) |
+| `--proxy, -p`                 | `PROXY_HOSTNAME`                  | `agent.proxy.hostname`                      |         | Proxy hostname (can include :port) |
+| `--name, -n`                  | `AGENT_NAME`                      | `agent.name`                                |         | Agent name                         |
+| `--admin, -r`                 | `ADMIN_ENABLED`                   | `agent.admin.enabled`                       | false   | Enable admin endpoints             |
+| `--admin_port, -i`            | `ADMIN_PORT`                      | `agent.admin.port`                          | 8093    | Admin listen port                  |
+| `--debug, -b`                 | `DEBUG_ENABLED`                   | `agent.admin.debugEnabled`                  | false   | Enable debug servlet               |
+| `--metrics, -e`               | `METRICS_ENABLED`                 | `agent.metrics.enabled`                     | false   | Enable metrics collection          |
+| `--metrics_port, -m`          | `METRICS_PORT`                    | `agent.metrics.port`                        | 8083    | Metrics listen port                |
+| `--consolidated, -o`          | `CONSOLIDATED`                    | `agent.consolidated`                        | false   | Allow multiple agents per path     |
+| `--timeout`                   | `SCRAPE_TIMEOUT_SECS`             | `agent.scrapeTimeoutSecs`                   | 15      | Scrape timeout (seconds)           |
+| `--max_retries`               | `SCRAPE_MAX_RETRIES`              | `agent.scrapeMaxRetries`                    | 0       | Max scrape retries (0 = disabled)  |
+| `--chunk`                     | `CHUNK_CONTENT_SIZE_KBS`          | `agent.chunkContentSizeKbs`                 | 32      | Chunking threshold (KB)            |
+| `--gzip`                      | `MIN_GZIP_SIZE_BYTES`             | `agent.minGzipSizeBytes`                    | 1024    | Min size for gzip (bytes)          |
+| `--tf_disabled`               | `TRANSPORT_FILTER_DISABLED`       | `agent.transportFilterDisabled`             | false   | Disable transport filter           |
+| `--trust_all_x509`            | `TRUST_ALL_X509_CERTIFICATES`     | `agent.http.enableTrustAllX509Certificates` | false   | Disable SSL verification           |
+| `--max_concurrent_clients`    | `MAX_CONCURRENT_CLIENTS`          | `agent.http.maxConcurrentClients`           | 1       | Max parallel scrapes               |
+| `--client_timeout_secs`       | `CLIENT_TIMEOUT_SECS`             | `agent.http.clientTimeoutSecs`              | 90      | HTTP client timeout (seconds)      |
+| `--max_content_length_mbytes` | `AGENT_MAX_CONTENT_LENGTH_MBYTES` | `agent.http.maxContentLengthMBytes`         | 10      | Max response size (MB)             |
+| `--log_level`                 | `AGENT_LOG_LEVEL`                 | `agent.logLevel`                            | "info"  | Log level                          |
+| `--cert, -t`                  | `CERT_CHAIN_FILE_PATH`            | `agent.tls.certChainFilePath`               |         | TLS cert chain file                |
+| `--key, -k`                   | `PRIVATE_KEY_FILE_PATH`           | `agent.tls.privateKeyFilePath`              |         | TLS private key file               |
+| `--trust, -s`                 | `TRUST_CERT_COLLECTION_FILE_PATH` | `agent.tls.trustCertCollectionFilePath`     |         | TLS trust cert file                |
+| `--override`                  | `OVERRIDE_AUTHORITY`              | `agent.tls.overrideAuthority`               |         | TLS authority override             |
+| `--version, -v`               |                                   |                                             |         | Print version info and exit        |
+| `--usage, -u`                 |                                   |                                             |         | Print usage message and exit       |
+| `-D`                          |                                   |                                             |         | Dynamic property assignment        |
 
 ### Agent HTTP Client Cache Options
 
-| CLI Option | Env Var | Property | Default | Description |
-|:-----------|:--------|:---------|:--------|:------------|
-| `--max_cache_size` | `MAX_CLIENT_CACHE_SIZE` | `agent.http.clientCache.maxSize` | 100 | Max cached HTTP clients |
-| `--max_cache_age_mins` | `MAX_CLIENT_CACHE_AGE_MINS` | `agent.http.clientCache.maxAgeMins` | 30 | Max age of cached clients (minutes) |
-| `--max_cache_idle_mins` | `MAX_CLIENT_CACHE_IDLE_MINS` | `agent.http.clientCache.maxIdleMins` | 10 | Max idle time before eviction (minutes) |
-| `--cache_cleanup_interval_mins` | `CLIENT_CACHE_CLEANUP_INTERVAL_MINS` | `agent.http.clientCache.cleanupIntervalMins` | 5 | Cleanup interval (minutes) |
+| CLI Option                      | Env Var                              | Property                                     | Default | Description                             |
+|:--------------------------------|:-------------------------------------|:---------------------------------------------|:--------|:----------------------------------------|
+| `--max_cache_size`              | `MAX_CLIENT_CACHE_SIZE`              | `agent.http.clientCache.maxSize`             | 100     | Max cached HTTP clients                 |
+| `--max_cache_age_mins`          | `MAX_CLIENT_CACHE_AGE_MINS`          | `agent.http.clientCache.maxAgeMins`          | 30      | Max age of cached clients (minutes)     |
+| `--max_cache_idle_mins`         | `MAX_CLIENT_CACHE_IDLE_MINS`         | `agent.http.clientCache.maxIdleMins`         | 10      | Max idle time before eviction (minutes) |
+| `--cache_cleanup_interval_mins` | `CLIENT_CACHE_CLEANUP_INTERVAL_MINS` | `agent.http.clientCache.cleanupIntervalMins` | 5       | Cleanup interval (minutes)              |
 
 ### Agent gRPC Options
 
-| CLI Option | Env Var | Property | Default | Description |
-|:-----------|:--------|:---------|:--------|:------------|
-| `--keepalive_time_secs` | `KEEPALIVE_TIME_SECS` | `agent.grpc.keepAliveTimeSecs` | INT_MAX | Interval between PING frames (seconds) |
-| `--keepalive_timeout_secs` | `KEEPALIVE_TIMEOUT_SECS` | `agent.grpc.keepAliveTimeoutSecs` | 20 | Timeout for PING acknowledgment (seconds) |
-| `--keepalive_without_calls` | `KEEPALIVE_WITHOUT_CALLS` | `agent.grpc.keepAliveWithoutCalls` | false | Allow keepalive without active streams |
-| `--unary_deadline_secs` | `UNARY_DEADLINE_SECS` | `agent.grpc.unaryDeadlineSecs` | 30 | Timeout for unary RPCs (seconds) |
+| CLI Option                  | Env Var                   | Property                           | Default | Description                               |
+|:----------------------------|:--------------------------|:-----------------------------------|:--------|:------------------------------------------|
+| `--keepalive_time_secs`     | `KEEPALIVE_TIME_SECS`     | `agent.grpc.keepAliveTimeSecs`     | INT_MAX | Interval between PING frames (seconds)    |
+| `--keepalive_timeout_secs`  | `KEEPALIVE_TIMEOUT_SECS`  | `agent.grpc.keepAliveTimeoutSecs`  | 20      | Timeout for PING acknowledgment (seconds) |
+| `--keepalive_without_calls` | `KEEPALIVE_WITHOUT_CALLS` | `agent.grpc.keepAliveWithoutCalls` | false   | Allow keepalive without active streams    |
+| `--unary_deadline_secs`     | `UNARY_DEADLINE_SECS`     | `agent.grpc.unaryDeadlineSecs`     | 30      | Timeout for unary RPCs (seconds)          |
 
 ## Log Levels
 

--- a/website/prometheus-proxy/docs/configuration/agent.md
+++ b/website/prometheus-proxy/docs/configuration/agent.md
@@ -32,12 +32,12 @@ Labels are included in service discovery responses and can be used for filtering
 
 Each path config entry has these fields:
 
-| Field | Required | Description |
-|:------|:---------|:------------|
-| `name` | Yes | Human-readable endpoint name (for logs and debugging) |
-| `path` | Yes | URL path on the proxy that Prometheus will scrape |
-| `url` | Yes | Actual metrics endpoint the agent fetches from |
-| `labels` | No | JSON string of labels for service discovery (default: `"{}"`) |
+| Field    | Required | Description                                                   |
+|:---------|:---------|:--------------------------------------------------------------|
+| `name`   | Yes      | Human-readable endpoint name (for logs and debugging)         |
+| `path`   | Yes      | URL path on the proxy that Prometheus will scrape             |
+| `url`    | Yes      | Actual metrics endpoint the agent fetches from                |
+| `labels` | No       | JSON string of labels for service discovery (default: `"{}"`) |
 
 ## Proxy Connection
 
@@ -79,12 +79,12 @@ scenarios). Configure cache behavior:
 --8<-- "ConfigExamples.txt:agent-scrape-config"
 ```
 
-| Setting | Default | Description |
-|:--------|:--------|:------------|
-| `scrapeTimeoutSecs` | 15 | Total time allowed for a scrape including retries |
-| `scrapeMaxRetries` | 0 | Maximum retries; 0 disables retries |
-| `chunkContentSizeKbs` | 32 | Responses larger than this are chunked |
-| `minGzipSizeBytes` | 512 | Responses larger than this are gzip-compressed |
+| Setting               | Default | Description                                       |
+|:----------------------|:--------|:--------------------------------------------------|
+| `scrapeTimeoutSecs`   | 15      | Total time allowed for a scrape including retries |
+| `scrapeMaxRetries`    | 0       | Maximum retries; 0 disables retries               |
+| `chunkContentSizeKbs` | 32      | Responses larger than this are chunked            |
+| `minGzipSizeBytes`    | 512     | Responses larger than this are gzip-compressed    |
 
 ## Consolidated Mode
 

--- a/website/prometheus-proxy/docs/configuration/index.md
+++ b/website/prometheus-proxy/docs/configuration/index.md
@@ -15,11 +15,11 @@ configuration. Values are evaluated in this precedence order (highest first):
 
 Typesafe Config supports three formats:
 
-| Format | Extension | Description |
-|:-------|:----------|:------------|
-| **HOCON** | `.conf` | Human-friendly JSON superset (recommended) |
-| **JSON** | `.json` | Standard JSON format |
-| **Properties** | `.properties` | Java properties format |
+| Format         | Extension     | Description                                |
+|:---------------|:--------------|:-------------------------------------------|
+| **HOCON**      | `.conf`       | Human-friendly JSON superset (recommended) |
+| **JSON**       | `.json`       | Standard JSON format                       |
+| **Properties** | `.properties` | Java properties format                     |
 
 ## Loading Configuration
 
@@ -97,28 +97,28 @@ For the complete configuration schema, see the reference file:
 
 <div class="grid cards" markdown>
 
--   :material-robot:{ .lg .middle } __Agent Configuration__
+- :material-robot:{ .lg .middle } __Agent Configuration__
 
-    ---
+  ---
 
-    Path configs, HTTP client, and scrape settings
+  Path configs, HTTP client, and scrape settings
 
-    [:octicons-arrow-right-24: Agent Configuration](agent.md)
+  [:octicons-arrow-right-24: Agent Configuration](agent.md)
 
--   :material-server:{ .lg .middle } __Proxy Configuration__
+- :material-server:{ .lg .middle } __Proxy Configuration__
 
-    ---
+  ---
 
-    HTTP service, gRPC, and service discovery settings
+  HTTP service, gRPC, and service discovery settings
 
-    [:octicons-arrow-right-24: Proxy Configuration](proxy.md)
+  [:octicons-arrow-right-24: Proxy Configuration](proxy.md)
 
--   :material-console:{ .lg .middle } __CLI Reference__
+- :material-console:{ .lg .middle } __CLI Reference__
 
-    ---
+  ---
 
-    All CLI options and environment variables
+  All CLI options and environment variables
 
-    [:octicons-arrow-right-24: CLI Reference](../cli-reference.md)
+  [:octicons-arrow-right-24: CLI Reference](../cli-reference.md)
 
 </div>

--- a/website/prometheus-proxy/docs/configuration/proxy.md
+++ b/website/prometheus-proxy/docs/configuration/proxy.md
@@ -53,13 +53,13 @@ proxy {
 
 When enabled, the following endpoints are available:
 
-| Endpoint | Description |
-|:---------|:------------|
-| `GET /ping` | Returns "pong" (liveness check) |
-| `GET /healthcheck` | Returns health status JSON |
-| `GET /version` | Returns version information |
-| `GET /threaddump` | Returns JVM thread dump |
-| `GET /debug` | Proxy debug info (requires `debugEnabled = true`) |
+| Endpoint           | Description                                       |
+|:-------------------|:--------------------------------------------------|
+| `GET /ping`        | Returns "pong" (liveness check)                   |
+| `GET /healthcheck` | Returns health status JSON                        |
+| `GET /version`     | Returns version information                       |
+| `GET /threaddump`  | Returns JVM thread dump                           |
+| `GET /debug`       | Proxy debug info (requires `debugEnabled = true`) |
 
 ## Metrics
 
@@ -79,12 +79,12 @@ Configure agent cleanup and scrape request management:
 --8<-- "AdvancedExamples.txt:stale-agent-config"
 ```
 
-| Setting | Default | Description |
-|:--------|:--------|:------------|
-| `staleAgentCheckEnabled` | true | Enable periodic stale agent cleanup |
-| `maxAgentInactivitySecs` | 60 | Seconds of inactivity before agent is evicted |
-| `staleAgentCheckPauseSecs` | 10 | Interval between cleanup checks |
-| `scrapeRequestTimeoutSecs` | 90 | Timeout for individual scrape requests |
+| Setting                    | Default | Description                                   |
+|:---------------------------|:--------|:----------------------------------------------|
+| `staleAgentCheckEnabled`   | true    | Enable periodic stale agent cleanup           |
+| `maxAgentInactivitySecs`   | 60      | Seconds of inactivity before agent is evicted |
+| `staleAgentCheckPauseSecs` | 10      | Interval between cleanup checks               |
+| `scrapeRequestTimeoutSecs` | 90      | Timeout for individual scrape requests        |
 
 ## Content Size Limits
 

--- a/website/prometheus-proxy/docs/docker.md
+++ b/website/prometheus-proxy/docs/docker.md
@@ -7,8 +7,8 @@ icon: lucide/container
 Multi-platform images (amd64, arm64, s390x) are published on Docker Hub for every release.
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.1.0
-docker pull pambrose/prometheus-agent:3.1.0
+docker pull pambrose/prometheus-proxy:3.1.1
+docker pull pambrose/prometheus-agent:3.1.1
 ```
 
 ## Basic Usage
@@ -77,4 +77,4 @@ docker pull pambrose/prometheus-agent:latest
 
 !!! tip "Pin versions in production"
 
-    Use explicit version tags (e.g., `3.1.0`) in production to avoid unexpected upgrades.
+    Use explicit version tags (e.g., `3.1.1`) in production to avoid unexpected upgrades.

--- a/website/prometheus-proxy/docs/embedded-agent.md
+++ b/website/prometheus-proxy/docs/embedded-agent.md
@@ -55,20 +55,20 @@ The embedded agent uses the same HOCON configuration as the standalone agent:
 
 Starts the agent in background threads/coroutines.
 
-| Parameter | Type | Description |
-|:----------|:-----|:------------|
-| `configFilename` | `String` | Path to the HOCON config file |
+| Parameter             | Type      | Description                              |
+|:----------------------|:----------|:-----------------------------------------|
+| `configFilename`      | `String`  | Path to the HOCON config file            |
 | `exitOnMissingConfig` | `Boolean` | Exit the JVM if config file is not found |
-| `logBanner` | `Boolean` | Log the startup banner (default: `true`) |
+| `logBanner`           | `Boolean` | Log the startup banner (default: `true`) |
 
 **Returns:** `EmbeddedAgentInfo`
 
 ### `EmbeddedAgentInfo`
 
-| Property | Type | Description |
-|:---------|:-----|:------------|
-| `launchId` | `String` | Unique ID for this agent launch |
-| `agentName` | `String` | Name of the agent |
+| Property    | Type     | Description                     |
+|:------------|:---------|:--------------------------------|
+| `launchId`  | `String` | Unique ID for this agent launch |
+| `agentName` | `String` | Name of the agent               |
 
 ## How It Works
 

--- a/website/prometheus-proxy/docs/getting-started.md
+++ b/website/prometheus-proxy/docs/getting-started.md
@@ -31,8 +31,8 @@ icon: lucide/play
     Multi-platform images (amd64, arm64, s390x) are available on Docker Hub:
 
     ```bash
-    docker pull pambrose/prometheus-proxy:3.1.0
-    docker pull pambrose/prometheus-agent:3.1.0
+    docker pull pambrose/prometheus-proxy:3.1.1
+    docker pull pambrose/prometheus-agent:3.1.1
     ```
 
 ## Start the Proxy
@@ -54,7 +54,7 @@ The proxy runs outside the firewall alongside your Prometheus server.
 
     ```bash
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.1.0
+      pambrose/prometheus-proxy:3.1.1
     ```
 
 ## Start the Agent
@@ -108,7 +108,7 @@ Each entry in `pathConfigs` maps:
       --mount type=bind,source="$(pwd)"/agent.conf,target=/app/agent.conf \
       --env AGENT_CONFIG=agent.conf \
       --env PROXY_HOSTNAME=proxy-host.example.com \
-      pambrose/prometheus-agent:3.1.0
+      pambrose/prometheus-agent:3.1.1
     ```
 
 === "Remote Config"

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -82,13 +82,13 @@ See the [Quick Start Guide](getting-started.md) for detailed instructions.
 
 ## Common Use Cases
 
-| Scenario | Description |
-|:---------|:------------|
-| **Enterprise environments** | Scrape metrics across corporate firewall boundaries |
-| **Multi-cloud deployments** | Bridge different network segments |
-| **Secure environments** | Monitor internal services without opening inbound ports |
-| **Federation** | Scrape existing Prometheus instances via `/federate` endpoint |
-| **Kubernetes** | Monitor services across clusters or namespaces |
+| Scenario                    | Description                                                   |
+|:----------------------------|:--------------------------------------------------------------|
+| **Enterprise environments** | Scrape metrics across corporate firewall boundaries           |
+| **Multi-cloud deployments** | Bridge different network segments                             |
+| **Secure environments**     | Monitor internal services without opening inbound ports       |
+| **Federation**              | Scrape existing Prometheus instances via `/federate` endpoint |
+| **Kubernetes**              | Monitor services across clusters or namespaces                |
 
 ## API Reference
 
@@ -98,36 +98,36 @@ Full API documentation (KDocs) is available at [KDocs](kdocs/).
 
 <div class="grid cards" markdown>
 
--   :material-sitemap:{ .lg .middle } __Architecture__
+- :material-sitemap:{ .lg .middle } __Architecture__
 
-    ---
+  ---
 
-    Understand the proxy/agent components, gRPC protocol, and request flow
+  Understand the proxy/agent components, gRPC protocol, and request flow
 
-    [:octicons-arrow-right-24: Architecture](architecture.md)
+  [:octicons-arrow-right-24: Architecture](architecture.md)
 
--   :material-cog:{ .lg .middle } __Configuration__
+- :material-cog:{ .lg .middle } __Configuration__
 
-    ---
+  ---
 
-    Configure the application with HOCON and environment variables
+  Configure the application with HOCON and environment variables
 
-    [:octicons-arrow-right-24: Configuration](configuration/index.md)
+  [:octicons-arrow-right-24: Configuration](configuration/index.md)
 
--   :material-shield-lock:{ .lg .middle } __Security & TLS__
+- :material-shield-lock:{ .lg .middle } __Security & TLS__
 
-    ---
+  ---
 
-    Set up TLS encryption and mutual authentication
+  Set up TLS encryption and mutual authentication
 
-    [:octicons-arrow-right-24: Security](security/index.md)
+  [:octicons-arrow-right-24: Security](security/index.md)
 
--   :material-chart-line:{ .lg .middle } __Monitoring__
+- :material-chart-line:{ .lg .middle } __Monitoring__
 
-    ---
+  ---
 
-    Built-in metrics and Grafana dashboards
+  Built-in metrics and Grafana dashboards
 
-    [:octicons-arrow-right-24: Monitoring](monitoring.md)
+  [:octicons-arrow-right-24: Monitoring](monitoring.md)
 
 </div>

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -70,12 +70,12 @@ Get running in under a minute:
     ```bash
     # Start the proxy
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.1.0
+      pambrose/prometheus-proxy:3.1.1
 
     # Start the agent
     docker run --rm \
       --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-      pambrose/prometheus-agent:3.1.0
+      pambrose/prometheus-agent:3.1.1
     ```
 
 See the [Quick Start Guide](getting-started.md) for detailed instructions.

--- a/website/prometheus-proxy/docs/monitoring.md
+++ b/website/prometheus-proxy/docs/monitoring.md
@@ -54,38 +54,38 @@ The same options are available under `agent.metrics`.
 
 ### Counters
 
-| Metric | Labels | Description |
-|:-------|:-------|:------------|
-| `proxy_scrape_requests` | `type` | Scrape request outcomes (see below) |
-| `proxy_connect_count` | -- | Agent connection count |
-| `proxy_eviction_count` | -- | Stale agent evictions |
-| `proxy_heartbeat_count` | -- | Heartbeats received from agents |
-| `proxy_chunk_validation_failures_total` | `stage` | Chunk integrity failures (`chunk` or `summary`) |
-| `proxy_chunked_transfers_abandoned_total` | -- | Chunked transfers abandoned mid-stream |
-| `proxy_agent_displacement_total` | -- | Path registrations that displaced another agent |
+| Metric                                    | Labels  | Description                                     |
+|:------------------------------------------|:--------|:------------------------------------------------|
+| `proxy_scrape_requests`                   | `type`  | Scrape request outcomes (see below)             |
+| `proxy_connect_count`                     | --      | Agent connection count                          |
+| `proxy_eviction_count`                    | --      | Stale agent evictions                           |
+| `proxy_heartbeat_count`                   | --      | Heartbeats received from agents                 |
+| `proxy_chunk_validation_failures_total`   | `stage` | Chunk integrity failures (`chunk` or `summary`) |
+| `proxy_chunked_transfers_abandoned_total` | --      | Chunked transfers abandoned mid-stream          |
+| `proxy_agent_displacement_total`          | --      | Path registrations that displaced another agent |
 
 **`proxy_scrape_requests` type labels:**
 
-| Value | Meaning |
-|:------|:--------|
-| `success` | Scrape completed successfully |
-| `timed_out` | Agent did not respond within timeout |
-| `no_agents` | No agents registered for the requested path |
-| `invalid_path` | Requested path is empty or unrecognized |
-| `agent_disconnected` | Agent stream closed before response was received |
-| `missing_results` | Internal error: results object was null |
-| `path_not_found` | Agent returned a non-200 status for the target |
-| `payload_too_large` | Unzipped content exceeded size limit |
-| `invalid_gzip` | Gzip decompression failed |
-| `proxy_not_running` | Proxy is shutting down |
-| `invalid_agent_context` | All agents for the path are in an invalid state |
+| Value                   | Meaning                                          |
+|:------------------------|:-------------------------------------------------|
+| `success`               | Scrape completed successfully                    |
+| `timed_out`             | Agent did not respond within timeout             |
+| `no_agents`             | No agents registered for the requested path      |
+| `invalid_path`          | Requested path is empty or unrecognized          |
+| `agent_disconnected`    | Agent stream closed before response was received |
+| `missing_results`       | Internal error: results object was null          |
+| `path_not_found`        | Agent returned a non-200 status for the target   |
+| `payload_too_large`     | Unzipped content exceeded size limit             |
+| `invalid_gzip`          | Gzip decompression failed                        |
+| `proxy_not_running`     | Proxy is shutting down                           |
+| `invalid_agent_context` | All agents for the path are in an invalid state  |
 
 ### Histograms
 
-| Metric | Labels | Description |
-|:-------|:-------|:------------|
-| `proxy_scrape_request_latency_seconds` | `path` | End-to-end scrape latency |
-| `proxy_scrape_response_bytes` | `path`, `encoding` | Response payload size after decompression |
+| Metric                                 | Labels             | Description                               |
+|:---------------------------------------|:-------------------|:------------------------------------------|
+| `proxy_scrape_request_latency_seconds` | `path`             | End-to-end scrape latency                 |
+| `proxy_scrape_response_bytes`          | `path`, `encoding` | Response payload size after decompression |
 
 Latency buckets: 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s
 
@@ -93,13 +93,13 @@ Response size buckets: 1KB, 10KB, 100KB, 500KB, 1MB, 5MB, 10MB
 
 ### Gauges
 
-| Metric | Description |
-|:-------|:------------|
-| `proxy_start_time_seconds` | Proxy start time (Unix epoch) |
-| `proxy_agent_map_size` | Number of connected agents |
-| `proxy_path_map_size` | Number of registered scrape paths |
-| `proxy_scrape_map_size` | Number of in-flight scrape requests |
-| `proxy_chunk_context_map_size` | Number of in-flight chunked transfers |
+| Metric                                | Description                                    |
+|:--------------------------------------|:-----------------------------------------------|
+| `proxy_start_time_seconds`            | Proxy start time (Unix epoch)                  |
+| `proxy_agent_map_size`                | Number of connected agents                     |
+| `proxy_path_map_size`                 | Number of registered scrape paths              |
+| `proxy_scrape_map_size`               | Number of in-flight scrape requests            |
+| `proxy_chunk_context_map_size`        | Number of in-flight chunked transfers          |
 | `proxy_cumulative_agent_backlog_size` | Total queued scrape requests across all agents |
 
 ---
@@ -108,27 +108,27 @@ Response size buckets: 1KB, 10KB, 100KB, 500KB, 1MB, 5MB, 10MB
 
 ### Counters
 
-| Metric | Labels | Description |
-|:-------|:-------|:------------|
-| `agent_scrape_request_count` | `launch_id`, `type` | Scrape requests processed |
-| `agent_scrape_result_count` | `launch_id`, `type` | Results sent (`non-gzipped`, `gzipped`, `chunked`) |
-| `agent_connect_count` | `launch_id`, `type` | Connection attempts (`success`, `failure`) |
+| Metric                       | Labels              | Description                                        |
+|:-----------------------------|:--------------------|:---------------------------------------------------|
+| `agent_scrape_request_count` | `launch_id`, `type` | Scrape requests processed                          |
+| `agent_scrape_result_count`  | `launch_id`, `type` | Results sent (`non-gzipped`, `gzipped`, `chunked`) |
+| `agent_connect_count`        | `launch_id`, `type` | Connection attempts (`success`, `failure`)         |
 
 The `launch_id` label uniquely identifies each agent process lifetime.
 
 ### Histograms
 
-| Metric | Labels | Description |
-|:-------|:-------|:------------|
+| Metric                                 | Labels                    | Description                        |
+|:---------------------------------------|:--------------------------|:-----------------------------------|
 | `agent_scrape_request_latency_seconds` | `launch_id`, `agent_name` | Time to fetch from target endpoint |
 
 ### Gauges
 
-| Metric | Labels | Description |
-|:-------|:-------|:------------|
-| `agent_start_time_seconds` | `launch_id` | Agent start time (Unix epoch) |
+| Metric                      | Labels      | Description                    |
+|:----------------------------|:------------|:-------------------------------|
+| `agent_start_time_seconds`  | `launch_id` | Agent start time (Unix epoch)  |
 | `agent_scrape_backlog_size` | `launch_id` | Pending scrape requests queued |
-| `agent_client_cache_size` | `launch_id` | Number of cached HTTP clients |
+| `agent_client_cache_size`   | `launch_id` | Number of cached HTTP clients  |
 
 ---
 
@@ -217,23 +217,23 @@ java -jar prometheus-agent.jar --admin
 
 Key panels to monitor:
 
-| Section | What to Watch |
-|:--------|:-------------|
-| **Overview** | Success rate dropping below 99%, error count spikes |
-| **Throughput** | Sudden changes in request volume or error ratio |
-| **Latency** | P99 creeping up indicates slow targets or network issues |
-| **Payload** | Unexpectedly large responses, gzip vs plain distribution |
-| **Internal State** | Growing backlog means agents can't keep up |
-| **Errors** | Which error types dominate, frequent evictions |
+| Section            | What to Watch                                            |
+|:-------------------|:---------------------------------------------------------|
+| **Overview**       | Success rate dropping below 99%, error count spikes      |
+| **Throughput**     | Sudden changes in request volume or error ratio          |
+| **Latency**        | P99 creeping up indicates slow targets or network issues |
+| **Payload**        | Unexpectedly large responses, gzip vs plain distribution |
+| **Internal State** | Growing backlog means agents can't keep up               |
+| **Errors**         | Which error types dominate, frequent evictions           |
 
 ### Agents Dashboard
 
 Key panels to monitor:
 
-| Section | What to Watch |
-|:--------|:-------------|
-| **Overview** | Unexpected agent count changes |
-| **Connections** | Failure spikes indicate proxy or network issues |
-| **Scrape Activity** | Imbalanced load across agents |
-| **Latency** | Per-agent latency outliers point to slow targets |
-| **Internals** | Growing backlog means the agent is falling behind |
+| Section             | What to Watch                                     |
+|:--------------------|:--------------------------------------------------|
+| **Overview**        | Unexpected agent count changes                    |
+| **Connections**     | Failure spikes indicate proxy or network issues   |
+| **Scrape Activity** | Imbalanced load across agents                     |
+| **Latency**         | Per-agent latency outliers point to slow targets  |
+| **Internals**       | Growing backlog means the agent is falling behind |

--- a/website/prometheus-proxy/docs/security/index.md
+++ b/website/prometheus-proxy/docs/security/index.md
@@ -18,11 +18,11 @@ Prometheus Proxy is designed to be firewall-friendly:
 Agents connect to the proxy using [gRPC](https://grpc.io), which supports TLS with or without
 mutual authentication.
 
-| Mode | Proxy Needs | Agent Needs |
-|:-----|:------------|:------------|
-| **No TLS** | Nothing | Nothing |
-| **TLS (server only)** | Server cert + key | CA cert (trust store) |
-| **Mutual TLS** | Server cert + key + CA cert | Client cert + key + CA cert |
+| Mode                  | Proxy Needs                 | Agent Needs                 |
+|:----------------------|:----------------------------|:----------------------------|
+| **No TLS**            | Nothing                     | Nothing                     |
+| **TLS (server only)** | Server cert + key           | CA cert (trust store)       |
+| **Mutual TLS**        | Server cert + key + CA cert | Client cert + key + CA cert |
 
 See [TLS Setup](tls.md) for detailed configuration instructions.
 

--- a/website/prometheus-proxy/docs/security/tls.md
+++ b/website/prometheus-proxy/docs/security/tls.md
@@ -10,17 +10,17 @@ icon: lucide/lock
 
 Server-side TLS authenticates the proxy to the agent:
 
-| Component | Required Files |
-|:----------|:---------------|
+| Component | Required Files                                                       |
+|:----------|:---------------------------------------------------------------------|
 | **Proxy** | `certChainFilePath` (server cert), `privateKeyFilePath` (server key) |
-| **Agent** | `trustCertCollectionFilePath` (CA cert) |
+| **Agent** | `trustCertCollectionFilePath` (CA cert)                              |
 
 ### TLS With Mutual Authentication
 
 Both sides authenticate each other:
 
-| Component | Required Files |
-|:----------|:---------------|
+| Component | Required Files                                                           |
+|:----------|:-------------------------------------------------------------------------|
 | **Proxy** | `certChainFilePath`, `privateKeyFilePath`, `trustCertCollectionFilePath` |
 | **Agent** | `certChainFilePath`, `privateKeyFilePath`, `trustCertCollectionFilePath` |
 
@@ -108,9 +108,9 @@ java -jar prometheus-agent.jar --override expected.hostname.com --config agent.c
 
 The repository includes complete TLS configuration examples:
 
-| File | Description |
-|:-----|:------------|
-| [`examples/tls-no-mutual-auth.conf`](https://github.com/pambrose/prometheus-proxy/blob/master/examples/tls-no-mutual-auth.conf) | Server-side TLS only |
+| File                                                                                                                                | Description               |
+|:------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|
+| [`examples/tls-no-mutual-auth.conf`](https://github.com/pambrose/prometheus-proxy/blob/master/examples/tls-no-mutual-auth.conf)     | Server-side TLS only      |
 | [`examples/tls-with-mutual-auth.conf`](https://github.com/pambrose/prometheus-proxy/blob/master/examples/tls-with-mutual-auth.conf) | Mutual TLS authentication |
 
 ## Setting Up TLS

--- a/website/prometheus-proxy/docs/service-discovery.md
+++ b/website/prometheus-proxy/docs/service-discovery.md
@@ -47,13 +47,13 @@ The endpoint returns a JSON array in the format expected by Prometheus HTTP SD:
 
 Each entry contains:
 
-| Field | Description |
-|:------|:------------|
-| `targets` | Array containing the proxy endpoint (from `targetPrefix`) |
-| `labels.__metrics_path__` | The path to scrape on the proxy |
-| `labels.agentName` | Name(s) of agent(s) serving this path |
-| `labels.hostName` | Hostname(s) of agent(s) serving this path |
-| `labels.*` | Custom labels from agent `pathConfigs` |
+| Field                     | Description                                               |
+|:--------------------------|:----------------------------------------------------------|
+| `targets`                 | Array containing the proxy endpoint (from `targetPrefix`) |
+| `labels.__metrics_path__` | The path to scrape on the proxy                           |
+| `labels.agentName`        | Name(s) of agent(s) serving this path                     |
+| `labels.hostName`         | Hostname(s) of agent(s) serving this path                 |
+| `labels.*`                | Custom labels from agent `pathConfigs`                    |
 
 ## Prometheus Configuration
 


### PR DESCRIPTION
## Summary

- Bump version to **3.1.1** with refreshed dependencies (Kotlin 2.3.21, Ktor 3.4.3, serialization 1.11.0, tcnative 2.0.77.Final, utils 2.8.1, gradle-plugins 1.0.14, protobuf plugin 0.10.0, taskinfo 3.0.2).
- Document the public API: KDoc on every `@Parameter` field of `BaseOptions` / `AgentOptions` / `ProxyOptions`, every value of `EnvVars`, the `Agent` and `Proxy` companion entry points, and `EmbeddedAgentInfo`. Trim `docs/packages.md` so Dokka has no dangling cross-references — only the supported public surface (`Agent`, `Proxy`, `*Options`, `EnvVars`, `EmbeddedAgentInfo`) is now linked.
- Build-script cleanup: replace the `agentJar` / `proxyJar` zipTree-rewrap with two dedicated `ShadowJar` tasks (configuration-cache safe), drop the redundant `java` plugin, switch `:generateProto` references to `tasks.named("generateProto")`, centralize repos in `settings.gradle.kts` via `dependencyResolutionManagement(FAIL_ON_PROJECT_REPOS)`, and add `-PoverrideReleaseDate` / `-PoverrideBuildTime` / `-PoverrideVersion` properties for reproducible builds.
- Mark internal `Utils` object as `internal` so it no longer leaks into the public API.
- Update CHANGELOG, RELEASE_NOTES, README (Kotlin badge), CLAUDE.md, and llms.txt for 3.1.1.

## Test plan

- [ ] `./gradlew detekt lintKotlinMain build` passes locally
- [ ] `./gradlew agentJar proxyJar` produces both fat JARs with correct `Main-Class` entries (verified locally: ~47 MB each, `io.prometheus.Agent` / `io.prometheus.Proxy`)
- [ ] `./gradlew dokkaGeneratePublicationHtml` builds with no unresolved-link warnings
- [ ] CI green
- [ ] Spot-check the rendered Dokka site shows `Agent`, `Proxy`, `*Options`, `EnvVars`, and `EmbeddedAgentInfo` only (no internal types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)