### PR TITLE
Refresh BuildConfig timestamps each build via ValueSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
 
 ### Build & Tooling
 
+- Replace the `-PreleaseDate` / `-PbuildTime` Gradle property overrides with `ValueSource`-backed providers so `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` are read fresh on each build instead of being frozen by the configuration cache. The override flags are removed; release artifacts are no longer byte-for-byte reproducible
 - Move detekt configuration from `etc/detekt/` to `config/detekt/` (standard detekt convention)
 - Add `detekt` to the `lint` Makefile target so `make lint` runs `lintKotlinMain`, `lintKotlinTest`, and `detekt`
 - Add `detekt-baseline` Makefile target wrapping `./gradlew detektBaseline`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,16 +115,17 @@ Uses Typesafe Config (HOCON). Precedence: CLI args → env vars → config file 
 
 The `ConfigVals` class is auto-generated from the HOCON schema using tscfg (`make tsconfig`).
 
-## Reproducible Builds
+## Build Version
 
-`group`, `version`, and `releaseDate` live in `gradle.properties` (single source of truth). `build.gradle.kts` reads them via `providers.gradleProperty(...)`; `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` default to those values (or the local clock for `buildTime`) and can be overridden on the command line:
+`group` and `version` live in `gradle.properties` (single source of truth). The version can be overridden on the command line for CI snapshot publishing:
 
 ```bash
-./gradlew build -PreleaseDate=04/25/2026 -PbuildTime=1745558400000
 ./gradlew build -PoverrideVersion=3.1.2-SNAPSHOT
 ```
 
-Use these for CI snapshot publishing and bit-identical artifact reproduction. `-PoverrideVersion` keeps its `override` prefix because it intentionally only applies when supplied (so the `gradle.properties` default is never accidentally cleared); `-PreleaseDate` / `-PbuildTime` map directly to the underlying property names.
+`-PoverrideVersion` keeps its `override` prefix because it intentionally only applies when supplied (so the `gradle.properties` default is never accidentally cleared).
+
+`BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` are populated each build via `ValueSource`, so they reflect the actual build time and are not overridable. As a side effect, the configuration cache invalidates and `BuildConfig` regenerates on every build; release artifacts are therefore not byte-for-byte reproducible.
 
 ## Testing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ _Unreleased_
 
 - **Testcontainers smoke test** — A new `ContainersSmokeTest` builds the proxy and agent Docker images from `etc/docker/*.df`, runs them alongside an nginx metrics stub and a real Prometheus container, and verifies the full `Prometheus → proxy → agent → endpoint` scrape path end-to-end. Surfaces packaging/image regressions that the in-JVM harness can't catch.
 - **Shadow JAR fix** — Re-register grpc-core's `DnsNameResolverProvider` and `PickFirstLoadBalancerProvider` in the agent and proxy fat JARs. Shadow 9.4.1's `mergeServiceFiles()` was silently dropping them when grpc-netty-shaded provided same-named service files, which made the gRPC client default to the `unix` scheme on any non-IP hostname (`Address types of NameResolver 'unix' for 'unix:///host:port' not supported by transport`). Anyone running the published agent/proxy JAR against a hostname-addressed proxy could have hit this.
+- **Live `BUILD_TIME` / `APP_RELEASE_DATE`** — Switched these `BuildConfig` fields to `ValueSource`-backed providers so they refresh each build instead of being frozen by Gradle's configuration cache. The 3.1.1 `-PreleaseDate` / `-PbuildTime` overrides have been removed; release artifacts are no longer byte-for-byte reproducible.
 
 ### Bug Fixes
 
@@ -25,6 +26,7 @@ _Unreleased_
 
 ### Build & Tooling
 
+- Replace the `-PreleaseDate` / `-PbuildTime` Gradle property overrides with `ValueSource`-backed providers so `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` are read fresh on each build rather than being frozen by Gradle's configuration cache. The override flags introduced in 3.1.1 are removed; release artifacts are no longer byte-for-byte reproducible
 - Move detekt configuration from `etc/detekt/` to `config/detekt/` (the standard detekt convention); `build.gradle.kts` and `CLAUDE.md` updated accordingly
 - Add `detekt` to the `lint` Makefile target so `make lint` now runs `lintKotlinMain`, `lintKotlinTest`, and `detekt` together
 - Add `detekt-baseline` Makefile target (`./gradlew detektBaseline`) for grandfathering existing findings when tightening rules

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SourcesJar
 import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -29,12 +31,22 @@ plugins {
   alias(libs.plugins.taskinfo) apply false
 }
 
-// Version and group are defined in gradle.properties; also update version refs in README.md and website/srcref/docs/{api,getting-started}.md
+// Version and group are defined in gradle.properties; also update version refs in README.md and llms.txt
 providers.gradleProperty("overrideVersion").orNull?.let { version = it }
 
-val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate: String = providers.gradleProperty("releaseDate").orNull ?: LocalDate.now().format(formatter)
-val buildTime: Long = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
+// ValueSources are read fresh on each build (configuration-cache-safe), so APP_RELEASE_DATE and
+// BUILD_TIME reflect the actual build time rather than a frozen configuration-cache value.
+abstract class CurrentDateValueSource : ValueSource<String, ValueSourceParameters.None> {
+  override fun obtain(): String =
+    LocalDate.now().format(DateTimeFormatter.ofPattern("MM/dd/yyyy"))
+}
+
+abstract class CurrentTimeValueSource : ValueSource<Long, ValueSourceParameters.None> {
+  override fun obtain(): Long = System.currentTimeMillis()
+}
+
+val releaseDate = providers.of(CurrentDateValueSource::class) {}
+val buildTime = providers.of(CurrentTimeValueSource::class) {}
 
 val basePackage = "io.prometheus"
 val displayName = "Prometheus Proxy"
@@ -47,8 +59,8 @@ buildConfig {
   packageName(basePackage)
   buildConfigField("String", "APP_NAME", "\"${project.name}\"")
   buildConfigField("String", "APP_VERSION", "\"${project.version}\"")
-  buildConfigField("String", "APP_RELEASE_DATE", "\"$releaseDate\"")
-  buildConfigField("long", "BUILD_TIME", "${buildTime}L")
+  buildConfigField("String", "APP_RELEASE_DATE", releaseDate.map { "\"$it\"" })
+  buildConfigField("long", "BUILD_TIME", buildTime.map { "${it}L" })
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ datetime = "0.7.1"
 dropwizard = "4.2.38"
 gengrpc = "1.5.0"
 grpc = "1.81.0"
-jakartaServlet = "6.1.0"
 jcommander = "3.0"
 jetty = "11.0.26"
 kotest = "6.1.11"
@@ -67,9 +66,6 @@ common-utils-ktor-client = { module = "com.pambrose.common-utils:ktor-client-uti
 common-utils-prometheus = { module = "com.pambrose.common-utils:prometheus-utils", version.ref = "utils" }
 common-utils-service = { module = "com.pambrose.common-utils:service-utils", version.ref = "utils" }
 common-utils-zipkin = { module = "com.pambrose.common-utils:zipkin-utils", version.ref = "utils" }
-
-# Jakarta Servlet
-jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakartaServlet" }
 
 # Jetty
 jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "jetty" }

--- a/llms.txt
+++ b/llms.txt
@@ -159,11 +159,9 @@ cd prometheus-proxy
 ./gradlew build                              # Build with tests
 ./gradlew agentJar proxyJar                  # Named fat JARs in build/libs/
 ./gradlew build -PoverrideVersion=X.Y.Z      # Build with a custom version
-./gradlew build -PreleaseDate=04/25/2026     # Override embedded release date
-./gradlew build -PbuildTime=1745558400000    # Override embedded build time (ms epoch)
 ```
 
-`group`, `version`, and `releaseDate` live in `gradle.properties` (single source of truth) and are read by `build.gradle.kts` via `providers.gradleProperty(...)`. `agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled to avoid producing a third redundant fat jar. Repository declarations are centralized in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`).
+`group` and `version` live in `gradle.properties` (single source of truth) and are read by `build.gradle.kts` via `providers.gradleProperty(...)`. `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` are populated each build via `ValueSource`, so they reflect the actual build time and are not overridable. `agentJar` and `proxyJar` are dedicated `ShadowJar` tasks; the default `shadowJar` task is disabled to avoid producing a third redundant fat jar. Repository declarations are centralized in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`).
 
 The fat JARs include `src/shadow/resources/META-INF/services/io.grpc.NameResolverProvider` and `io.grpc.LoadBalancerProvider` so DNS / PickFirst providers stay registered — shadow 9.4.1 silently drops one of the two same-named files when both `grpc-core` and `grpc-netty-shaded` contribute, and without DNS the gRPC client defaults to `unix:///host:port` on any non-IP hostname.
 


### PR DESCRIPTION
## Summary

- Replace direct `LocalDate.now()` / `System.currentTimeMillis()` reads with `ValueSource`-backed `Provider`s so `BuildConfig.APP_RELEASE_DATE` and `BuildConfig.BUILD_TIME` refresh each build instead of being frozen by the configuration cache
- Remove the 3.1.1 `-PreleaseDate` / `-PbuildTime` Gradle property overrides (release artifacts are no longer byte-for-byte reproducible; `-PoverrideVersion` is preserved)
- Drop the unused `jakarta-servlet-api` entry from the version catalog and fix a stale doc-update comment in `build.gradle.kts`
- Update `CLAUDE.md`, `CHANGELOG.md`, `RELEASE_NOTES.md`, and `llms.txt` to match

## Test plan

- [ ] `./gradlew generateBuildConfig` regenerates `BuildConfig.kt` with current timestamps
- [ ] Run twice in succession and confirm `BUILD_TIME` advances between builds
- [ ] `./gradlew detekt lintKotlinMain build -xtest` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)