### PR TITLE
Drop email address from copyright headers (#135)

### DIFF
--- a/src/main/java/io/prometheus/common/ConfigVals.java
+++ b/src/main/java/io/prometheus/common/ConfigVals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentClientInterceptor.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentClientInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentMetrics.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentMetrics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
+++ b/src/main/kotlin/io/prometheus/agent/EmbeddedAgentInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/RequestFailureException.kt
+++ b/src/main/kotlin/io/prometheus/agent/RequestFailureException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/SslSettings.kt
+++ b/src/main/kotlin/io/prometheus/agent/SslSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/agent/TrustAllX509TrustManager.kt
+++ b/src/main/kotlin/io/prometheus/agent/TrustAllX509TrustManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/ConfigWrappers.kt
+++ b/src/main/kotlin/io/prometheus/common/ConfigWrappers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/Constants.kt
+++ b/src/main/kotlin/io/prometheus/common/Constants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/EnvVars.kt
+++ b/src/main/kotlin/io/prometheus/common/EnvVars.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/ScrapeResults.kt
+++ b/src/main/kotlin/io/prometheus/common/ScrapeResults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/TypeAliases.kt
+++ b/src/main/kotlin/io/prometheus/common/TypeAliases.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/AgentContextCleanupService.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextCleanupService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ChunkedContext.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ChunkedContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyConstants.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyGrpcService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpService.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyMetrics.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyMetrics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServerInterceptor.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServerInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServerTransportFilter.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServerTransportFilter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright © 2026 Paul Ambrose
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/java/website/EmbeddedAgentJavaExample.java
+++ b/src/test/java/website/EmbeddedAgentJavaExample.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package website;
 
 // --8<-- [start:embedded-java]

--- a/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentClientInterceptorTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentClientInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentContextManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentContextTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/EmbeddedAgentInfoTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/EmbeddedAgentInfoTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/RequestFailureExceptionTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/RequestFailureExceptionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/agent/TrustAllX509TrustManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/TrustAllX509TrustManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/ConfigWrappersTest.kt
+++ b/src/test/kotlin/io/prometheus/common/ConfigWrappersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/ConstantsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/ConstantsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/ScrapeResultsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/ScrapeResultsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/common/UtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/UtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
+++ b/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/HarnessConstants.kt
+++ b/src/test/kotlin/io/prometheus/harness/HarnessConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/InProcessTestNoAdminMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessTestNoAdminMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/InProcessTestWithAdminMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessTestWithAdminMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/NettyTestNoAdminMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/NettyTestNoAdminMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/NettyTestWithAdminMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/NettyTestWithAdminMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/TlsNoMutualAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsNoMutualAuthTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/support/AbstractHarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/AbstractHarnessTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSetup.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSetup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/AdminDefaultPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminDefaultPathTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/ConfigValsTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/ConfigValsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/DataClassTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/DataClassTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextCleanupServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextCleanupServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ChunkedContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ChunkedContextTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyGrpcServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyMetricsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServerInterceptorTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServerInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServerTransportFilterTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServerTransportFilterTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/RecentReqsSynchronizationTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/RecentReqsSynchronizationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ScrapeRequestManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ScrapeRequestManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ * Copyright © 2026 Paul Ambrose
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/website/EmbeddedAgentKotlinExample.kt
+++ b/src/test/kotlin/website/EmbeddedAgentKotlinExample.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package website
 
 // --8<-- [start:embedded-kotlin]

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright © 2026 Paul Ambrose
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
## Summary
- Apply the IDE copyright-profile update from `.idea/copyright/Apache.xml` (merged in #134) across every source file: `Copyright © 2026 Paul Ambrose (pambrose@mac.com)` → `Copyright © 2026 Paul Ambrose`.
- No code changes; header-only edit.

## Test plan
- [ ] CI build green (`detekt`, `lintKotlinMain`, `lintKotlinTest` already pass locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)