### PR TITLE
Add tests for SslSettings success paths and BaseOptions URL config

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
@@ -53,20 +53,12 @@ class SslSettingsTest : StringSpec() {
     // block so it is cleared on both success and failure paths.
 
     "getKeyStore should zero password char array after successful load" {
-      // Create a temporary keystore to test the success path
-      val storePassword = "test-password"
-      val tmpFile = File.createTempFile("test-keystore", ".jks")
-      tmpFile.deleteOnExit()
-      KeyStore.getInstance(KeyStore.getDefaultType()).apply {
-        load(null, null)
-        FileOutputStream(tmpFile).use { store(it, storePassword.toCharArray()) }
-      }
-
+      val (path, storePassword) = createTempKeyStore()
       val password = storePassword.toCharArray()
-      SslSettings.getKeyStore(tmpFile.absolutePath, password)
+
+      SslSettings.getKeyStore(path, password)
 
       password.all { it == '\u0000' }.shouldBeTrue()
-      tmpFile.delete()
     }
 
     "getKeyStore should zero password char array even when file does not exist" {
@@ -111,34 +103,22 @@ class SslSettingsTest : StringSpec() {
 
     "getTrustManagerFactory should return initialized factory for valid keystore" {
       val (path, password) = createTempKeyStore()
-      try {
-        val factory = SslSettings.getTrustManagerFactory(path, password)
-        factory.shouldNotBeNull()
-        factory.trustManagers.isNotEmpty() shouldBe true
-      } finally {
-        File(path).delete()
-      }
+      val factory = SslSettings.getTrustManagerFactory(path, password)
+      factory.shouldNotBeNull()
+      factory.trustManagers.isNotEmpty() shouldBe true
     }
 
     "getSslContext should return a TLS context for valid keystore" {
       val (path, password) = createTempKeyStore()
-      try {
-        val sslContext = SslSettings.getSslContext(path, password)
-        sslContext.shouldNotBeNull()
-        sslContext.protocol shouldBe "TLS"
-      } finally {
-        File(path).delete()
-      }
+      val sslContext = SslSettings.getSslContext(path, password)
+      sslContext.shouldNotBeNull()
+      sslContext.protocol shouldBe "TLS"
     }
 
     "getTrustManager should return an X509TrustManager for valid keystore" {
       val (path, password) = createTempKeyStore()
-      try {
-        val trustManager = SslSettings.getTrustManager(path, password)
-        trustManager.shouldBeInstanceOf<X509TrustManager>()
-      } finally {
-        File(path).delete()
-      }
+      val trustManager = SslSettings.getTrustManager(path, password)
+      trustManager.shouldBeInstanceOf<X509TrustManager>()
     }
 
     // ==================== Type Verification Tests ====================

--- a/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
@@ -104,6 +104,43 @@ class SslSettingsTest : StringSpec() {
       }
     }
 
+    // ==================== Success Path Tests ====================
+    // These exercise the success branches of getTrustManagerFactory/getSslContext/
+    // getTrustManager against a real (empty) keystore. The prior tests only covered the
+    // FileNotFoundException paths, leaving the success bodies uncovered.
+
+    "getTrustManagerFactory should return initialized factory for valid keystore" {
+      val (path, password) = createTempKeyStore()
+      try {
+        val factory = SslSettings.getTrustManagerFactory(path, password)
+        factory.shouldNotBeNull()
+        factory.trustManagers.isNotEmpty() shouldBe true
+      } finally {
+        File(path).delete()
+      }
+    }
+
+    "getSslContext should return a TLS context for valid keystore" {
+      val (path, password) = createTempKeyStore()
+      try {
+        val sslContext = SslSettings.getSslContext(path, password)
+        sslContext.shouldNotBeNull()
+        sslContext.protocol shouldBe "TLS"
+      } finally {
+        File(path).delete()
+      }
+    }
+
+    "getTrustManager should return an X509TrustManager for valid keystore" {
+      val (path, password) = createTempKeyStore()
+      try {
+        val trustManager = SslSettings.getTrustManager(path, password)
+        trustManager.shouldBeInstanceOf<X509TrustManager>()
+      } finally {
+        File(path).delete()
+      }
+    }
+
     // ==================== Type Verification Tests ====================
     // These tests verify the return types of the methods when they succeed
 
@@ -135,5 +172,17 @@ class SslSettingsTest : StringSpec() {
       trustManagers.isNotEmpty() shouldBe true
       trustManagers[0].shouldBeInstanceOf<X509TrustManager>()
     }
+  }
+
+  // Creates an empty keystore in a temp file and returns its path and password.
+  private fun createTempKeyStore(): Pair<String, String> {
+    val password = "test-password"
+    val tmpFile = File.createTempFile("ssl-settings-test", ".jks")
+    tmpFile.deleteOnExit()
+    KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+      load(null, null)
+      FileOutputStream(tmpFile).use { store(it, password.toCharArray()) }
+    }
+    return tmpFile.absolutePath to password
   }
 }

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -276,37 +276,11 @@ class BaseOptionsTest : StringSpec() {
     // to exercise the URL branch and the JSON/CONF syntax detection.
 
     "should load conf config from http url" {
-      val server = embeddedServer(ServerCIO, port = 0) {
-        routing {
-          get("/config.conf") {
-            call.respondText("proxy { http.port = 4444 }")
-          }
-        }
-      }
-      try {
-        val port = server.startAndAwaitReady()
-        val options = ProxyOptions(listOf("-c", "http://localhost:$port/config.conf"))
-        options.proxyPort shouldBe 4444
-      } finally {
-        server.stop(0, 0)
-      }
+      verifyHttpConfigLoads("config.conf", "proxy { http.port = 4444 }", expectedPort = 4444)
     }
 
     "should load json config from http url" {
-      val server = embeddedServer(ServerCIO, port = 0) {
-        routing {
-          get("/config.json") {
-            call.respondText("""{ "proxy": { "http": { "port": 3333 } } }""")
-          }
-        }
-      }
-      try {
-        val port = server.startAndAwaitReady()
-        val options = ProxyOptions(listOf("-c", "http://localhost:$port/config.json"))
-        options.proxyPort shouldBe 3333
-      } finally {
-        server.stop(0, 0)
-      }
+      verifyHttpConfigLoads("config.json", """{ "proxy": { "http": { "port": 3333 } } }""", expectedPort = 3333)
     }
 
     "dynamic params should strip surrounding quotes" {
@@ -539,6 +513,29 @@ class BaseOptionsTest : StringSpec() {
         envVarValue = "true",
         configDefault = true,
       ).shouldBeFalse()
+    }
+  }
+
+  // Serves the given config body over HTTP at /<fileName> and asserts the loaded proxy port.
+  // Exercises the URL branch of readConfig() and the suffix-based syntax detection.
+  private suspend fun verifyHttpConfigLoads(
+    fileName: String,
+    body: String,
+    expectedPort: Int,
+  ) {
+    val server = embeddedServer(ServerCIO, port = 0) {
+      routing {
+        get("/$fileName") {
+          call.respondText(body)
+        }
+      }
+    }
+    try {
+      val port = server.startAndAwaitReady()
+      val options = ProxyOptions(listOf("-c", "http://localhost:$port/$fileName"))
+      options.proxyPort shouldBe expectedPort
+    } finally {
+      server.stop(0, 0)
     }
   }
 }

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -27,12 +27,17 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeEmpty
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
 import io.prometheus.agent.AgentOptions
 import io.prometheus.common.BaseOptions.Companion.resolveBoolean
 import io.prometheus.proxy.ProxyOptions
 import java.io.File
 import java.net.URI
 import kotlin.io.path.createTempDirectory
+import io.ktor.server.cio.CIO as ServerCIO
 
 class BaseOptionsTest : StringSpec() {
   init {
@@ -262,6 +267,45 @@ class BaseOptionsTest : StringSpec() {
         options.proxyPort shouldBe 6666
       } finally {
         tempDir.deleteRecursively()
+      }
+    }
+
+    // ==================== Config File Loading over HTTP (URL branch) ====================
+    // The file-based tests above go through ConfigFactory.parseFileAnySyntax, which skips
+    // the URL branch of readConfig() and getConfigSyntax(). These serve a config over HTTP
+    // to exercise the URL branch and the JSON/CONF syntax detection.
+
+    "should load conf config from http url" {
+      val server = embeddedServer(ServerCIO, port = 0) {
+        routing {
+          get("/config.conf") {
+            call.respondText("proxy { http.port = 4444 }")
+          }
+        }
+      }
+      try {
+        val port = server.startAndAwaitReady()
+        val options = ProxyOptions(listOf("-c", "http://localhost:$port/config.conf"))
+        options.proxyPort shouldBe 4444
+      } finally {
+        server.stop(0, 0)
+      }
+    }
+
+    "should load json config from http url" {
+      val server = embeddedServer(ServerCIO, port = 0) {
+        routing {
+          get("/config.json") {
+            call.respondText("""{ "proxy": { "http": { "port": 3333 } } }""")
+          }
+        }
+      }
+      try {
+        val port = server.startAndAwaitReady()
+        val options = ProxyOptions(listOf("-c", "http://localhost:$port/config.json"))
+        options.proxyPort shouldBe 3333
+      } finally {
+        server.stop(0, 0)
       }
     }
 


### PR DESCRIPTION
## Summary

Improves test coverage for two areas that had untested branches:

- **`SslSettings`** (78% → 100% line coverage): the existing tests only exercised the `FileNotFoundException` paths. Added tests against a real (empty) temp keystore that cover the success bodies of `getTrustManagerFactory`, `getSslContext`, and `getTrustManager`.
- **`BaseOptions`** (77% → 85%): the config-file tests went through `ConfigFactory.parseFileAnySyntax`, which skips the URL branch of `readConfig()` and `getConfigSyntax()`. Added tests that serve `.conf` and `.json` config over an embedded Ktor HTTP server, exercising the URL branch and JSON/CONF syntax detection.

The remaining uncovered lines in `BaseOptions` are the `exitProcess(1)` error branches, which can't be tested in-process without killing the JVM.

## Verification

- `./gradlew test --tests SslSettingsTest --tests BaseOptionsTest` — pass
- `./gradlew lintKotlinTest detekt` — clean
- `koverXmlReport` confirms `SslSettings` 100%, `BaseOptions` 85%

🤖 Generated with [Claude Code](https://claude.com/claude-code)