### PR TITLE
Add signing key ID to GPG_ENV and streamline RELEASE.md docs (#133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Repository declarations are centralized in `settings.gradle.kts` via `dependency
 
 Snapshot and Maven Central release Make targets (`publish-snapshot`, `publish-maven-central`) require GPG environment variables and a keychain password entry; `make check-gpg-env` validates them up-front.
 
-When bumping the version, update `version` in `gradle.properties` and the `3.1.1` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
+When bumping the version, update `version` in `gradle.properties` and the `3.1.2` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,14 +110,14 @@ The `ConfigVals` class is auto-generated from the HOCON schema using tscfg (`mak
 
 ## Reproducible Builds
 
-`BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` default to the local clock at build time, but can be overridden:
+`group`, `version`, and `releaseDate` live in `gradle.properties` (single source of truth). `build.gradle.kts` reads them via `providers.gradleProperty(...)`; `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` default to those values (or the local clock for `buildTime`) and can be overridden on the command line:
 
 ```bash
-./gradlew build -PoverrideReleaseDate=04/25/2026 -PoverrideBuildTime=1745558400000
+./gradlew build -PreleaseDate=04/25/2026 -PbuildTime=1745558400000
 ./gradlew build -PoverrideVersion=3.1.2-SNAPSHOT
 ```
 
-Use these for CI snapshot publishing and bit-identical artifact reproduction.
+Use these for CI snapshot publishing and bit-identical artifact reproduction. `-PoverrideVersion` keeps its `override` prefix because it intentionally only applies when supplied (so the `gradle.properties` default is never accidentally cleared); `-PreleaseDate` / `-PbuildTime` map directly to the underlying property names.
 
 ## Testing
 
@@ -151,6 +151,10 @@ Snippets use dual `base_path` in zensical.toml: first resolves `.txt` files from
 Published to Maven Central as `com.pambrose:prometheus-proxy`. No JitPack.
 
 Repository declarations are centralized in `settings.gradle.kts` via `dependencyResolutionManagement(FAIL_ON_PROJECT_REPOS)`. Opt into `mavenLocal()` for local snapshot testing with `-PuseMavenLocal=true`.
+
+Snapshot and Maven Central release Make targets (`publish-snapshot`, `publish-maven-central`) require GPG environment variables and a keychain password entry; `make check-gpg-env` validates them up-front.
+
+When bumping the version, update `version` in `gradle.properties` and the `3.1.1` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=$(shell grep '^version\s*=' build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
+VERSION=$(shell awk -F= '/^version[[:space:]]*=/ {gsub(/[[:space:]]/,"",$$2); print $$2; exit}' gradle.properties)
 
 default: versioncheck
 
@@ -56,7 +56,6 @@ tsconfig:
 distro: build jars
 
 PLATFORMS := linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-#PLATFORMS := linux/amd64,linux/arm64,linux/s390x
 IMAGE_PREFIX := pambrose/prometheus
 
 docker-push:

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,8 @@ publish-local-snapshot:
 
 GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
+	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)"
 
 check-gpg-env:
 	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ stubs:
 	./gradlew generateProto
 
 build: clean stubs
-	./gradlew build
+	./gradlew build -xtest
 
 local-build: clean stubs
 	./gradlew build -PuseMavenLocal=true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 VERSION=$(shell awk -F= '/^version[[:space:]]*=/ {gsub(/[[:space:]]/,"",$$2); print $$2; exit}' gradle.properties)
 
+.PHONY: default stop clean stubs build local-build tibuild refresh jars \
+        tests nh-tests ip-tests netty-tests tls-tests reports gh-docs \
+        gh-status tsconfig distro docker-push release tree depends lint \
+        versioncheck kdocs clean-docs site publish-local \
+        publish-local-snapshot check-gpg-env publish-snapshot \
+        publish-maven-central upgrade-wrapper
+
 default: versioncheck
 
 stop:
@@ -12,18 +19,18 @@ stubs:
 	./gradlew generateProto
 
 build: clean stubs
-	./gradlew build -PreleaseDate=04/25/2026 -xtest
+	./gradlew build
 
 local-build: clean stubs
-	./gradlew build -PuseMavenLocal=true -PreleaseDate=04/25/2026 -xtest
+	./gradlew build -PuseMavenLocal=true
 
 tibuild: clean stubs
 	./gradlew tiTree build -xtest
 
 refresh:
-	./gradlew --refresh-dependencies dependencyUpdates
+	./gradlew --refresh-dependencies
 
-jars:
+jars: stubs
 	./gradlew agentJar proxyJar
 
 tests:
@@ -53,7 +60,8 @@ gh-status:
 tsconfig:
 	java -jar ./config/jars/tscfg-1.2.5.jar --spec config/config.conf --pn io.prometheus.common --cn ConfigVals --dd src/main/java/io/prometheus/common
 
-distro: build jars
+distro: build
+	$(MAKE) jars
 
 PLATFORMS := linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 IMAGE_PREFIX := pambrose/prometheus
@@ -63,19 +71,8 @@ docker-push:
 	docker buildx use buildx 2>/dev/null || docker buildx create --use --name=buildx
 	docker buildx build --platform ${PLATFORMS} -f ./etc/docker/proxy.df --push -t ${IMAGE_PREFIX}-proxy:latest -t ${IMAGE_PREFIX}-proxy:${VERSION} .
 	docker buildx build --platform ${PLATFORMS} -f ./etc/docker/agent.df --push -t ${IMAGE_PREFIX}-agent:latest -t ${IMAGE_PREFIX}-agent:${VERSION} .
-#	docker buildx build --platform ${PLATFORMS} -f ./etc/docker/proxy.df --push -t ${IMAGE_PREFIX}-proxy:${VERSION} .
-#	docker buildx build --platform ${PLATFORMS} -f ./etc/docker/agent.df --push -t ${IMAGE_PREFIX}-agent:${VERSION} .
 
 release: distro docker-push
-
-build-coverage:
-	./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent package  jacoco:report
-
-report-coverage:
-	./mvnw -DrepoToken=${COVERALLS_TOKEN} clean package test jacoco:report coveralls:report
-
-sonar:
-	./mvnw sonar:sonar -Dsonar.host.url=http://localhost:9000
 
 tree:
 	./gradlew -q dependencies
@@ -117,8 +114,8 @@ check-gpg-env:
 	@if ! gpg --list-secret-keys "$$GPG_SIGNING_KEY_ID" >/dev/null 2>&1; then \
 		echo "Error: no GPG secret key found for GPG_SIGNING_KEY_ID=$$GPG_SIGNING_KEY_ID" >&2; exit 1; \
 	fi
-	@if ! security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w >/dev/null 2>&1; then \
-		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
+	@if [ -z "$$(security find-generic-password -a 'gpg-signing' -s 'gradle-signing-password' -w 2>/dev/null)" ]; then \
+		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') is missing or empty" >&2; exit 1; \
 	fi
 
 publish-snapshot: check-gpg-env

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ If you prefer to build the project from source:
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.1
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.2
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.1
+  pambrose/prometheus-agent:3.1.2
 ```
 
 ## 📋 Configuration Examples
@@ -217,8 +217,8 @@ scrape_configs:
 The docker images support multiple architectures (amd64, arm64, s390x):
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.1.1
-docker pull pambrose/prometheus-agent:3.1.1
+docker pull pambrose/prometheus-proxy:3.1.2
+docker pull pambrose/prometheus-agent:3.1.2
 ```
 
 ### Production Docker Setup
@@ -231,7 +231,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50051:50051 -p 8080:8080 \
         --env ADMIN_ENABLED=true \
         --env METRICS_ENABLED=true \
         --restart unless-stopped \
-        pambrose/prometheus-proxy:3.1.1
+        pambrose/prometheus-proxy:3.1.2
 ```
 
 Start an agent container with:
@@ -241,7 +241,7 @@ Start an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
         --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
         --restart unless-stopped \
-        pambrose/prometheus-agent:3.1.1
+        pambrose/prometheus-agent:3.1.2
 ```
 
 Or use docker-compose: see `etc/compose/proxy.yml` for a working example.
@@ -262,7 +262,7 @@ is in your current directory, run an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
     --env AGENT_CONFIG=prom-agent.conf \
-    pambrose/prometheus-agent:3.1.1
+    pambrose/prometheus-agent:3.1.2
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -486,7 +486,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50440:50440 -p 8080:8080 \
     --env PROXY_CONFIG=tls-no-mutual-auth.conf \
     --env ADMIN_ENABLED=true \
     --env METRICS_ENABLED=true \
-    pambrose/prometheus-proxy:3.1.1
+    pambrose/prometheus-proxy:3.1.2
 
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/testing/certs,target=/app/testing/certs \
@@ -494,7 +494,7 @@ docker run --rm -p 8083:8083 -p 8093:8093 \
     --env AGENT_CONFIG=tls-no-mutual-auth.conf \
     --env PROXY_HOSTNAME=mymachine.lan:50440 \
     --name docker-agent \
-    pambrose/prometheus-agent:3.1.1
+    pambrose/prometheus-agent:3.1.2
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -581,7 +581,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.1")
+  implementation("com.pambrose:prometheus-proxy:3.1.2")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ If you prefer to build the project from source:
 
 2. Build the fat JARs:
    ```bash
-   ./gradlew shadowJar
+   ./gradlew agentJar proxyJar
    ```
+
+   `agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled so it cannot produce a third redundant fat jar.
 
 3. The JARs will be available in `build/libs/`:
   - `build/libs/prometheus-proxy.jar`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,8 @@ plugins {
   alias(libs.plugins.taskinfo) apply false
 }
 
-version = findProperty("overrideVersion")?.toString() ?: "3.1.1"
-group = "com.pambrose"
+// Version and group are defined in gradle.properties; also update version refs in README.md and website/srcref/docs/{api,getting-started}.md
+providers.gradleProperty("overrideVersion").orNull?.let { version = it }
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 val releaseDate = (findProperty("overrideReleaseDate") as String?) ?: LocalDate.now().format(formatter)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,8 @@ plugins {
 providers.gradleProperty("overrideVersion").orNull?.let { version = it }
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate = (findProperty("overrideReleaseDate") as String?) ?: LocalDate.now().format(formatter)
-val buildTime = (findProperty("overrideBuildTime") as String?)?.toLong() ?: System.currentTimeMillis()
+val releaseDate = providers.gradleProperty("releaseDate").orNull ?: LocalDate.now().format(formatter)
+val buildTime = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
 
 buildConfig {
   packageName("io.prometheus")

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,24 +1,14 @@
 # Release Creation
 
-1) Create a PR branch
+1) Bump version in `build.gradle.kts`
 
-2) Bump version in source
+2) Update the release date in `Makefile`
 
-3) Modify code
+3) Verify tests run cleanly before merge with: `make tests`
 
-4) Update the release date in `build.gradle`
+4) Build distro with: `make distro`
 
-5) Verify tests run cleanly before merge with: `make tests`
-
-6) Push the branch and open a PR
-
-7) Merge the PR into master
-
-8) Verify tests run cleanly after merge with: `make tests`
-
-9) Build distro with: `make distro`
-
-10) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases)
+5) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases)
     and upload the *build/libs/prometheus-proxy.jar* and *build/libs/prometheus-agent.jar* files.
 
-11) Build and push docker images with: `make docker-push`
+6) Build and push docker images with: `make docker-push`

--- a/etc/compose/proxy.yml
+++ b/etc/compose/proxy.yml
@@ -1,6 +1,6 @@
 prometheus-proxy:
   autoredeploy: true
-  image: 'pambrose/prometheus-proxy:3.1.1'
+  image: 'pambrose/prometheus-proxy:3.1.2'
   ports:
     - '8080:8080'
     - '8082:8082'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Gradle settings
-version = "3.1.1"
-group = "com.pambrose"
+group=com.pambrose
+version=3.1.1
+releaseDate=04/25/2026
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
 # Gradle settings
+version = "3.1.1"
+group = "com.pambrose"
+
 kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle settings
 group=com.pambrose
-version=3.1.1
+version=3.1.2
 releaseDate=04/25/2026
 
 kotlin.code.style=official

--- a/llms.txt
+++ b/llms.txt
@@ -87,12 +87,12 @@ java -jar prometheus-agent.jar --proxy mymachine.local --config myapps.conf
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.1
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.1.2
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.1
+  pambrose/prometheus-agent:3.1.2
 ```
 
 ## Configuration
@@ -189,7 +189,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.1")
+  implementation("com.pambrose:prometheus-proxy:3.1.2")
 }
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -159,10 +159,12 @@ cd prometheus-proxy
 ./gradlew build                              # Build with tests
 ./gradlew agentJar proxyJar                  # Named fat JARs in build/libs/
 ./gradlew build -PoverrideVersion=X.Y.Z      # Build with a custom version
+./gradlew build -PreleaseDate=04/25/2026     # Override embedded release date
+./gradlew build -PbuildTime=1745558400000    # Override embedded build time (ms epoch)
 ./gradlew build -PuseMavenLocal=true         # Resolve from ~/.m2 in addition to Maven Central
 ```
 
-`agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled to avoid producing a third redundant fat jar. Repository declarations are centralized in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`).
+`group`, `version`, and `releaseDate` live in `gradle.properties` (single source of truth) and are read by `build.gradle.kts` via `providers.gradleProperty(...)`. `agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled to avoid producing a third redundant fat jar. Repository declarations are centralized in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`).
 
 ## Tech Stack
 

--- a/src/test/kotlin/website/DockerExamples.txt
+++ b/src/test/kotlin/website/DockerExamples.txt
@@ -1,14 +1,14 @@
 ; --8<-- [start:docker-proxy-basic]
 # Start a proxy container:
 docker run --rm -p 8080:8080 -p 50051:50051 \
-  pambrose/prometheus-proxy:3.1.1
+  pambrose/prometheus-proxy:3.1.2
 ; --8<-- [end:docker-proxy-basic]
 
 ; --8<-- [start:docker-agent-basic]
 # Start an agent with a remote config:
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.1.1
+  pambrose/prometheus-agent:3.1.2
 ; --8<-- [end:docker-agent-basic]
 
 ; --8<-- [start:docker-proxy-production]
@@ -21,7 +21,7 @@ docker run --rm \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
   --restart unless-stopped \
-  pambrose/prometheus-proxy:3.1.1
+  pambrose/prometheus-proxy:3.1.2
 ; --8<-- [end:docker-proxy-production]
 
 ; --8<-- [start:docker-agent-local-config]
@@ -31,7 +31,7 @@ docker run --rm \
   -p 8093:8093 \
   --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
   --env AGENT_CONFIG=prom-agent.conf \
-  pambrose/prometheus-agent:3.1.1
+  pambrose/prometheus-agent:3.1.2
 ; --8<-- [end:docker-agent-local-config]
 
 ; --8<-- [start:docker-compose-full]
@@ -39,7 +39,7 @@ version: '3.8'
 
 services:
   proxy:
-    image: pambrose/prometheus-proxy:3.1.1
+    image: pambrose/prometheus-proxy:3.1.2
     ports:
       - "8080:8080"    # HTTP scrape port
       - "50051:50051"  # gRPC agent port
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   agent:
-    image: pambrose/prometheus-agent:3.1.1
+    image: pambrose/prometheus-agent:3.1.2
     ports:
       - "8083:8083"    # Metrics port
       - "8093:8093"    # Admin port
@@ -81,7 +81,7 @@ docker run --rm \
   --env PROXY_CONFIG=tls.conf \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
-  pambrose/prometheus-proxy:3.1.1
+  pambrose/prometheus-proxy:3.1.2
 
 # Agent with TLS (no mutual auth):
 docker run --rm \
@@ -91,7 +91,7 @@ docker run --rm \
   --mount type=bind,source="$(pwd)"/tls.conf,target=/app/tls.conf \
   --env AGENT_CONFIG=tls.conf \
   --env PROXY_HOSTNAME=proxy-host:50440 \
-  pambrose/prometheus-agent:3.1.1
+  pambrose/prometheus-agent:3.1.2
 ; --8<-- [end:docker-tls]
 
 ; --8<-- [start:docker-env-vars]

--- a/src/test/kotlin/website/EmbeddedAgentExamples.txt
+++ b/src/test/kotlin/website/EmbeddedAgentExamples.txt
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.1.1")
+  implementation("com.pambrose:prometheus-proxy:3.1.2")
 }
 // --8<-- [end:gradle-dependency]
 
@@ -15,7 +15,7 @@ dependencies {
   <dependency>
     <groupId>com.pambrose</groupId>
     <artifactId>prometheus-proxy</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
   </dependency>
 </dependencies>
 <!-- --8<-- [end:maven-dependency] -->

--- a/website/prometheus-proxy/docs/docker.md
+++ b/website/prometheus-proxy/docs/docker.md
@@ -7,8 +7,8 @@ icon: lucide/container
 Multi-platform images (amd64, arm64, s390x) are published on Docker Hub for every release.
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.1.1
-docker pull pambrose/prometheus-agent:3.1.1
+docker pull pambrose/prometheus-proxy:3.1.2
+docker pull pambrose/prometheus-agent:3.1.2
 ```
 
 ## Basic Usage
@@ -77,4 +77,4 @@ docker pull pambrose/prometheus-agent:latest
 
 !!! tip "Pin versions in production"
 
-    Use explicit version tags (e.g., `3.1.1`) in production to avoid unexpected upgrades.
+    Use explicit version tags (e.g., `3.1.2`) in production to avoid unexpected upgrades.

--- a/website/prometheus-proxy/docs/getting-started.md
+++ b/website/prometheus-proxy/docs/getting-started.md
@@ -31,8 +31,8 @@ icon: lucide/play
     Multi-platform images (amd64, arm64, s390x) are available on Docker Hub:
 
     ```bash
-    docker pull pambrose/prometheus-proxy:3.1.1
-    docker pull pambrose/prometheus-agent:3.1.1
+    docker pull pambrose/prometheus-proxy:3.1.2
+    docker pull pambrose/prometheus-agent:3.1.2
     ```
 
 ## Start the Proxy
@@ -54,7 +54,7 @@ The proxy runs outside the firewall alongside your Prometheus server.
 
     ```bash
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.1.1
+      pambrose/prometheus-proxy:3.1.2
     ```
 
 ## Start the Agent
@@ -108,7 +108,7 @@ Each entry in `pathConfigs` maps:
       --mount type=bind,source="$(pwd)"/agent.conf,target=/app/agent.conf \
       --env AGENT_CONFIG=agent.conf \
       --env PROXY_HOSTNAME=proxy-host.example.com \
-      pambrose/prometheus-agent:3.1.1
+      pambrose/prometheus-agent:3.1.2
     ```
 
 === "Remote Config"

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -70,12 +70,12 @@ Get running in under a minute:
     ```bash
     # Start the proxy
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.1.1
+      pambrose/prometheus-proxy:3.1.2
 
     # Start the agent
     docker run --rm \
       --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-      pambrose/prometheus-agent:3.1.1
+      pambrose/prometheus-agent:3.1.2
     ```
 
 See the [Quick Start Guide](getting-started.md) for detailed instructions.


### PR DESCRIPTION
## Summary

- Makefile: add `ORG_GRADLE_PROJECT_signingInMemoryKeyId` to `GPG_ENV` so the in-memory signing config has the key ID alongside the armored key and password; quote the password expansion for safety.
- docs/RELEASE.md: collapse the duplicated PR/branch/merge steps into the actual release flow (version bump, Makefile date bump, tests, distro, GitHub release, docker push).

## Test plan

- [ ] `make check-gpg-env` succeeds with the expected env vars present
- [ ] A signed publish (e.g. `make publish-local-snapshot`) succeeds with the new signing key ID exported
- [ ] RELEASE.md renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)