### PR TITLE
Replace hardcoded HTTP timeout default with named constant

### DIFF
--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -242,7 +242,9 @@ internal class AgentHttpService(
         // If internal.cioTimeoutSecs is set to a non-default and httpClientTimeoutSecs is set to the default, then use
         // internal.cioTimeoutSecs value. Otherwise, use httpClientTimeoutSecs.
         val timeoutSecs =
-          if (agent.configVals.agent.internal.cioTimeoutSecs != 90 && agent.options.httpClientTimeoutSecs == 90)
+          if (agent.configVals.agent.internal.cioTimeoutSecs != DEFAULT_HTTP_TIMEOUT_SECS &&
+            agent.options.httpClientTimeoutSecs == DEFAULT_HTTP_TIMEOUT_SECS
+          )
             agent.configVals.agent.internal.cioTimeoutSecs
           else
             agent.options.httpClientTimeoutSecs
@@ -293,6 +295,13 @@ internal class AgentHttpService(
 
   companion object {
     private val logger = logger {}
+
+    // Factory default (in seconds) shared by both http.clientTimeoutSecs and the deprecated
+    // internal.cioTimeoutSecs in config/config.conf. Used to detect whether the deprecated
+    // cioTimeoutSecs was explicitly overridden while clientTimeoutSecs was left at its default.
+    // MUST stay in sync with the defaults in config/config.conf.
+    private const val DEFAULT_HTTP_TIMEOUT_SECS = 90
+
     private const val INVALID_PATH_MSG = "invalid_path"
     private const val SUCCESS_MSG = "success"
     private const val UNSUCCESSFUL_MSG = "unsuccessful"


### PR DESCRIPTION
## Summary

The CIO timeout selection in `AgentHttpService.newHttpClient()` compared two config values against the bare literal `90` in two places. That `90` is the factory default shared by both `http.clientTimeoutSecs` and the deprecated `internal.cioTimeoutSecs` in `config/config.conf`. The duplicated magic number was a maintenance hazard: if either default changed in `config.conf` without updating both literals, the timeout-selection logic would silently break.

This extracts a single documented `DEFAULT_HTTP_TIMEOUT_SECS` constant and uses it in both comparisons.

## Notes

- **Behavior is unchanged.** The constant is intentionally kept as the *factory default* sentinel rather than wired to the live `configVals` value. Comparing against the configured value would break the legitimate case where a user sets `http.clientTimeoutSecs` in config — the new setting should win over the deprecated `cioTimeoutSecs`.
- The constant carries a comment noting it must stay in sync with `config/config.conf`.

## Verification

- `./gradlew lintKotlinMain detekt` — clean
- `./gradlew compileKotlin` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)