### PR TITLE
Use prebuilt Liberica JRE base image for proxy/agent containers

### DIFF
--- a/etc/docker/agent.df
+++ b/etc/docker/agent.df
@@ -1,6 +1,5 @@
-FROM alpine
+FROM bellsoft/liberica-openjre-alpine:17
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
-RUN apk add openjdk17-jre
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
 ENV APPLICATION_USER=prometheus

--- a/etc/docker/proxy.df
+++ b/etc/docker/proxy.df
@@ -1,6 +1,5 @@
-FROM alpine
+FROM bellsoft/liberica-openjre-alpine:17
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
-RUN apk add openjdk17-jre
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
 ENV APPLICATION_USER=prometheus


### PR DESCRIPTION
## Problem

`make container-tests` intermittently fails while Testcontainers builds the proxy/agent images:

```
Could not build image: The command '/bin/sh -c apk add openjdk17-jre' returned a non-zero code: 1
```

`etc/docker/proxy.df` and `agent.df` used `FROM alpine` + `RUN apk add openjdk17-jre`. The package still resolves on current Alpine, but it pulls the **full** JRE (27 packages, ~193 MB, including fonts/X11/libjpeg) from the Alpine mirror at build time. Building both images back-to-back makes that heavy network step stall or fail intermittently, so the build aborts with a non-zero exit — flaky infrastructure, not a logic error.

## Fix

Replace `FROM alpine` + `apk add` with the prebuilt `bellsoft/liberica-openjre-alpine:17` base image in both Dockerfiles. No apk download at build time — the base layer is pulled once and cached, so builds are fast and reliable.

Why Liberica specifically:
- **Multi-arch (amd64 + arm64)** — `eclipse-temurin:17-jre-alpine`, the obvious choice, is amd64-only and won't run on Apple Silicon.
- **True JRE** (small), same OpenJDK 17 LTS.
- **Alpine-based**, so the existing busybox `adduser` step is unchanged.

Note: these are the project's published production images, so this also changes the shipped runtime from Alpine's OpenJDK build to BellSoft Liberica (both OpenJDK 17 LTS).

## Verification

- Liberica image runs on arm64: Alpine 3.23.4, Java 17.0.19, `adduser` works.
- Built **both** `proxy.df` and `agent.df` from the produced jars — both succeed.
- Ran the proxy image: it boots and reports `Version: 3.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)