### PR TITLE
Fix flaky AgentTest Bug #1 coroutine backpressure test (#130)

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -21,6 +21,7 @@ package io.prometheus.agent
 import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -33,6 +34,7 @@ import io.kotest.matchers.string.shouldNotBeEmpty
 import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.Agent
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -461,8 +463,12 @@ class AgentTest : StringSpec() {
         val activeCoroutines = AtomicInt(0)
         val waitingActions = Channel<suspend () -> Unit>(Channel.UNLIMITED)
         val processedCount = AtomicInt(0)
+        // Each action blocks on this gate so the active count is deterministic
+        // until we explicitly release it — no reliance on delay() timing windows.
+        val gate = CompletableDeferred<Unit>()
 
-        // This test simulates the loop in Agent.kt:294
+        // Mirrors the loop in Agent.connectToProxy: acquire the semaphore BEFORE
+        // launching the child coroutine to provide backpressure to the channel.
         val job = launch(Dispatchers.Default) {
           for (action in waitingActions) {
             semaphore.acquire() // This is the fix for Bug #1
@@ -479,23 +485,26 @@ class AgentTest : StringSpec() {
           }
         }
 
-        // Flood the channel with many actions
+        // Flood the channel with many actions, each suspended on the gate.
+        // Without the fix, all `floodSize` coroutines would launch immediately
+        // and activeCoroutines would reach `floodSize`; with the fix, only
+        // `maxConcurrency` coroutines may proceed past the increment.
         val floodSize = 100
         repeat(floodSize) {
-          waitingActions.send {
-            delay(10.milliseconds)
-          }
+          waitingActions.send { gate.await() }
         }
 
-        // Wait a bit for processing to start
-        delay(50.milliseconds)
+        // Wait until the active count settles at the expected ceiling, with a
+        // generous timeout to absorb scheduler jitter under CI load.
+        eventually(2.seconds) {
+          activeCoroutines.load() shouldBe maxConcurrency
+        }
 
-        // Without the fix, activeCoroutines would be floodSize (all launched immediately)
-        // With the fix, activeCoroutines should be <= maxConcurrency
+        // Sanity: still bounded after settling.
         activeCoroutines.load() shouldBeGreaterThanOrEqual 0
-        activeCoroutines.load() shouldBe maxConcurrency // Exactly maxConcurrency should be active
 
-        // Clean up
+        // Release the gate, drain the channel, and verify every action ran.
+        gate.complete(Unit)
         waitingActions.close()
         job.join()
         processedCount.load() shouldBe floodSize


### PR DESCRIPTION
## Summary

`AgentTest > Bug #1: semaphore.acquire() before launch should limit waiting coroutines` was failing intermittently with `expected:<2> but was:<0>`.

**Root cause:** the test asserted exactly `maxConcurrency` active coroutines after a fixed `delay(50.milliseconds)` while each action did `delay(10.milliseconds)`. The consumer loop cycles through *active → release → re-acquire → active again*, so the 50 ms sample could land in the brief gap between one batch finishing (`activeCoroutines--`, `semaphore.release()`) and the next batch starting (`activeCoroutines++`). On the failing run the sample observed that gap and read `0`.

**Note:** the production fix being verified (`semaphore.acquire()` before `launch` in `Agent.connectToProxy`) is correct — backpressure works. The test was just probing it the wrong way.

**Fix:** replace the timing-based probe with a deterministic gate.

- Each action now suspends on a shared `CompletableDeferred<Unit>` instead of `delay(10ms)`. While the gate is closed, the active count is pinned at exactly `maxConcurrency` until we choose to release.
- Use Kotest's `eventually(2.seconds) { activeCoroutines shouldBe maxConcurrency }` to absorb scheduler jitter on busy CI hosts.
- After the assertion, `gate.complete(Unit)` releases all waiters, the channel is closed, and `processedCount shouldBe floodSize` confirms every queued action eventually ran.

## Test plan

- [x] `./gradlew test --tests AgentTest --rerun-tasks` passes locally (verified 'Bug #1' test PASSED)
- [x] `./gradlew detekt lintKotlinTest` clean
- [ ] CI green (re-run a few times to confirm no flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)