### PR TITLE
Address code-review findings across agent, proxy, and common

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ To scrape HTTPS endpoints with a self-signed certificate:
 java -jar prometheus-agent.jar --trust_all_x509 --config myconfig.conf
 ```
 
-**⚠️ Security Note:** Only use `--trust_all_x509` in development/testing environments.
+**⚠️ Security Note:** Only use `--trust_all_x509` in development/testing environments. Its scope is
+process-global and all-or-nothing: enabling it to reach a single self-signed endpoint disables certificate
+validation for **every** HTTPS target the agent scrapes. There is no per-target trust override.
 
 ## 🔧 Troubleshooting
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -97,3 +97,6 @@ of its size).
 - [EnvVars][io.prometheus.common.EnvVars] is a typed enumeration of all environment variable
   names recognized by the Proxy and Agent, with `getEnv()` overloads for `String`, `Boolean`,
   `Int`, and `Long` that reject malformed values.
+- [ConfigLoadException][io.prometheus.common.ConfigLoadException] is thrown when a configuration
+  file or URL cannot be loaded and the process was started with `exitOnMissingConfig = false`
+  (embedded mode). Embedders can catch it so a config failure does not terminate the host JVM.

--- a/etc/docker/agent.df
+++ b/etc/docker/agent.df
@@ -1,6 +1,5 @@
-FROM alpine
+FROM bellsoft/liberica-openjre-alpine:17
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
-RUN apk add openjdk17-jre
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
 ENV APPLICATION_USER=prometheus

--- a/etc/docker/proxy.df
+++ b/etc/docker/proxy.df
@@ -1,6 +1,5 @@
-FROM alpine
+FROM bellsoft/liberica-openjre-alpine:17
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
-RUN apk add openjdk17-jre
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
 ENV APPLICATION_USER=prometheus

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -328,7 +328,10 @@ class Agent(
                   try {
                     // The url fetch occurs here during scrapeRequestAction.invoke()
                     val scrapeResponse = scrapeRequestAction.invoke()
-                    connectionContext.sendScrapeResults(scrapeResponse)
+                    // A false return means the result was dropped because the connection closed
+                    // mid-scrape; surface it as a metric so the loss is observable, not silent.
+                    if (!connectionContext.sendScrapeResults(scrapeResponse))
+                      metrics { scrapeResultCount.labels(launchId, "dropped").inc() }
                   } finally {
                     semaphore.release()
                     decrementBacklog(1)

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -332,6 +332,13 @@ class Proxy(
 
     pathManager.removeFromPathManager(agentId, reason)
     scrapeRequestManager.failAllScrapeRequests(agentId, "Agent disconnected: $reason")
+    // Proactively reclaim any in-flight chunked-transfer buffers for this agent (the requests
+    // themselves were just failed above) rather than waiting for each stream's orphan sweep.
+    agentContextManager.removeChunkedContextsForAgent(agentId)
+      .also { reclaimed ->
+        if (reclaimed.isNotEmpty())
+          logger.info { "Reclaimed ${reclaimed.size} in-flight chunked context(s) for agentId: $agentId ($reason)" }
+      }
     return agentContextManager.removeFromContextManager(agentId, reason)
   }
 

--- a/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
@@ -51,16 +51,24 @@ internal class AgentConnectionContext(
     scrapeRequestActionsChannel.send(scrapeRequestAction)
   }
 
-  fun sendScrapeResults(scrapeResults: ScrapeResults) {
-    // Use trySend() instead of send() to avoid ClosedSendChannelException when the
-    // connection is closed while in-flight scrape coroutines are still completing.
-    // For an UNLIMITED channel, trySend() always succeeds immediately if open.
-    // If the channel is closed (disconnect), we log a warning instead of throwing,
-    // which prevents the exception from cancelling sibling scrape coroutines.
+  /**
+   * Offers a computed [scrapeResults] to the outbound channel.
+   *
+   * Uses `trySend()` instead of `send()` to avoid `ClosedSendChannelException` when the connection
+   * is closed while in-flight scrape coroutines are still completing. For an UNLIMITED channel,
+   * `trySend()` succeeds immediately while the channel is open. If the channel is closed (a
+   * disconnect mid-scrape), the result is dropped with a warning rather than throwing, which would
+   * otherwise cancel sibling scrape coroutines.
+   *
+   * @return `true` if the result was accepted into the channel, `false` if it was dropped because
+   *   the connection had already closed. Callers can use the return value to record a metric.
+   */
+  fun sendScrapeResults(scrapeResults: ScrapeResults): Boolean {
     val result = scrapeResultsChannel.trySend(scrapeResults)
     if (result.isClosed) {
       logger.warn { "Scrape result for scrapeId ${scrapeResults.srScrapeId} dropped: connection closed" }
     }
+    return result.isSuccess
   }
 
   fun close(): Int {

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -209,8 +209,14 @@ internal class AgentGrpcService(
       agent.metrics { connectCount.labels(agent.launchId, "success").inc() }
       true
     }.getOrElse { e ->
+      // Re-throw JVM Errors (OutOfMemoryError, StackOverflowError, etc.) so they propagate to
+      // handleConnectionFailure() and terminate the agent instead of being collapsed into a
+      // routine "couldn't connect, will retry". Only transient connection failures return false.
+      if (e is Error)
+        throw e
       agent.metrics { connectCount.labels(agent.launchId, "failure").inc() }
-      logger.error {
+      // Pass the throwable so a stack trace is captured for diagnosis.
+      logger.error(e) {
         "Cannot connect to proxy at ${agent.proxyHost} using ${tlsContext.desc()} - ${e.simpleClassName}: ${e.message}"
       }
       false

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -248,8 +248,9 @@ internal class AgentHttpService(
         requestTimeout = timeoutSecs.seconds.inWholeMilliseconds
 
         if (agent.options.trustAllX509Certificates) {
+          // Note: this disables certificate validation for EVERY HTTPS scrape target this agent
+          // talks to, not just a specific one (the setting is process-global, all-or-nothing).
           https {
-            // trustManager = SslSettings.getTrustManager()
             trustManager = TrustAllX509TrustManager
           }
         }

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -239,15 +239,11 @@ internal class AgentHttpService(
     HttpClient(CIO) {
       expectSuccess = false
       engine {
-        // If internal.cioTimeoutSecs is set to a non-default and httpClientTimeoutSecs is set to the default, then use
-        // internal.cioTimeoutSecs value. Otherwise, use httpClientTimeoutSecs.
         val timeoutSecs =
-          if (agent.configVals.agent.internal.cioTimeoutSecs != DEFAULT_HTTP_TIMEOUT_SECS &&
-            agent.options.httpClientTimeoutSecs == DEFAULT_HTTP_TIMEOUT_SECS
+          resolveTimeoutSecs(
+            cioTimeoutSecs = agent.configVals.agent.internal.cioTimeoutSecs,
+            httpClientTimeoutSecs = agent.options.httpClientTimeoutSecs,
           )
-            agent.configVals.agent.internal.cioTimeoutSecs
-          else
-            agent.options.httpClientTimeoutSecs
 
         requestTimeout = timeoutSecs.seconds.inWholeMilliseconds
 
@@ -301,6 +297,23 @@ internal class AgentHttpService(
     // cioTimeoutSecs was explicitly overridden while clientTimeoutSecs was left at its default.
     // MUST stay in sync with the defaults in config/config.conf.
     private const val DEFAULT_HTTP_TIMEOUT_SECS = 90
+
+    /**
+     * Resolves the effective HTTP client request timeout.
+     *
+     * Honors the deprecated `internal.cioTimeoutSecs` only when it was explicitly overridden (set
+     * to a non-[default] value) while the replacement `http.clientTimeoutSecs` was left at its
+     * [default]. In every other case `http.clientTimeoutSecs` wins.
+     */
+    internal fun resolveTimeoutSecs(
+      cioTimeoutSecs: Int,
+      httpClientTimeoutSecs: Int,
+      default: Int = DEFAULT_HTTP_TIMEOUT_SECS,
+    ): Int =
+      if (cioTimeoutSecs != default && httpClientTimeoutSecs == default)
+        cioTimeoutSecs
+      else
+        httpClientTimeoutSecs
 
     private const val INVALID_PATH_MSG = "invalid_path"
     private const val SUCCESS_MSG = "success"

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -43,7 +43,6 @@ import io.prometheus.common.EnvVars.SCRAPE_TIMEOUT_SECS
 import io.prometheus.common.EnvVars.TRUST_ALL_X509_CERTIFICATES
 import io.prometheus.common.EnvVars.UNARY_DEADLINE_SECS
 import io.prometheus.common.Utils.parseHostPort
-import io.prometheus.common.Utils.setLogLevel
 import kotlin.time.Duration.Companion.seconds
 
 class AgentOptions(
@@ -107,14 +106,21 @@ class AgentOptions(
     private set
 
   /**
-   * Threshold above which a scrape response is split into chunked gRPC messages, expressed in **kilobytes**
-   * on input. After resolution, the field is converted in-place to **bytes** for runtime use; the
-   * `chunkContentSizeBytes` name reflects that final unit.
+   * Threshold (in **kilobytes**) above which a scrape response is split into chunked gRPC messages; also the
+   * chunk buffer size. This is the raw `--chunk` input value and keeps the unit of the config key/env var.
    *
    * `-1` means "fall back to [CHUNK_CONTENT_SIZE_KBS] env var, then `agent.chunkContentSizeKbs` (default `32` KB)".
-   * Validated `> 0` and that the resulting byte value fits in [Int].
+   * Validated `> 0`. The byte value used at runtime is the derived [chunkContentSizeBytes].
    */
   @Parameter(names = ["--chunk"], description = "Threshold for chunking content to Proxy and buffer size (KBs)")
+  var chunkContentSizeKbs = -1
+    private set
+
+  /**
+   * Chunking threshold and buffer size in **bytes**, derived once from [chunkContentSizeKbs] during option
+   * resolution (`chunkContentSizeKbs * 1024`). This is the value read at runtime by the gRPC client; it is
+   * `-1` until [chunkContentSizeKbs] has been resolved. Validated to fit in [Int].
+   */
   var chunkContentSizeBytes = -1
     private set
 
@@ -131,6 +137,9 @@ class AgentOptions(
    * scrape targets — no hostname or chain validation. Intended only for self-signed internal endpoints during
    * development; logs a warning at startup. Resolved from CLI → [TRUST_ALL_X509_CERTIFICATES] env var →
    * `agent.http.enableTrustAllX509Certificates` config.
+   *
+   * Scope is **process-global and all-or-nothing**: enabling it to reach one self-signed endpoint disables
+   * validation for *every* HTTPS target this agent scrapes. There is no per-target trust override.
    */
   @Parameter(names = ["--trust_all_x509"], description = "Disable SSL verification for https agent endpoints")
   var trustAllX509Certificates = false
@@ -257,13 +266,14 @@ class AgentOptions(
       scrapeMaxRetries = SCRAPE_MAX_RETRIES.getEnv(agentConfigVals.scrapeMaxRetries)
     logger.info { "scrapeMaxRetries: $scrapeMaxRetries" }
 
-    if (chunkContentSizeBytes == -1)
-      chunkContentSizeBytes = CHUNK_CONTENT_SIZE_KBS.getEnv(agentConfigVals.chunkContentSizeKbs)
-    require(chunkContentSizeBytes > 0) { "chunkContentSizeKbs must be > 0: ($chunkContentSizeBytes)" }
-    // Convert KB value to bytes with overflow protection
-    val chunkSizeAsBytes = chunkContentSizeBytes.toLong() * 1024
+    if (chunkContentSizeKbs == -1)
+      chunkContentSizeKbs = CHUNK_CONTENT_SIZE_KBS.getEnv(agentConfigVals.chunkContentSizeKbs)
+    require(chunkContentSizeKbs > 0) { "chunkContentSizeKbs must be > 0: ($chunkContentSizeKbs)" }
+    logger.info { "chunkContentSizeKbs: $chunkContentSizeKbs" }
+    // Derive the byte value once, with overflow protection, into the runtime field.
+    val chunkSizeAsBytes = chunkContentSizeKbs.toLong() * 1024
     require(chunkSizeAsBytes <= Int.MAX_VALUE) {
-      "chunkContentSizeKbs value $chunkContentSizeBytes is too large (max: ${Int.MAX_VALUE / 1024})"
+      "chunkContentSizeKbs value $chunkContentSizeKbs is too large (max: ${Int.MAX_VALUE / 1024})"
     }
     chunkContentSizeBytes = chunkSizeAsBytes.toInt()
     logger.info { "chunkContentSizeBytes: $chunkContentSizeBytes" }
@@ -292,19 +302,19 @@ class AgentOptions(
     logger.info { "grpc.unaryDeadlineSecs: $unaryDeadlineSecs" }
 
     agentConfigVals.apply {
-      assignKeepAliveTimeSecs(grpc.keepAliveTimeSecs)
-      assignKeepAliveTimeoutSecs(grpc.keepAliveTimeoutSecs)
-      assignAdminEnabled(admin.enabled)
-      assignAdminPort(admin.port)
-      assignMetricsEnabled(metrics.enabled)
-      assignMetricsPort(metrics.port)
-      assignTransportFilterDisabled(transportFilterDisabled)
-      assignDebugEnabled(admin.debugEnabled)
-
-      assignCertChainFilePath(tls.certChainFilePath)
-      assignPrivateKeyFilePath(tls.privateKeyFilePath)
-      assignTrustCertCollectionFilePath(tls.trustCertCollectionFilePath)
-      validateTlsConfig()
+      assignCommonOptions(
+        keepAliveTimeSecs = grpc.keepAliveTimeSecs,
+        keepAliveTimeoutSecs = grpc.keepAliveTimeoutSecs,
+        adminEnabled = admin.enabled,
+        adminPort = admin.port,
+        metricsEnabled = metrics.enabled,
+        metricsPort = metrics.port,
+        transportFilterDisabled = transportFilterDisabled,
+        debugEnabled = admin.debugEnabled,
+        certChainFilePath = tls.certChainFilePath,
+        privateKeyFilePath = tls.privateKeyFilePath,
+        trustCertCollectionFilePath = tls.trustCertCollectionFilePath,
+      )
 
       logger.info { "scrapeTimeoutSecs: ${scrapeTimeoutSecs.seconds}" }
       logger.info { "agent.internal.cioTimeoutSecs: ${internal.cioTimeoutSecs.seconds}" }
@@ -316,14 +326,7 @@ class AgentOptions(
       logger.info { "agent.internal.heartbeatMaxInactivitySecs: $inactivityVal" }
     }
 
-    if (logLevel.isEmpty())
-      logLevel = AGENT_LOG_LEVEL.getEnv(agentConfigVals.logLevel)
-    if (logLevel.isNotEmpty()) {
-      logger.info { "agent.logLevel: $logLevel" }
-      setLogLevel("agent", logLevel)
-    } else {
-      logger.info { "agent.logLevel: info" }
-    }
+    assignLogLevel("agent", AGENT_LOG_LEVEL, agentConfigVals.logLevel)
   }
 
   private fun assignHttpClientConfigVals(agentConfigVals: ConfigVals.Agent) {

--- a/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
@@ -48,30 +48,14 @@ internal class AgentPathManager(
 
   suspend fun pathMapSize(): Int = agent.grpcService.pathMapSize()
 
-  private val pathConfigs =
+  private val pathConfigs: List<PathConfig> =
     agentConfigVals.pathConfigs
-      .map {
-        mapOf(
-          NAME to """"${it.name}"""",
-          PATH to it.path,
-          URL to it.url,
-          LABELS to it.labels,
-        )
-      }
+      .map { PathConfig(name = it.name, path = it.path, url = it.url, labels = it.labels) }
       .onEach {
-        logger.info { "Proxy path /${it[PATH]} will be assigned to ${it[URL]} with labels ${it[LABELS]}" }
+        logger.info { "Proxy path /${it.path} will be assigned to ${it.url} with labels ${it.labels}" }
       }
 
-  suspend fun registerPaths() =
-    pathConfigs.forEach {
-      val path = it[PATH]
-      val url = it[URL]
-      val labels = it[LABELS]
-      if (path != null && url != null && labels != null)
-        registerPath(path, url, labels)
-      else
-        logger.error { "Null path/url/labels value: $path/$url/$labels" }
-    }
+  suspend fun registerPaths() = pathConfigs.forEach { registerPath(it.path, it.url, it.labels) }
 
   suspend fun registerPath(
     pathVal: String,
@@ -107,18 +91,25 @@ internal class AgentPathManager(
   }
 
   fun toPlainText(): String {
-    val maxName = pathConfigs.maxOfOrNull { it[NAME].orEmpty().length } ?: 0
-    val maxPath = pathConfigs.maxOfOrNull { it[PATH].orEmpty().length } ?: 0
+    val maxName = pathConfigs.maxOfOrNull { it.quotedName.length } ?: 0
+    val maxPath = pathConfigs.maxOfOrNull { it.path.length } ?: 0
     return "Agent Path Configs:\n" + "Name".padEnd(maxName + 1) + "Path".padEnd(maxPath + 2) + "URL\n" +
-      pathConfigs.joinToString("\n") { c -> "${c[NAME]?.padEnd(maxName)} /${c[PATH]?.padEnd(maxPath)} ${c[URL]}" }
+      pathConfigs.joinToString("\n") { c -> "${c.quotedName.padEnd(maxName)} /${c.path.padEnd(maxPath)} ${c.url}" }
   }
 
   companion object {
     private val logger = logger {}
-    private const val NAME = "name"
-    private const val PATH = "path"
-    private const val URL = "url"
-    private const val LABELS = "labels"
+  }
+
+  // Strongly-typed view of a single `agent.pathConfigs` entry, replacing the prior magic-string map.
+  private data class PathConfig(
+    val name: String,
+    val path: String,
+    val url: String,
+    val labels: String,
+  ) {
+    // Name wrapped in double-quotes for the toPlainText() display, preserving the original format.
+    val quotedName: String get() = "\"$name\""
   }
 
   data class PathContext(

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -63,6 +63,12 @@ internal class HttpClientCache(
   private val accessMutex = Mutex()
   private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+  // Set to true (under accessMutex) by close(). Once closed, getOrCreateClient() rejects new
+  // requests, preventing an in-flight scrape racing shutdown from creating and caching a fresh
+  // HttpClient into the now-dead cache (whose cleanup coroutine is cancelled) — which would leak
+  // that client until JVM exit. Especially relevant for embedded agents restarted in a host JVM.
+  private var closed = false
+
   // Clients removed via removeEntry() that are not in use and need to be closed.
   // Only accessed while holding accessMutex. Drained after releasing the mutex
   // so that potentially slow HttpClient.close() calls don't block other cache operations.
@@ -150,6 +156,7 @@ internal class HttpClientCache(
 
     val (entry, clientsToClose) =
       accessMutex.withLock {
+        check(!closed) { "HttpClientCache is closed" }
         val result = cache[cacheKey]?.let { existing ->
           if (isEntryValid(existing, now)) {
             existing.lastAccessedAt = now
@@ -287,6 +294,9 @@ internal class HttpClientCache(
       clientsToClose += drainPendingCloses()
       cache.clear()
       accessOrder.clear()
+      // Set the terminal flag in the same critical section that clears the map, so there is no
+      // window where getOrCreateClient() could repopulate the cache after this point.
+      closed = true
     }
     // Close clients outside the lock to avoid blocking
     clientsToClose.forEach { it.close() }

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -388,42 +388,52 @@ abstract class BaseOptions protected constructor(
     fallback: Config,
     exitOnMissingConfig: Boolean,
   ): Config {
-    when {
-      configName.isBlank() -> {
-        if (exitOnMissingConfig) {
-          logger.error { $$"A configuration file or url must be specified with --config or $$$envConfig" }
-          exitProcess(1)
+    // Captures the parse failure (if any) so the post-when handling can honor exitOnMissingConfig.
+    // The success paths return early from inside runCatchingCancellable.
+    val failureCause: Throwable? =
+      when {
+        configName.isBlank() -> {
+          if (exitOnMissingConfig) {
+            logger.error { $$"A configuration file or url must be specified with --config or $$$envConfig" }
+            exitProcess(1)
+          }
+          return fallback
         }
-        return fallback
+
+        configName.isUrlPrefix() -> {
+          runCatchingCancellable {
+            val configSyntax = getConfigSyntax(configName)
+            return ConfigFactory
+              .parseURL(URI(configName).toURL(), configParseOptions.setSyntax(configSyntax))
+              .withFallback(fallback)
+          }.exceptionOrNull()
+            ?.also { e ->
+              if (e.cause is FileNotFoundException)
+                logger.error { "Invalid config url: $configName" }
+              else
+                logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
+            }
+        }
+
+        else -> {
+          runCatchingCancellable {
+            return ConfigFactory.parseFileAnySyntax(File(configName), configParseOptions).withFallback(fallback)
+          }.exceptionOrNull()
+            ?.also { e ->
+              if (e.cause is FileNotFoundException)
+                logger.error { "Invalid config filename: $configName" }
+              else
+                logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
+            }
+        }
       }
 
-      configName.isUrlPrefix() -> {
-        runCatchingCancellable {
-          val configSyntax = getConfigSyntax(configName)
-          return ConfigFactory
-            .parseURL(URI(configName).toURL(), configParseOptions.setSyntax(configSyntax))
-            .withFallback(fallback)
-        }.onFailure { e ->
-          if (e.cause is FileNotFoundException)
-            logger.error { "Invalid config url: $configName" }
-          else
-            logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
-        }
-      }
-
-      else -> {
-        runCatchingCancellable {
-          return ConfigFactory.parseFileAnySyntax(File(configName), configParseOptions).withFallback(fallback)
-        }.onFailure { e ->
-          if (e.cause is FileNotFoundException)
-            logger.error { "Invalid config filename: $configName" }
-          else
-            logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
-        }
-      }
-    }
-
-    exitProcess(1)
+    // A parse failure reached here. In standalone mode terminate the process; in embedded mode
+    // (exitOnMissingConfig == false) throw so the host application can recover instead of dying.
+    if (exitOnMissingConfig)
+      exitProcess(1)
+    else
+      throw ConfigLoadException("Unable to load configuration from '$configName'", failureCause)
   }
 
   internal companion object {

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -343,6 +343,59 @@ abstract class BaseOptions protected constructor(
     logger.info { "trustCertCollectionFilePath: $trustCertCollectionFilePath" }
   }
 
+  /**
+   * Resolves the options common to both Proxy and Agent in a single, shared order, ending with
+   * [validateTlsConfig]. Each argument is the role-specific config default; the underlying `assign*`
+   * helpers apply CLI > env > config precedence. Centralizing this avoids the two subclasses drifting
+   * out of sync when a common option is added or reordered.
+   */
+  @Suppress("LongParameterList")
+  protected fun assignCommonOptions(
+    keepAliveTimeSecs: Long,
+    keepAliveTimeoutSecs: Long,
+    adminEnabled: Boolean,
+    adminPort: Int,
+    metricsEnabled: Boolean,
+    metricsPort: Int,
+    transportFilterDisabled: Boolean,
+    debugEnabled: Boolean,
+    certChainFilePath: String,
+    privateKeyFilePath: String,
+    trustCertCollectionFilePath: String,
+  ) {
+    assignKeepAliveTimeSecs(keepAliveTimeSecs)
+    assignKeepAliveTimeoutSecs(keepAliveTimeoutSecs)
+    assignAdminEnabled(adminEnabled)
+    assignAdminPort(adminPort)
+    assignMetricsEnabled(metricsEnabled)
+    assignMetricsPort(metricsPort)
+    assignTransportFilterDisabled(transportFilterDisabled)
+    assignDebugEnabled(debugEnabled)
+    assignCertChainFilePath(certChainFilePath)
+    assignPrivateKeyFilePath(privateKeyFilePath)
+    assignTrustCertCollectionFilePath(trustCertCollectionFilePath)
+    validateTlsConfig()
+  }
+
+  /**
+   * Resolves [logLevel] from CLI > [envVar] > [configDefault] and applies it. When the resolved value is
+   * empty the level from `logback.xml` is left in place. [role] is used only for log/exception text.
+   */
+  protected fun assignLogLevel(
+    role: String,
+    envVar: EnvVars,
+    configDefault: String,
+  ) {
+    if (logLevel.isEmpty())
+      logLevel = envVar.getEnv(configDefault)
+    if (logLevel.isNotEmpty()) {
+      logger.info { "$role.logLevel: $logLevel" }
+      Utils.setLogLevel(role, logLevel)
+    } else {
+      logger.info { "$role.logLevel: info" }
+    }
+  }
+
   private fun readConfig(
     envConfig: String,
     exitOnMissingConfig: Boolean,

--- a/src/main/kotlin/io/prometheus/common/ConfigLoadException.kt
+++ b/src/main/kotlin/io/prometheus/common/ConfigLoadException.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.common
+
+/**
+ * Thrown when a configuration file or URL cannot be loaded or parsed and the process was started
+ * with `exitOnMissingConfig = false` (the embedded mode used by
+ * [Agent.startAsyncAgent][io.prometheus.Agent.Companion.startAsyncAgent]).
+ *
+ * In standalone mode (`exitOnMissingConfig = true`) a config-load failure terminates the process
+ * via `exitProcess(1)` instead. Embedders that host an Agent inside their own JVM should catch this
+ * exception so a transient remote-config fetch failure or a malformed config file does not kill the
+ * host application.
+ *
+ * @param message a human-readable description of which config source failed to load
+ * @param cause the underlying failure (e.g. a parse error or `FileNotFoundException`), if any
+ */
+class ConfigLoadException(
+  message: String,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -31,12 +31,47 @@ import java.net.URLDecoder
 import kotlin.text.Charsets.UTF_8
 
 internal object Utils {
+  private const val REDACTED = "***"
+
   internal fun getVersionDesc(asJson: Boolean = false): String = Proxy::class.versionDesc(asJson)
 
   fun decodeParams(encodedQueryParams: String): String =
     if (encodedQueryParams.isNotBlank()) "?${URLDecoder.decode(encodedQueryParams, UTF_8)}" else ""
 
-  fun sanitizeUrl(url: String): String = url.replace(Regex("(://)[^@/?#]+@"), "$1***@")
+  /**
+   * Masks secrets in a URL before it is logged or echoed back to Prometheus.
+   *
+   * Redacts both the userinfo component (`user:pass@host` becomes `***@host`) and every
+   * query-parameter value (`?token=secret&job=x` becomes `?token=***&job=***`). Query values are
+   * redacted unconditionally rather than via a key allowlist, since custom secret parameter names
+   * (api_key, access_token, sig, …) cannot be enumerated in advance. The fragment is preserved.
+   */
+  fun sanitizeUrl(url: String): String {
+    val userRedacted = url.replace(Regex("(://)[^@/?#]+@"), "$1***@")
+    val queryStart = userRedacted.indexOf('?')
+    if (queryStart < 0) return userRedacted
+    val prefix = userRedacted.substring(0, queryStart + 1)
+    val afterQuery = userRedacted.substring(queryStart + 1)
+    val fragmentStart = afterQuery.indexOf('#')
+    val query = if (fragmentStart < 0) afterQuery else afterQuery.substring(0, fragmentStart)
+    val fragment = if (fragmentStart < 0) "" else afterQuery.substring(fragmentStart)
+    return prefix + redactQueryValues(query) + fragment
+  }
+
+  /**
+   * Masks the values of a bare URL-encoded query string (without a leading `?`), preserving the
+   * keys. Used when logging Prometheus-supplied query params that may carry credentials.
+   */
+  fun sanitizeQueryParams(encodedQueryParams: String): String =
+    if (encodedQueryParams.isBlank()) encodedQueryParams else redactQueryValues(encodedQueryParams)
+
+  private fun redactQueryValues(query: String): String =
+    query
+      .split("&")
+      .joinToString("&") { param ->
+        val eq = param.indexOf('=')
+        if (eq < 0) param else param.substring(0, eq + 1) + REDACTED
+      }
 
   fun appendQueryParams(
     baseUrl: String,

--- a/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
@@ -75,6 +75,20 @@ internal class AgentContextManager(
 
   fun removeChunkedContext(scrapeId: Long): ChunkedContext? = chunkedContextMap.remove(scrapeId)
 
+  /**
+   * Removes every in-flight [ChunkedContext] owned by [agentId] (e.g. when the agent disconnects or is
+   * evicted), reclaiming their buffered output streams immediately instead of waiting for each chunked
+   * stream's own orphan sweep. The corresponding scrape requests are failed separately by
+   * [ScrapeRequestManager.failAllScrapeRequests]; this only frees the chunk buffers.
+   *
+   * @return the scrape IDs that were removed
+   */
+  fun removeChunkedContextsForAgent(agentId: String): List<Long> {
+    val scrapeIds = chunkedContextMap.entries.filter { (_, context) -> context.agentId == agentId }.map { it.key }
+    scrapeIds.forEach { chunkedContextMap.remove(it) }
+    return scrapeIds
+  }
+
   fun findStaleAgents(maxInactivity: Duration): List<Pair<String, AgentContext>> =
     agentContextMap
       .filter { (_, agentContext) -> agentContext.inactivityDuration > maxInactivity }

--- a/src/main/kotlin/io/prometheus/proxy/ChunkedContext.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ChunkedContext.kt
@@ -42,6 +42,9 @@ internal class ChunkedContext(
   private val baos = ByteArrayOutputStream()
   private val header = response.header
 
+  /** The agent that owns this in-flight transfer; used to reclaim contexts when that agent is removed. */
+  val agentId: String get() = header.headerAgentId
+
   var totalChunkCount = 0
     private set
   var totalByteCount = 0L

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpConfig.kt
@@ -77,7 +77,10 @@ internal object ProxyHttpConfig {
   }
 
   fun CallLoggingConfig.configureCallLogging() {
-    level = Level.INFO
+    // Log per-request call lines at DEBUG, not INFO. A proxy fronting many targets is scraped every
+    // few seconds per path, so INFO here produces a continuous stream that buries real WARN/ERROR
+    // events at the default INFO root level. Operators can opt back in by lowering the root level.
+    level = Level.DEBUG
     filter { call -> call.request.path().startsWith("/") }
     format { call -> getFormattedLog(call) }
   }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -37,6 +37,7 @@ import io.prometheus.Proxy
 import io.prometheus.common.Utils.sanitizeQueryParams
 import io.prometheus.proxy.ProxyConstants.CACHE_CONTROL_VALUE
 import io.prometheus.proxy.ProxyConstants.FAVICON_FILENAME
+import io.prometheus.proxy.ProxyUtils.DecodedContent
 import io.prometheus.proxy.ProxyUtils.incrementScrapeRequestCount
 import io.prometheus.proxy.ProxyUtils.respondWith
 import io.prometheus.proxy.ProxyUtils.unzip
@@ -304,9 +305,12 @@ internal object ProxyHttpRoutes {
       else
         scrapeResults.run {
           val maxSize = proxy.proxyConfigVals.internal.maxUnzippedContentSizeMBytes * 1024L * 1024L
-          val contentText =
+          val decoded =
             try {
-              if (srZipped) srContentAsZipped.unzip(maxSize) else srContentAsText
+              if (srZipped)
+                srContentAsZipped.unzip(maxSize)
+              else
+                DecodedContent(srContentAsText, srContentAsText.toByteArray().size.toLong())
             } catch (e: ProxyUtils.ZipBombException) {
               return ScrapeRequestResponse(
                 statusCode = HttpStatusCode.PayloadTooLarge,
@@ -328,14 +332,16 @@ internal object ProxyHttpRoutes {
             }
 
           proxy.metrics {
+            // Observe the byte count already computed during unzip (gzipped) or the small plain
+            // payload's length, instead of re-encoding the decoded text just to measure it.
             val encoding = if (srZipped) ProxyMetrics.ENCODING_GZIPPED else ProxyMetrics.ENCODING_PLAIN
-            scrapeResponseBytes.labels(path, encoding).observe(contentText.toByteArray().size.toDouble())
+            scrapeResponseBytes.labels(path, encoding).observe(decoded.byteCount.toDouble())
           }
 
           ScrapeRequestResponse(
             statusCode = statusCode,
             contentType = contentType,
-            contentText = contentText,
+            contentText = decoded.text,
             failureReason = srFailureReason,
             url = srUrl,
             updateMsg = "success",

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -34,6 +34,7 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.prometheus.Proxy
+import io.prometheus.common.Utils.sanitizeQueryParams
 import io.prometheus.proxy.ProxyConstants.CACHE_CONTROL_VALUE
 import io.prometheus.proxy.ProxyConstants.FAVICON_FILENAME
 import io.prometheus.proxy.ProxyUtils.incrementScrapeRequestCount
@@ -97,7 +98,8 @@ internal object ProxyHttpRoutes {
       val queryParams = call.request.queryParameters.formUrlEncode()
 
       logger.debug {
-        "Servicing request for path: $path${if (queryParams.isNotEmpty()) " with query params $queryParams" else ""}"
+        val safeParams = sanitizeQueryParams(queryParams)
+        "Servicing request for path: $path${if (queryParams.isNotEmpty()) " with query params $safeParams" else ""}"
       }
 
       val responseResults =

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -155,10 +155,12 @@ class ProxyOptions(
       .also { proxyConfigVals ->
         if (proxyPort == -1)
           proxyPort = PROXY_PORT.getEnv(proxyConfigVals.http.port)
+        require(proxyPort in 1..65535) { "proxyPort must be in 1..65535: $proxyPort" }
         logger.info { "proxyPort: $proxyPort" }
 
         if (proxyAgentPort == -1)
           proxyAgentPort = AGENT_PORT.getEnv(proxyConfigVals.agent.port)
+        require(proxyAgentPort in 1..65535) { "proxyAgentPort must be in 1..65535: $proxyAgentPort" }
         logger.info { "proxyAgentPort: $proxyAgentPort" }
 
         sdEnabled =
@@ -189,6 +191,7 @@ class ProxyOptions(
 
         if (handshakeTimeoutSecs == -1L)
           handshakeTimeoutSecs = HANDSHAKE_TIMEOUT_SECS.getEnv(proxyConfigVals.grpc.handshakeTimeoutSecs)
+        requireGrpcTimeout(handshakeTimeoutSecs, "grpc.handshakeTimeoutSecs")
         val hsTimeout = if (handshakeTimeoutSecs == -1L) "default (120)" else handshakeTimeoutSecs
         logger.info { "grpc.handshakeTimeoutSecs: $hsTimeout" }
 
@@ -203,22 +206,26 @@ class ProxyOptions(
 
         if (permitKeepAliveTimeSecs == -1L)
           permitKeepAliveTimeSecs = PERMIT_KEEPALIVE_TIME_SECS.getEnv(proxyConfigVals.grpc.permitKeepAliveTimeSecs)
+        requireGrpcTimeout(permitKeepAliveTimeSecs, "grpc.permitKeepAliveTimeSecs")
         val kaTime = if (permitKeepAliveTimeSecs == -1L) "default (300)" else permitKeepAliveTimeSecs
         logger.info { "grpc.permitKeepAliveTimeSecs: $kaTime" }
 
         if (maxConnectionIdleSecs == -1L)
           maxConnectionIdleSecs = MAX_CONNECTION_IDLE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionIdleSecs)
+        requireGrpcTimeout(maxConnectionIdleSecs, "grpc.maxConnectionIdleSecs")
         val idleVal = if (maxConnectionIdleSecs == -1L) "default (INT_MAX)" else maxConnectionIdleSecs
         logger.info { "grpc.maxConnectionIdleSecs: $idleVal" }
 
         if (maxConnectionAgeSecs == -1L)
           maxConnectionAgeSecs = MAX_CONNECTION_AGE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionAgeSecs)
+        requireGrpcTimeout(maxConnectionAgeSecs, "grpc.maxConnectionAgeSecs")
         val ageVal = if (maxConnectionAgeSecs == -1L) "default (INT_MAX)" else maxConnectionAgeSecs
         logger.info { "grpc.maxConnectionAgeSecs: $ageVal" }
 
         if (maxConnectionAgeGraceSecs == -1L)
           maxConnectionAgeGraceSecs =
             MAX_CONNECTION_AGE_GRACE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionAgeGraceSecs)
+        requireGrpcTimeout(maxConnectionAgeGraceSecs, "grpc.maxConnectionAgeGraceSecs")
         val graceVal = if (maxConnectionAgeGraceSecs == -1L) "default (INT_MAX)" else maxConnectionAgeGraceSecs
         logger.info { "grpc.maxConnectionAgeGraceSecs: $graceVal" }
 
@@ -256,5 +263,13 @@ class ProxyOptions(
 
   internal companion object {
     private val logger = logger {}
+
+    // gRPC timeout fields use -1L as the "leave the gRPC default in place" sentinel (the
+    // `> -1L` guards in ProxyGrpcService rely on it). Any other non-positive value is invalid
+    // and would otherwise surface as an opaque gRPC builder exception at startup.
+    private fun requireGrpcTimeout(
+      value: Long,
+      name: String,
+    ) = require(value == -1L || value > 0L) { "$name must be -1 (default) or > 0: $value" }
   }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -36,7 +36,6 @@ import io.prometheus.common.EnvVars.REFLECTION_DISABLED
 import io.prometheus.common.EnvVars.SD_ENABLED
 import io.prometheus.common.EnvVars.SD_PATH
 import io.prometheus.common.EnvVars.SD_TARGET_PREFIX
-import io.prometheus.common.Utils.setLogLevel
 
 class ProxyOptions(
   args: Array<String>,
@@ -230,19 +229,19 @@ class ProxyOptions(
         logger.info { "grpc.maxConnectionAgeGraceSecs: $graceVal" }
 
         proxyConfigVals.apply {
-          assignKeepAliveTimeSecs(grpc.keepAliveTimeSecs)
-          assignKeepAliveTimeoutSecs(grpc.keepAliveTimeoutSecs)
-          assignAdminEnabled(admin.enabled)
-          assignAdminPort(admin.port)
-          assignMetricsEnabled(metrics.enabled)
-          assignMetricsPort(metrics.port)
-          assignTransportFilterDisabled(transportFilterDisabled)
-          assignDebugEnabled(admin.debugEnabled)
-
-          assignCertChainFilePath(tls.certChainFilePath)
-          assignPrivateKeyFilePath(tls.privateKeyFilePath)
-          assignTrustCertCollectionFilePath(tls.trustCertCollectionFilePath)
-          validateTlsConfig()
+          assignCommonOptions(
+            keepAliveTimeSecs = grpc.keepAliveTimeSecs,
+            keepAliveTimeoutSecs = grpc.keepAliveTimeoutSecs,
+            adminEnabled = admin.enabled,
+            adminPort = admin.port,
+            metricsEnabled = metrics.enabled,
+            metricsPort = metrics.port,
+            transportFilterDisabled = transportFilterDisabled,
+            debugEnabled = admin.debugEnabled,
+            certChainFilePath = tls.certChainFilePath,
+            privateKeyFilePath = tls.privateKeyFilePath,
+            trustCertCollectionFilePath = tls.trustCertCollectionFilePath,
+          )
 
           logger.info { "internal.scrapeRequestTimeoutSecs: ${internal.scrapeRequestTimeoutSecs}" }
           logger.info { "internal.staleAgentCheckPauseSecs: ${internal.staleAgentCheckPauseSecs}" }
@@ -250,14 +249,7 @@ class ProxyOptions(
           logger.info { "internal.maxUnzippedContentSizeMBytes: ${internal.maxUnzippedContentSizeMBytes}" }
         }
 
-        if (logLevel.isEmpty())
-          logLevel = PROXY_LOG_LEVEL.getEnv(proxyConfigVals.logLevel)
-        if (logLevel.isNotEmpty()) {
-          logger.info { "proxy.logLevel: $logLevel" }
-          setLogLevel("proxy", logLevel)
-        } else {
-          logger.info { "proxy.logLevel: info" }
-        }
+        assignLogLevel("proxy", PROXY_LOG_LEVEL, proxyConfigVals.logLevel)
       }
   }
 

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -204,6 +204,13 @@ internal class ProxyServiceImpl(
           throw e
         } catch (e: Exception) {
           logger.error(e) { "Error processing scrape response for scrapeId: ${response.scrapeId}" }
+          // Fail the in-flight request immediately so the waiting HTTP handler returns a 502 now
+          // instead of blocking until scrapeRequestTimeoutSecs and reporting a misleading timeout.
+          // Mirrors the failScrapeRequest() handling in writeChunkedResponsesToProxy().
+          proxy.scrapeRequestManager.failScrapeRequest(
+            response.scrapeId,
+            "Error processing scrape response: ${e.message}",
+          )
         }
       }
     }.onFailure { throwable ->

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -225,6 +225,11 @@ internal class ProxyServiceImpl(
   }
 
   override suspend fun writeChunkedResponsesToProxy(requests: Flow<ChunkedScrapeResponse>): Empty {
+    // activeScrapeIds is a plain (non-thread-safe) set, which is safe ONLY because grpc-kotlin
+    // confines a client-streaming RPC's collect{} and the post-collect cleanup to a single
+    // coroutine — there is no launch/async/flowOn here that would fan the body across threads.
+    // The genuinely shared chunkedContextMap is a ConcurrentHashMap. If this RPC is ever
+    // refactored to process chunks concurrently, switch this to a thread-safe/synchronized set.
     val activeScrapeIds = mutableSetOf<Long>()
     runCatchingCancellable {
       requests.collect { response ->

--- a/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
@@ -35,8 +35,17 @@ import java.util.zip.GZIPInputStream
 internal object ProxyUtils {
   private val logger = logger {}
 
-  fun ByteArray.unzip(maxSize: Long): String {
-    if (isEmpty()) return ""
+  /** Decoded scrape content plus its UTF-8 byte length, already counted during decompression. */
+  data class DecodedContent(
+    val text: String,
+    val byteCount: Long,
+  )
+
+  // Decompress and return both the text and its byte length. The byte count is the running total
+  // computed for the zip-bomb guard anyway, so callers can record the response-size metric without
+  // re-encoding the (potentially multi-MB) decoded String with a throwaway toByteArray() call.
+  fun ByteArray.unzip(maxSize: Long): DecodedContent {
+    if (isEmpty()) return DecodedContent("", 0L)
     GZIPInputStream(ByteArrayInputStream(this)).use { gzis ->
       ByteArrayOutputStream().use { baos ->
         val buffer = ByteArray(1024)
@@ -52,7 +61,7 @@ internal object ProxyUtils {
           }
           baos.write(buffer, 0, len)
         }
-        return baos.toString(Charsets.UTF_8.name())
+        return DecodedContent(baos.toString(Charsets.UTF_8.name()), totalBytes)
       }
     }
   }

--- a/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
@@ -165,6 +165,20 @@ class AgentConnectionContextTest : StringSpec() {
       result.isClosed.shouldBeTrue()
     }
 
+    // Item 8: sendScrapeResults reports delivery (true) vs. drop-on-closed (false) so the caller
+    // can increment a "dropped" metric instead of silently losing a computed result.
+    "sendScrapeResults should return true when open and false after close" {
+      val context = AgentConnectionContext()
+      val result = ScrapeResults(srAgentId = "agent-1", srScrapeId = 1L, srValidResponse = true)
+
+      // While the connection is open, the result is accepted into the unbounded channel.
+      context.sendScrapeResults(result).shouldBeTrue()
+
+      // After close(), the channel is closed and a late result is dropped (reported as false).
+      context.close()
+      context.sendScrapeResults(result).shouldBeFalse()
+    }
+
     "backlogCapacity should be respected" {
       val capacity = 50
       val context = AgentConnectionContext(capacity)

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -1292,5 +1292,55 @@ class AgentHttpServiceTest : StringSpec() {
         server.stop(0, 0)
       }
     }
+
+    // ==================== Item 29: timeout resolution precedence ====================
+    // resolveTimeoutSecs honors the deprecated cioTimeoutSecs only when it was explicitly
+    // overridden (non-default) while httpClientTimeoutSecs was left at the default. Otherwise
+    // httpClientTimeoutSecs always wins.
+
+    "Item 29: cioTimeoutSecs wins when overridden and httpClientTimeoutSecs is at the default" {
+      AgentHttpService.resolveTimeoutSecs(cioTimeoutSecs = 30, httpClientTimeoutSecs = 90, default = 90) shouldBe 30
+    }
+
+    "Item 29: httpClientTimeoutSecs wins when it is overridden" {
+      AgentHttpService.resolveTimeoutSecs(cioTimeoutSecs = 30, httpClientTimeoutSecs = 120, default = 90) shouldBe 120
+    }
+
+    "Item 29: httpClientTimeoutSecs wins when both are at the default" {
+      AgentHttpService.resolveTimeoutSecs(cioTimeoutSecs = 90, httpClientTimeoutSecs = 90, default = 90) shouldBe 90
+    }
+
+    // ==================== Item 31: wrapped timeout detection ====================
+
+    // Item 31: a CancellationException whose cause is an HttpRequestTimeoutException (Ktor
+    // sometimes wraps the timeout) must be converted to a 408 via the cause-walk, not rethrown.
+    "Item 31: fetchScrapeUrl converts a wrapped-timeout CancellationException to 408" {
+      val mockAgent = createMockAgentWithPaths()
+      val service = AgentHttpService(mockAgent)
+      mockAgent.pathManager.registerPath("metrics", "http://localhost:8080/metrics")
+
+      val request = scrapeRequest {
+        agentId = "agent-1"
+        scrapeId = 72L
+        path = "metrics"
+      }
+
+      val spiedService = spyk(service)
+      // No cause-accepting constructor exists on CancellationException, so set it via initCause.
+      coEvery {
+        spiedService.fetchContent(any<String>(), any())
+      } coAnswers {
+        throw CancellationException("wrapped timeout").apply {
+          initCause(io.ktor.client.plugins.HttpRequestTimeoutException("url", 1000L))
+        }
+      }
+
+      val results = spiedService.fetchScrapeUrl(request)
+
+      results.srStatusCode shouldBe 408
+      results.srValidResponse shouldBe false
+
+      service.close()
+    }
   }
 }

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -69,6 +69,13 @@ class AgentOptionsTest : StringSpec() {
       options.chunkContentSizeBytes shouldBe 32 * 1024
     }
 
+    // Item 16: --chunk now binds the KB-unit input field; chunkContentSizeBytes is derived once.
+    "chunkContentSizeKbs should hold the raw --chunk input and chunkContentSizeBytes its KB*1024 value" {
+      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--chunk", "64"), false)
+      options.chunkContentSizeKbs shouldBe 64
+      options.chunkContentSizeBytes shouldBe 64 * 1024
+    }
+
     "minGzipSizeBytes should be settable via command line" {
       val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--gzip", "2048"), false)
       options.minGzipSizeBytes shouldBe 2048

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -19,12 +19,14 @@
 package io.prometheus.agent
 
 import com.pambrose.common.concurrent.await
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.mockk.every
@@ -69,6 +71,25 @@ class HttpClientCacheTest : StringSpec() {
 
     afterEach {
       cache.close()
+    }
+
+    // Item 4: once closed, the cache must reject new requests. Otherwise an in-flight scrape
+    // racing shutdown could create and cache a fresh HttpClient into the dead cache (whose cleanup
+    // coroutine is cancelled), leaking that client until JVM exit. The factory must not be invoked.
+    "getOrCreateClient should throw after close" {
+      cache.close()
+
+      var factoryInvoked = false
+      val exception =
+        shouldThrow<IllegalStateException> {
+          cache.getOrCreateClient(ClientKey(null, null)) {
+            factoryInvoked = true
+            createMockHttpClient()
+          }
+        }
+
+      exception.message shouldContain "closed"
+      factoryInvoked.shouldBeFalse()
     }
 
     "should cache and reuse clients for same key" {

--- a/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
+++ b/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
@@ -32,34 +32,55 @@ import kotlin.time.TimeSource.Monotonic
 // TCP-connect probe isn't enough: CIO's listening socket can accept and immediately close
 // while the routing pipeline is still being installed, surfacing as EOFException or empty
 // bodies on the next real request. Sending a real HTTP/1.0 line and waiting for the "HTTP/"
-// reply means routing is live before we hand back the port.
+// reply means the request pipeline is live before we hand back the port.
 //
-// The deadline is generous because it is only a ceiling, not a wait: the loop returns the
-// instant the server responds, so a healthy server still returns in milliseconds. The extra
-// headroom absorbs CPU contention during a full test-suite run, where many embedded servers
-// and the gRPC harness compete for cores and a fresh CIO server can take several seconds to
-// start answering. A tighter default (5s) caused intermittent "did not start serving HTTP"
-// failures on whichever embedded-server test happened to run during a load spike.
-suspend fun EmbeddedServer<*, *>.startAndAwaitReady(timeout: Duration = 30.seconds): Int {
+// A *single* HTTP reply is still not enough under a full-suite load spike: there is a narrow
+// window where the engine answers one request and then briefly stalls or resets the next while
+// the application module finishes installing, so the first real scrape can land in that gap and
+// see a transient non-200 (e.g. a default 404 before the test's route is matchable). To close
+// that window we require [stableProbes] *consecutive* successful HTTP replies, each on a fresh
+// connection with a short gap; any failure resets the streak. This only ever delays the return
+// (never advances it), so it cannot make a healthy server look unready — it just refuses to hand
+// back the port until the server has answered cleanly several times in a row.
+//
+// The deadline is generous because it is only a ceiling, not a wait: a healthy server satisfies
+// the streak in tens of milliseconds. The extra headroom absorbs CPU contention during a full
+// test-suite run, where many embedded servers and the gRPC harness compete for cores and a fresh
+// CIO server can take several seconds to start answering.
+suspend fun EmbeddedServer<*, *>.startAndAwaitReady(
+  timeout: Duration = 30.seconds,
+  stableProbes: Int = 3,
+): Int {
   start(wait = false)
   val port = engine.resolvedConnectors().first().port
   val deadline = Monotonic.markNow() + timeout
+  var consecutive = 0
   while (Monotonic.markNow() < deadline) {
-    try {
-      Socket().use { sock ->
-        sock.connect(InetSocketAddress("localhost", port), 200)
-        sock.soTimeout = 200
-        sock.getOutputStream().apply {
-          write("GET /__readiness__ HTTP/1.0\r\nHost: localhost\r\n\r\n".toByteArray())
-          flush()
-        }
-        val reply = sock.getInputStream().readNBytes(12).decodeToString()
-        if (reply.startsWith("HTTP/")) return port
-      }
-    } catch (_: IOException) {
-      // not ready yet
+    if (probeServesHttp(port)) {
+      consecutive++
+      if (consecutive >= stableProbes) return port
+    } else {
+      consecutive = 0
     }
     delay(20.milliseconds)
   }
-  error("Embedded server on port $port did not start serving HTTP within $timeout")
+  error("Embedded server on port $port did not stably serve HTTP within $timeout")
 }
+
+// Single readiness probe: open a fresh connection, send a real HTTP/1.0 request line, and report
+// whether the server answers with an HTTP status line. Any connect/read failure (the accept-then-
+// close window, a reset, a read timeout) returns false so the caller's streak resets.
+private fun probeServesHttp(port: Int): Boolean =
+  try {
+    Socket().use { sock ->
+      sock.connect(InetSocketAddress("localhost", port), 200)
+      sock.soTimeout = 200
+      sock.getOutputStream().apply {
+        write("GET /__readiness__ HTTP/1.0\r\nHost: localhost\r\n\r\n".toByteArray())
+        flush()
+      }
+      sock.getInputStream().readNBytes(12).decodeToString().startsWith("HTTP/")
+    }
+  } catch (_: IOException) {
+    false
+  }

--- a/src/test/kotlin/io/prometheus/common/UtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/UtilsTest.kt
@@ -32,6 +32,7 @@ import io.prometheus.common.Utils.decodeParams
 import io.prometheus.common.Utils.defaultEmptyJsonObject
 import io.prometheus.common.Utils.exceptionDetails
 import io.prometheus.common.Utils.parseHostPort
+import io.prometheus.common.Utils.sanitizeQueryParams
 import io.prometheus.common.Utils.sanitizeUrl
 import io.prometheus.common.Utils.setLogLevel
 import io.prometheus.common.Utils.toJsonElement
@@ -456,12 +457,12 @@ class UtilsTest : StringSpec() {
       sanitizeUrl("http://host:8080/metrics") shouldBe "http://host:8080/metrics"
     }
 
-    "sanitizeUrl should handle https URL with credentials" {
-      sanitizeUrl("https://user:pass@example.com/path?q=1") shouldBe "https://***@example.com/path?q=1"
+    "sanitizeUrl should redact both credentials and query values" {
+      sanitizeUrl("https://user:pass@example.com/path?q=1") shouldBe "https://***@example.com/path?q=***"
     }
 
-    "sanitizeUrl should not modify URL with @ in query string" {
-      sanitizeUrl("http://host/path?email=user@example.com") shouldBe "http://host/path?email=user@example.com"
+    "sanitizeUrl should redact query value even when value contains @" {
+      sanitizeUrl("http://host/path?email=user@example.com") shouldBe "http://host/path?email=***"
     }
 
     "sanitizeUrl should handle empty string" {
@@ -470,6 +471,47 @@ class UtilsTest : StringSpec() {
 
     "sanitizeUrl should handle URL without scheme" {
       sanitizeUrl("host:8080/metrics") shouldBe "host:8080/metrics"
+    }
+
+    // Item 1: query-string secrets (?token=…, ?api_key=…) must be redacted before logging/echoing.
+    "sanitizeUrl should redact a single query-parameter value" {
+      sanitizeUrl("http://host:8080/metrics?token=secret123") shouldBe "http://host:8080/metrics?token=***"
+    }
+
+    "sanitizeUrl should redact every query-parameter value while preserving keys" {
+      sanitizeUrl("https://host/m?api_key=abc&job=node&access_token=xyz") shouldBe
+        "https://host/m?api_key=***&job=***&access_token=***"
+    }
+
+    "sanitizeUrl should redact both userinfo and query values together" {
+      sanitizeUrl("http://admin:hunter2@host:8080/m?token=s3cr3t") shouldBe "http://***@host:8080/m?token=***"
+    }
+
+    "sanitizeUrl should preserve the fragment after redacting query values" {
+      sanitizeUrl("http://host/m?token=s#section") shouldBe "http://host/m?token=***#section"
+    }
+
+    "sanitizeUrl should leave a valueless query token untouched" {
+      sanitizeUrl("http://host/m?debug&token=s") shouldBe "http://host/m?debug&token=***"
+    }
+
+    "sanitizeUrl should not modify a URL with no query string" {
+      sanitizeUrl("http://host:8080/metrics") shouldBe "http://host:8080/metrics"
+    }
+
+    // ==================== sanitizeQueryParams Tests ====================
+
+    "sanitizeQueryParams should return blank input unchanged" {
+      sanitizeQueryParams("") shouldBe ""
+      sanitizeQueryParams("   ") shouldBe "   "
+    }
+
+    "sanitizeQueryParams should redact values while preserving keys" {
+      sanitizeQueryParams("token=abc&job=node") shouldBe "token=***&job=***"
+    }
+
+    "sanitizeQueryParams should leave a valueless key untouched" {
+      sanitizeQueryParams("debug&token=abc") shouldBe "debug&token=***"
     }
   }
 }

--- a/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.prometheus.harness
+
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.prometheus.Agent
+import io.prometheus.Proxy
+import io.prometheus.agent.AgentOptions
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.harness.HarnessConstants.CONFIG_ARG
+import io.prometheus.harness.support.exceptionHandler
+import io.prometheus.proxy.ProxyOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration.Companion.seconds
+
+// Item 28: negative-path coverage for mutual TLS. The existing TlsWithMutualAuthTest /
+// TlsNoMutualAuthTest run over the in-process transport (a non-empty serverName selects in-process,
+// which ignores the TLS context), so they only verify TLS *config* parsing, never a real handshake.
+//
+// This test uses an empty serverName, which selects the Netty transport and performs an actual TLS
+// handshake. The proxy requires a client certificate (--trust enables mutual auth); the agent is
+// started WITHOUT --cert/--key, so the handshake is rejected and the agent never registers. A
+// regression that silently stopped enforcing client-cert verification — a security boundary — would
+// let the agent connect and fail this test.
+class TlsMutualAuthRejectionTest : StringSpec() {
+  init {
+    "agent without a client certificate is rejected by a mutual-auth proxy" {
+      CollectorRegistry.defaultRegistry.clear()
+
+      val proxyOptions =
+        ProxyOptions(
+          buildList {
+            addAll(CONFIG_ARG)
+            addAll(listOf("--agent_port", AGENT_PORT.toString()))
+            addAll(listOf("--cert", "testing/certs/server1.pem"))
+            addAll(listOf("--key", "testing/certs/server1.key"))
+            addAll(listOf("--trust", "testing/certs/ca.pem"))
+            add("-Dproxy.admin.enabled=false")
+            add("-Dproxy.metrics.enabled=false")
+          },
+        )
+      // Empty inProcessServerName => Netty transport => a real TLS handshake is performed.
+      val proxy = Proxy(options = proxyOptions, proxyPort = HTTP_PORT, testMode = true) { startSync() }
+
+      val agentOptions =
+        AgentOptions(
+          args =
+            buildList {
+              addAll(CONFIG_ARG)
+              addAll(listOf("--proxy", "localhost:$AGENT_PORT"))
+              // Trust the proxy's server cert, but present NO client certificate (no --cert/--key).
+              addAll(listOf("--trust", "testing/certs/ca.pem"))
+              addAll(listOf("--override", "foo.test.google.fr"))
+              add("-Dagent.admin.enabled=false")
+              add("-Dagent.metrics.enabled=false")
+            },
+          exitOnMissingConfig = false,
+        )
+      val agent = Agent(options = agentOptions, testMode = true) { startSync() }
+
+      try {
+        // The handshake fails (no client cert), so the agent keeps retrying and never registers.
+        // awaitInitialConnection returns false once the timeout elapses.
+        agent.awaitInitialConnection(5.seconds).shouldBeFalse()
+      } finally {
+        runBlocking {
+          for (service in listOf(proxy, agent)) {
+            launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    private val logger = logger {}
+
+    // Dedicated ports to avoid clashing with the shared harness ports (9505 / 50051 / 50440).
+    private const val HTTP_PORT = 9512
+    private const val AGENT_PORT = 50460
+  }
+}

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.Proxy
+import io.prometheus.grpc.chunkedScrapeResponse
+import io.prometheus.grpc.headerData
 import kotlinx.coroutines.async
 import kotlin.time.Duration.Companion.seconds
 
@@ -212,6 +214,46 @@ class AgentContextManagerTest : StringSpec() {
 
       manager.removeChunkedContext(1L)
       manager.chunkedContextSize shouldBe 1
+    }
+
+    // ==================== Item 6: per-agent chunked-context reclamation ====================
+
+    "removeChunkedContextsForAgent should remove only the given agent's chunked contexts" {
+      val manager = AgentContextManager(isTestMode = true)
+
+      fun chunkedContext(
+        scrapeIdVal: Long,
+        agentIdVal: String,
+      ) = ChunkedContext(
+        chunkedScrapeResponse {
+          header = headerData {
+            headerScrapeId = scrapeIdVal
+            headerAgentId = agentIdVal
+            headerValidResponse = true
+            headerStatusCode = 200
+            headerContentType = "text/plain"
+          }
+        },
+        1_000_000,
+      )
+
+      manager.putChunkedContext(1L, chunkedContext(1L, "agent-A"))
+      manager.putChunkedContext(2L, chunkedContext(2L, "agent-A"))
+      manager.putChunkedContext(3L, chunkedContext(3L, "agent-B"))
+      manager.chunkedContextSize shouldBe 3
+
+      val removed = manager.removeChunkedContextsForAgent("agent-A")
+
+      removed.sorted() shouldBe listOf(1L, 2L)
+      manager.chunkedContextSize shouldBe 1
+      manager.getChunkedContext(3L).shouldNotBeNull()
+      manager.getChunkedContext(1L).shouldBeNull()
+      manager.getChunkedContext(2L).shouldBeNull()
+    }
+
+    "removeChunkedContextsForAgent should return an empty list for an unknown agent" {
+      val manager = AgentContextManager(isTestMode = true)
+      manager.removeChunkedContextsForAgent("nobody") shouldBe emptyList()
     }
 
     // ==================== Non-Zero Backlog Aggregation ====================

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
@@ -34,6 +34,7 @@ import io.ktor.http.withCharset
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.calllogging.CallLoggingConfig
 import io.ktor.server.plugins.compression.CompressionConfig
 import io.ktor.server.plugins.compression.deflate
 import io.ktor.server.plugins.compression.gzip
@@ -49,6 +50,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.Proxy
 import io.prometheus.common.startAndAwaitReady
+import org.slf4j.event.Level
 import io.ktor.server.cio.CIO as ServerCIO
 
 // Tests for ProxyHttpConfig which configures Ktor server plugins for the proxy HTTP service.
@@ -395,6 +397,20 @@ class ProxyHttpConfigTest : StringSpec() {
       // which is unusual in HTTP but the filter handles it defensively
       val path = "metrics"
       path.startsWith("/") shouldBe false
+    }
+
+    // Item 26: per-request call logging is emitted at DEBUG (not INFO) so that, at the default
+    // INFO root level, the continuous scrape-rate stream does not bury real WARN/ERROR events.
+    "Item 26: configureCallLogging should set the call-logging level to DEBUG" {
+      val config = CallLoggingConfig()
+      with(ProxyHttpConfig) { config.configureCallLogging() }
+
+      // CallLoggingConfig.level has no public getter, so read the backing field reflectively.
+      val field = CallLoggingConfig::class.java.getDeclaredField("level")
+      field.isAccessible = true
+      val level = field.get(config) as Level
+
+      level shouldBe Level.DEBUG
     }
 
     // ==================== configureKtorServer Integration Tests ====================

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -18,10 +18,12 @@
 
 package io.prometheus.proxy
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 class ProxyOptionsTest : StringSpec() {
   init {
@@ -159,6 +161,38 @@ class ProxyOptionsTest : StringSpec() {
       options.maxConnectionAgeSecs shouldBe 1800L
       options.maxConnectionAgeGraceSecs shouldBe 30L
       options.permitKeepAliveWithoutCalls.shouldBeTrue()
+    }
+
+    // ==================== Item 27: Bounds Validation ====================
+    // ProxyOptions now fails fast on out-of-range ports and gRPC timeouts during construction,
+    // instead of surfacing opaque Ktor/gRPC builder exceptions later at server startup.
+
+    "proxyPort of 0 should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--port", "0")) }
+      exception.message shouldContain "proxyPort"
+    }
+
+    "proxyPort above 65535 should be rejected" {
+      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--port", "70000")) }
+    }
+
+    "proxyAgentPort of 0 should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--agent_port", "0")) }
+      exception.message shouldContain "proxyAgentPort"
+    }
+
+    "a zero gRPC handshake timeout should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--handshake_timeout_secs", "0")) }
+      exception.message shouldContain "handshakeTimeoutSecs"
+    }
+
+    "a zero gRPC max-connection-idle timeout should be rejected" {
+      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--max_connection_idle_secs", "0")) }
+    }
+
+    "the -1 sentinel should be accepted for gRPC timeouts" {
+      val options = ProxyOptions(listOf("--handshake_timeout_secs", "-1"))
+      options.handshakeTimeoutSecs shouldBe -1L
     }
 
     // ==================== Constructor Variants Tests ====================

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
@@ -1296,5 +1296,55 @@ class ProxyServiceImplTest : StringSpec() {
 
       verify(exactly = 2) { scrapeRequestManager.assignScrapeResults(any()) }
     }
+
+    // Item 7: a per-response processing error must fail the in-flight request immediately so the
+    // waiting HTTP handler returns a 502 now, rather than blocking until scrapeRequestTimeoutSecs
+    // and reporting a misleading timeout. Mirrors writeChunkedResponsesToProxy's failScrapeRequest.
+    "Item 7: writeResponsesToProxy should fail the scrape request when processing throws" {
+      val proxy = createMockProxy()
+      val scrapeRequestManager = proxy.scrapeRequestManager
+      every { scrapeRequestManager.assignScrapeResults(any()) } answers { error("Simulated processing failure") }
+
+      val response = scrapeResponse {
+        agentId = "agent-1"
+        scrapeId = 700L
+        validResponse = true
+        statusCode = 200
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val result = service.writeResponsesToProxy(flowOf(response))
+
+      result shouldBe EMPTY_INSTANCE
+      // The waiting HTTP handler is notified via failScrapeRequest for the failed scrapeId.
+      verify { scrapeRequestManager.failScrapeRequest(700L, match { it.contains("Error processing") }) }
+    }
+
+    // Item 30: a chunked HEADER for an unknown/stale scrapeId must be dropped, not turned into a
+    // ChunkedContext (which would leak the entry). The shared createMockProxy() stubs
+    // containsScrapeRequest=true, so override it to false to exercise the drop branch.
+    "Item 30: writeChunkedResponsesToProxy should drop header for unknown scrapeId" {
+      val proxy = createMockProxy()
+      val contextManager = proxy.agentContextManager
+      val scrapeId = 800L
+      every { proxy.scrapeRequestManager.containsScrapeRequest(scrapeId) } returns false
+
+      val header = chunkedScrapeResponse {
+        header = headerData {
+          headerValidResponse = true
+          headerScrapeId = scrapeId
+          headerAgentId = "agent-1"
+          headerStatusCode = 200
+          headerContentType = "text/plain"
+        }
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val result = service.writeChunkedResponsesToProxy(flowOf(header))
+
+      result shouldBe EMPTY_INSTANCE
+      // No ChunkedContext should be created for an unknown scrapeId.
+      verify(exactly = 0) { contextManager.putChunkedContext(any(), any()) }
+    }
   }
 }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
@@ -19,6 +19,8 @@
 package io.prometheus.proxy
 
 import com.pambrose.common.dsl.KtorDsl.newHttpClient
+import com.pambrose.common.util.zip
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -34,6 +36,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.Proxy
 import io.prometheus.proxy.ProxyUtils.respondWith
+import io.prometheus.proxy.ProxyUtils.unzip
 import io.ktor.server.cio.CIO as ServerCIO
 
 class ProxyUtilsTest : StringSpec() {
@@ -242,6 +245,37 @@ class ProxyUtilsTest : StringSpec() {
       } finally {
         server.stop(0, 0)
       }
+    }
+
+    // ==================== Item 11: unzip returns decoded text + byte count ====================
+
+    "unzip should round-trip content and report its UTF-8 byte count" {
+      val original = "metric_value 42\n# EOF"
+      val decoded = original.zip().unzip(1_000_000)
+
+      decoded.text shouldBe original
+      decoded.byteCount shouldBe original.toByteArray().size.toLong()
+    }
+
+    "unzip should report the byte count for multi-byte UTF-8 content" {
+      // "世界" is 2 chars but 6 UTF-8 bytes; byteCount must reflect bytes, not char length.
+      val original = "世界"
+      val decoded = original.zip().unzip(1_000_000)
+
+      decoded.text shouldBe original
+      decoded.byteCount shouldBe 6L
+    }
+
+    "unzip should return empty text and zero byte count for empty input" {
+      val decoded = ByteArray(0).unzip(1_000_000)
+
+      decoded.text shouldBe ""
+      decoded.byteCount shouldBe 0L
+    }
+
+    "unzip should throw ZipBombException when the decoded size exceeds the limit" {
+      val zipped = "a".repeat(1000).zip()
+      shouldThrow<ProxyUtils.ZipBombException> { zipped.unzip(100) }
     }
   }
 }


### PR DESCRIPTION
Implements the confirmed findings from a multi-dimension code review (secret redaction, error handling, lifecycle, validation, and several quality cleanups), with tests.

## Highlights

**Robustness / lifecycle**
- Proxy now proactively reclaims in-flight chunked-transfer buffers when an agent disconnects or is evicted (`removeChunkedContextsForAgent`), instead of waiting for each stream's orphan sweep.
- `startAndAwaitReady` requires consecutive readiness probes before declaring readiness.
- Dedicated `ConfigLoadException` for config-load failures.

**Options / config**
- `BaseOptions` gains shared `assignCommonOptions()` and `assignLogLevel()` so `AgentOptions` and `ProxyOptions` resolve common options through one ordered path (CLI > env > config), preventing the two subclasses from drifting.

**Efficiency**
- `unzip()` returns `DecodedContent` (text + byte count computed during decompression) so the response-size metric reuses that count rather than re-encoding the decoded String with a throwaway `toByteArray()`.

**Security / hygiene**
- Secret redaction and assorted error-handling/validation tightening across agent and common utilities.

**Containers**
- `proxy.df` / `agent.df` switched to the prebuilt `bellsoft/liberica-openjre-alpine:17` base image (matches the already-merged #152; merges as a no-op).

## Tests
New/expanded coverage for `AgentContextManager`, `ProxyUtils`, `ProxyServiceImpl`, `AgentHttpService`, `AgentConnectionContext`, `HttpClientCache`, `Utils`, options parsing, and a TLS mutual-auth rejection harness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)