### PR TITLE
Raise embedded test server readiness timeout to absorb suite load

### DIFF
--- a/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
+++ b/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
@@ -33,7 +33,14 @@ import kotlin.time.TimeSource.Monotonic
 // while the routing pipeline is still being installed, surfacing as EOFException or empty
 // bodies on the next real request. Sending a real HTTP/1.0 line and waiting for the "HTTP/"
 // reply means routing is live before we hand back the port.
-suspend fun EmbeddedServer<*, *>.startAndAwaitReady(timeout: Duration = 5.seconds): Int {
+//
+// The deadline is generous because it is only a ceiling, not a wait: the loop returns the
+// instant the server responds, so a healthy server still returns in milliseconds. The extra
+// headroom absorbs CPU contention during a full test-suite run, where many embedded servers
+// and the gRPC harness compete for cores and a fresh CIO server can take several seconds to
+// start answering. A tighter default (5s) caused intermittent "did not start serving HTTP"
+// failures on whichever embedded-server test happened to run during a load spike.
+suspend fun EmbeddedServer<*, *>.startAndAwaitReady(timeout: Duration = 30.seconds): Int {
   start(wait = false)
   val port = engine.resolvedConnectors().first().port
   val deadline = Monotonic.markNow() + timeout


### PR DESCRIPTION
## Summary

`startAndAwaitReady()` (in `EmbeddedTestServer.kt`) defaulted to a **5s** readiness deadline, shared by ~35 embedded-server test call sites. Under full-suite CPU contention — the gRPC harness plus many embedded servers competing for cores — a fresh CIO server can take several seconds to install its routing pipeline and answer the readiness probe, so the poll exhausts the 5s deadline and throws `did not start serving HTTP`. It surfaced intermittently on whichever embedded-server test happened to run during a load spike (recently `BaseOptionsTest`).

## Fix

Raised the default deadline `5s → 30s`. The deadline is only a **ceiling, not a wait**: the poll loop returns the instant the server responds, so a healthy server still returns in milliseconds and the happy path is unchanged. The extra headroom absorbs load-induced startup delay. No test asserts a fast failure of this helper, so there is no regression risk.

This is fixed in the shared helper rather than at one call site, since all ~35 callers share the same default and the same latent flake.

## Verification

- `./gradlew test` for all four caller classes — `BaseOptionsTest`, `AgentHttpServiceTest`, `AgentHttpServiceHeaderTest`, `ProxyHttpConfigTest` — pass
- `./gradlew lintKotlinTest` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)