### PR TITLE
Dedup the temp-keystore test helper

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
@@ -49,9 +50,6 @@ import io.prometheus.grpc.scrapeRequest
 import io.prometheus.common.startAndAwaitReady
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
-import java.io.File
-import java.io.FileOutputStream
-import java.security.KeyStore
 import javax.net.ssl.X509TrustManager
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
@@ -1361,7 +1359,7 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "resolveHttpsTrustManager prefers trust-all over a configured trust store" {
-      val (path, password) = createTempTrustStore()
+      val (path, password) = createTempKeyStore("agent-https-truststore-test")
       AgentHttpService.resolveHttpsTrustManager(
         trustAllX509Certificates = true,
         trustStorePath = path,
@@ -1370,7 +1368,7 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "resolveHttpsTrustManager loads an X509TrustManager from a configured trust store" {
-      val (path, password) = createTempTrustStore()
+      val (path, password) = createTempKeyStore("agent-https-truststore-test")
       val tm =
         AgentHttpService.resolveHttpsTrustManager(
           trustAllX509Certificates = false,
@@ -1378,7 +1376,7 @@ class AgentHttpServiceTest : StringSpec() {
           trustStorePassword = password,
         )
       tm.shouldBeInstanceOf<X509TrustManager>()
-      (tm === TrustAllX509TrustManager) shouldBe false
+      tm shouldNotBe TrustAllX509TrustManager
     }
 
     "resolveHttpsTrustManager returns null for the JDK default (no trust-all, empty path)" {
@@ -1388,17 +1386,5 @@ class AgentHttpServiceTest : StringSpec() {
         trustStorePassword = "",
       ).shouldBeNull()
     }
-  }
-
-  // Creates an empty keystore in a temp file and returns its path and password.
-  private fun createTempTrustStore(): Pair<String, String> {
-    val password = "test-password"
-    val tmpFile = File.createTempFile("agent-https-truststore-test", ".jks")
-    tmpFile.deleteOnExit()
-    KeyStore.getInstance(KeyStore.getDefaultType()).apply {
-      load(null, null)
-      FileOutputStream(tmpFile).use { store(it, password.toCharArray()) }
-    }
-    return tmpFile.absolutePath to password
   }
 }

--- a/src/test/kotlin/io/prometheus/agent/KeyStoreTestSupport.kt
+++ b/src/test/kotlin/io/prometheus/agent/KeyStoreTestSupport.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicFunction")
+
+package io.prometheus.agent
+
+import java.io.File
+import java.io.FileOutputStream
+import java.security.KeyStore
+
+/**
+ * Creates an empty keystore (default JKS/PKCS12 type) in an auto-deleted temp file and returns its
+ * path and password. Shared by the SslSettings and AgentHttpService trust-store tests.
+ */
+internal fun createTempKeyStore(prefix: String = "keystore-test"): Pair<String, String> {
+  val password = "test-password"
+  val tmpFile = File.createTempFile(prefix, ".jks")
+  tmpFile.deleteOnExit()
+  KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+    load(null, null)
+    FileOutputStream(tmpFile).use { store(it, password.toCharArray()) }
+  }
+  return tmpFile.absolutePath to password
+}

--- a/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/SslSettingsTest.kt
@@ -24,9 +24,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileOutputStream
 import java.security.KeyStore
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
@@ -152,17 +150,5 @@ class SslSettingsTest : StringSpec() {
       trustManagers.isNotEmpty() shouldBe true
       trustManagers[0].shouldBeInstanceOf<X509TrustManager>()
     }
-  }
-
-  // Creates an empty keystore in a temp file and returns its path and password.
-  private fun createTempKeyStore(): Pair<String, String> {
-    val password = "test-password"
-    val tmpFile = File.createTempFile("ssl-settings-test", ".jks")
-    tmpFile.deleteOnExit()
-    KeyStore.getInstance(KeyStore.getDefaultType()).apply {
-      load(null, null)
-      FileOutputStream(tmpFile).use { store(it, password.toCharArray()) }
-    }
-    return tmpFile.absolutePath to password
   }
 }


### PR DESCRIPTION
Follow-up cleanup from PR #155's `/simplify` review.

`AgentHttpServiceTest.createTempTrustStore` was a near-verbatim copy of
`SslSettingsTest.createTempKeyStore` — both build an empty JKS in a temp file and return
`(path, password)`.

- Extract a single shared `createTempKeyStore(prefix)` into `KeyStoreTestSupport.kt`
  (package `io.prometheus.agent`); both tests call it.
- Drop the now-unused `File` / `FileOutputStream` imports (and `KeyStore` in `AgentHttpServiceTest`,
  where it was only used by the removed helper; `SslSettingsTest` keeps `KeyStore`, still used elsewhere).
- Switch the trust-manager identity assertion to `tm shouldNotBe TrustAllX509TrustManager` for
  matcher-style consistency — the last leftover nit from the `/simplify` review.

Test-only; no production code or behavior changed. Verified: compile, detekt, lint, and
`SslSettingsTest` + `AgentHttpServiceTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)