### PR TITLE
Rename XLARGE1/XLARGE2 harness configs to XLARGE/XXLARGE (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/prometheus-proxy)](https://github.com/pambrose/prometheus-proxy/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/prometheus-proxy)](https://central.sonatype.com/artifact/com.pambrose/prometheus-proxy)
 [![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
-[![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![codecov](https://codecov.io/gh/pambrose/prometheus-proxy/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/prometheus-proxy)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/422df508473443df9fbd8ea00fdee973)](https://app.codacy.com/gh/pambrose/prometheus-proxy/dashboard)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,8 +140,8 @@ fun Project.configureTesting() {
     // and runs them through 2000+ sequential calls; the default 512m heap OOMs in bodyAsText().
     maxHeapSize =
       when (harnessConfig?.uppercase()) {
-        "XLARGE2" -> "8g"
-        "XLARGE1" -> "4g"
+        "XXLARGE" -> "8g"
+        "XLARGE" -> "4g"
         "LARGE" -> "2g"
         else -> "1g"
       }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -222,7 +222,7 @@ Each integration test class runs a standard suite defined in `AbstractHarnessTes
 - **BasicHarnessTests** — Reusable test implementations (missing path, invalid path, add/remove paths, etc.)
 - **HarnessTests** — Core integration logic: `proxyCallTest()` (sequential, parallel, concurrent queries) and
   `timeoutTest()`
-- **HarnessConfig** — Enum defining test scale configs (MINI, SMALL, MEDIUM, LARGE, XLARGE1, XLARGE2)
+- **HarnessConfig** — Enum defining test scale configs (MINI, SMALL, MEDIUM, LARGE, XLARGE, XXLARGE)
 - **HarnessConstants** — Test constants (ports, delays, config paths)
 
 ## Testing Patterns
@@ -258,7 +258,7 @@ fun `test async operation`(): Unit = runBlocking {
 
 ### Harness Test Scaling
 
-Integration tests scale via `HarnessConfig` (MINI to XLARGE2), which controls the number of agents, paths, and
+Integration tests scale via `HarnessConfig` (MINI to XXLARGE), which controls the number of agents, paths, and
 iterations used in integration tests.
 
 ### Bug Regression Tests

--- a/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
+++ b/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
@@ -61,7 +61,7 @@ enum class HarnessConfig(
     addRemoveReps = 3000,
     proxyCallTimeoutSecs = 120,
   ),
-  XLARGE1(
+  XLARGE(
     httpServerCount = 20,
     pathCount = 250,
     sequentialQueryCount = 5000,
@@ -70,7 +70,7 @@ enum class HarnessConfig(
     addRemoveReps = 5000,
     proxyCallTimeoutSecs = 240,
   ),
-  XLARGE2(
+  XXLARGE(
     httpServerCount = 40,
     pathCount = 500,
     sequentialQueryCount = 10000,


### PR DESCRIPTION
## Summary
- Renames the largest two `HarnessConfig` enum values for clearer ordering: `XLARGE1` → `XLARGE`, `XLARGE2` → `XXLARGE`
- Updates the matching JVM heap-size mapping in `build.gradle.kts` (`configureTesting`)
- Updates the corresponding entries in `docs/TESTING.md`
- Drops the now-stale ktlint badge from `README.md` (the project uses kotlinter)

## Test plan
- [ ] `./gradlew detekt lintKotlinMain lintKotlinTest build -xtest`
- [ ] Verify `HARNESS_CONFIG=XXLARGE ./gradlew test --tests "io.prometheus.harness.*"` resolves the new enum
- [ ] Confirm CI badges render on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)