### PR TITLE
Tidy build script: hoist build-config vars, fix Makefile date format (#132)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ stubs:
 	./gradlew generateProto
 
 build: clean stubs
-	./gradlew build -PreleaseDate=2026-04-25 -xtest
+	./gradlew build -PreleaseDate=04/25/2026 -xtest
 
 local-build: clean stubs
-	./gradlew build -PuseMavenLocal=true -PreleaseDate=2026-04-25 -xtest
+	./gradlew build -PuseMavenLocal=true -PreleaseDate=04/25/2026 -xtest
 
 tibuild: clean stubs
 	./gradlew tiTree build -xtest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,13 +29,14 @@ plugins {
 version = findProperty("overrideVersion")?.toString() ?: "3.1.1"
 group = "com.pambrose"
 
+val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+val releaseDate = (findProperty("overrideReleaseDate") as String?) ?: LocalDate.now().format(formatter)
+val buildTime = (findProperty("overrideBuildTime") as String?)?.toLong() ?: System.currentTimeMillis()
+
 buildConfig {
   packageName("io.prometheus")
   buildConfigField("String", "APP_NAME", "\"${project.name}\"")
   buildConfigField("String", "APP_VERSION", "\"${project.version}\"")
-  val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-  val releaseDate = (findProperty("overrideReleaseDate") as String?) ?: LocalDate.now().format(formatter)
-  val buildTime = (findProperty("overrideBuildTime") as String?)?.toLong() ?: System.currentTimeMillis()
   buildConfigField("String", "APP_RELEASE_DATE", "\"$releaseDate\"")
   buildConfigField("long", "BUILD_TIME", "${buildTime}L")
 }


### PR DESCRIPTION
## Summary

- Hoist `formatter`, `releaseDate`, and `buildTime` out of the `buildConfig {}` block in `build.gradle.kts` to top-level `val`s. Pure refactor, no behavior change — keeps the values addressable from elsewhere in the script.
- Fix the literal date passed by `make build` / `make local-build` from `2026-04-25` to `04/25/2026` so it matches the `MM/dd/yyyy` `DateTimeFormatter` pattern in `build.gradle.kts`.

## Heads up

The Makefile passes `-PreleaseDate=…`, but `build.gradle.kts` reads `findProperty("overrideReleaseDate")` (introduced with 3.1.1). The `-PreleaseDate` flag has been a no-op since then. This PR only corrects the date literal; rename the flag to `-PoverrideReleaseDate` in a follow-up if you want it to actually take effect.

## Test plan

- [x] `./gradlew detekt lintKotlinMain build -xtest` clean locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)