### PR TITLE
Use lintKotlin in the lint Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tibuild:  ## Build with taskinfo task tree
 	./gradlew clean generateProto tiTree build -xtest
 
 lint:  ## Run kotlinter and detekt
-	./gradlew lintKotlinMain lintKotlinTest detekt
+	./gradlew lintKotlin detekt
 
 detekt:  ## Run detekt static analysis
 	./gradlew detekt


### PR DESCRIPTION
## Summary
- Replace `lintKotlinMain lintKotlinTest` with the aggregate `lintKotlin` task in the `lint` Make recipe — same coverage, shorter invocation.

## Test plan
- [ ] `make lint` runs kotlinter against both main and test source sets and then detekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)