### PR TITLE
Fix flaky AgentHttpServiceTest by probing server readiness (#131)

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -46,7 +46,11 @@ import io.prometheus.grpc.registerPathResponse
 import io.prometheus.grpc.scrapeRequest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import java.net.InetSocketAddress
+import java.net.Socket
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource.Monotonic
 import kotlin.time.measureTime
 import io.ktor.server.cio.CIO as ServerCIO
 
@@ -168,9 +172,20 @@ class AgentHttpServiceTest : StringSpec() {
   private suspend fun startServerAndGetPort(server: EmbeddedServer<*, *>): Int {
     server.start(wait = false)
     val port = server.engine.resolvedConnectors().first().port
-    // Allow the CIO server engine to fully start accepting connections
-    delay(100.milliseconds)
-    return port
+
+    // Poll the bound port until it accepts a TCP connection. Replaces a fixed
+    // delay() that occasionally was not long enough on a busy machine, leaving
+    // the client to hit "connection refused" and fail the scrape.
+    val deadline = Monotonic.markNow() + 5.seconds
+    while (Monotonic.markNow() < deadline) {
+      try {
+        Socket().use { it.connect(InetSocketAddress("localhost", port), 200) }
+        return port
+      } catch (_: java.io.IOException) {
+        delay(20.milliseconds)
+      }
+    }
+    error("Embedded server on port $port did not start accepting connections within 5s")
   }
 
   init {


### PR DESCRIPTION
## Summary

`AgentHttpServiceTest > fetchScrapeUrl should forward accept header to target` (and any other test in the file using `startServerAndGetPort`) was failing intermittently with `false should equal true` on `srValidResponse`.

**Root cause:** `startServerAndGetPort` waited a fixed `delay(100.milliseconds)` after `server.start(wait = false)` before returning the bound port. Ktor's `start(wait = false)` returns once the listening socket is bound, but the CIO engine's accept loop can take longer than 100 ms on a busy machine. Client requests landing in that gap get "connection refused"; the exception path in `fetchContentFromUrl` returns a `ScrapeResults` *without* `srValidResponse = true`, and `shouldBeTrue()` fails.

**Fix:** replace the fixed sleep with an active TCP-connect probe.

```kotlin
val deadline = Monotonic.markNow() + 5.seconds
while (Monotonic.markNow() < deadline) {
  try {
    Socket().use { it.connect(InetSocketAddress("localhost", port), 200) }
    return port
  } catch (_: java.io.IOException) {
    delay(20.milliseconds)
  }
}
error("Embedded server on port $port did not start accepting connections within 5s")
```

`startServerAndGetPort` now returns only after a real TCP handshake completes. On fast hosts the loop succeeds on the first iteration; on busy hosts it polls every 20 ms up to 5 s, then fails loudly with a clear error rather than producing a misleading "false should equal true." Protects every test that uses the helper, not just the Accept-header one.

## Test plan

- [x] `./gradlew test --tests AgentHttpServiceTest --rerun-tasks` passes locally (5 consecutive runs verified clean)
- [x] `./gradlew detekt lintKotlinTest` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)