### PR TITLE
Collapse ConfigWrappers overloads onto shared private builders

### DIFF
--- a/src/main/kotlin/io/prometheus/common/ConfigWrappers.kt
+++ b/src/main/kotlin/io/prometheus/common/ConfigWrappers.kt
@@ -24,79 +24,111 @@ import com.pambrose.common.service.ZipkinConfig
 
 @Suppress("unused")
 internal object ConfigWrappers {
+  // The proxy.* and agent.* admin/metrics/zipkin blocks have identical fields but tscfg emits
+  // distinct types per path (Proxy2.Admin2 vs Agent.Admin, etc.), so each config needs an overload
+  // per role. Each overload only extracts the role-specific fields and delegates to a single private
+  // builder, so the actual AdminConfig/MetricsConfig/ZipkinConfig construction is defined once.
+
   fun newAdminConfig(
     enabled: Boolean,
     port: Int,
     admin: ConfigVals.Proxy2.Admin2,
-  ) = AdminConfig(
-    enabled = enabled,
-    port = port,
-    pingPath = admin.pingPath,
-    versionPath = admin.versionPath,
-    healthCheckPath = admin.healthCheckPath,
-    threadDumpPath = admin.threadDumpPath,
-  )
+  ) = adminConfig(enabled, port, admin.pingPath, admin.versionPath, admin.healthCheckPath, admin.threadDumpPath)
 
   fun newAdminConfig(
     enabled: Boolean,
     port: Int,
     admin: ConfigVals.Agent.Admin,
-  ) = AdminConfig(
-    enabled = enabled,
-    port = port,
-    pingPath = admin.pingPath,
-    versionPath = admin.versionPath,
-    healthCheckPath = admin.healthCheckPath,
-    threadDumpPath = admin.threadDumpPath,
-  )
+  ) = adminConfig(enabled, port, admin.pingPath, admin.versionPath, admin.healthCheckPath, admin.threadDumpPath)
 
   fun newMetricsConfig(
     enabled: Boolean,
     port: Int,
     metrics: ConfigVals.Proxy2.Metrics2,
-  ) = MetricsConfig(
-    enabled = enabled,
-    port = port,
-    path = metrics.path,
-    standardExportsEnabled = metrics.standardExportsEnabled,
-    memoryPoolsExportsEnabled = metrics.memoryPoolsExportsEnabled,
-    garbageCollectorExportsEnabled = metrics.garbageCollectorExportsEnabled,
-    threadExportsEnabled = metrics.threadExportsEnabled,
-    classLoadingExportsEnabled = metrics.classLoadingExportsEnabled,
-    versionInfoExportsEnabled = metrics.versionInfoExportsEnabled,
+  ) = metricsConfig(
+    enabled,
+    port,
+    metrics.path,
+    metrics.standardExportsEnabled,
+    metrics.memoryPoolsExportsEnabled,
+    metrics.garbageCollectorExportsEnabled,
+    metrics.threadExportsEnabled,
+    metrics.classLoadingExportsEnabled,
+    metrics.versionInfoExportsEnabled,
   )
 
   fun newMetricsConfig(
     enabled: Boolean,
     port: Int,
     metrics: ConfigVals.Agent.Metrics,
-  ) = MetricsConfig(
-    enabled = enabled,
-    port = port,
-    path = metrics.path,
-    standardExportsEnabled = metrics.standardExportsEnabled,
-    memoryPoolsExportsEnabled = metrics.memoryPoolsExportsEnabled,
-    garbageCollectorExportsEnabled = metrics.garbageCollectorExportsEnabled,
-    threadExportsEnabled = metrics.threadExportsEnabled,
-    classLoadingExportsEnabled = metrics.classLoadingExportsEnabled,
-    versionInfoExportsEnabled = metrics.versionInfoExportsEnabled,
+  ) = metricsConfig(
+    enabled,
+    port,
+    metrics.path,
+    metrics.standardExportsEnabled,
+    metrics.memoryPoolsExportsEnabled,
+    metrics.garbageCollectorExportsEnabled,
+    metrics.threadExportsEnabled,
+    metrics.classLoadingExportsEnabled,
+    metrics.versionInfoExportsEnabled,
   )
 
   fun newZipkinConfig(zipkin: ConfigVals.Proxy2.Internal2.Zipkin2) =
-    ZipkinConfig(
-      enabled = zipkin.enabled,
-      hostname = zipkin.hostname,
-      port = zipkin.port,
-      path = zipkin.path,
-      serviceName = zipkin.serviceName,
-    )
+    zipkinConfig(zipkin.enabled, zipkin.hostname, zipkin.port, zipkin.path, zipkin.serviceName)
 
   fun newZipkinConfig(zipkin: ConfigVals.Agent.Internal.Zipkin) =
-    ZipkinConfig(
-      enabled = zipkin.enabled,
-      hostname = zipkin.hostname,
-      port = zipkin.port,
-      path = zipkin.path,
-      serviceName = zipkin.serviceName,
-    )
+    zipkinConfig(zipkin.enabled, zipkin.hostname, zipkin.port, zipkin.path, zipkin.serviceName)
+
+  private fun adminConfig(
+    enabled: Boolean,
+    port: Int,
+    pingPath: String,
+    versionPath: String,
+    healthCheckPath: String,
+    threadDumpPath: String,
+  ) = AdminConfig(
+    enabled = enabled,
+    port = port,
+    pingPath = pingPath,
+    versionPath = versionPath,
+    healthCheckPath = healthCheckPath,
+    threadDumpPath = threadDumpPath,
+  )
+
+  // Parameters are in MetricsConfig field order; callers pass the matching tscfg fields in that order.
+  private fun metricsConfig(
+    enabled: Boolean,
+    port: Int,
+    path: String,
+    standardExportsEnabled: Boolean,
+    memoryPoolsExportsEnabled: Boolean,
+    garbageCollectorExportsEnabled: Boolean,
+    threadExportsEnabled: Boolean,
+    classLoadingExportsEnabled: Boolean,
+    versionInfoExportsEnabled: Boolean,
+  ) = MetricsConfig(
+    enabled = enabled,
+    port = port,
+    path = path,
+    standardExportsEnabled = standardExportsEnabled,
+    memoryPoolsExportsEnabled = memoryPoolsExportsEnabled,
+    garbageCollectorExportsEnabled = garbageCollectorExportsEnabled,
+    threadExportsEnabled = threadExportsEnabled,
+    classLoadingExportsEnabled = classLoadingExportsEnabled,
+    versionInfoExportsEnabled = versionInfoExportsEnabled,
+  )
+
+  private fun zipkinConfig(
+    enabled: Boolean,
+    hostname: String,
+    port: Int,
+    path: String,
+    serviceName: String,
+  ) = ZipkinConfig(
+    enabled = enabled,
+    hostname = hostname,
+    port = port,
+    path = path,
+    serviceName = serviceName,
+  )
 }


### PR DESCRIPTION
Code-review cleanup #21. `ConfigWrappers` had three pairs of overloads (`newAdminConfig` / `newMetricsConfig` / `newZipkinConfig`) with byte-identical bodies that differed only in the tscfg-generated parameter type (`Proxy2.Admin2` vs `Agent.Admin`, etc.) — most notably `newMetricsConfig` duplicated a 7-field `MetricsConfig(...)` construction twice.

tscfg emits a distinct type per config path, so the per-role overloads must stay. But each overload now only extracts its role-specific fields and delegates to a single `private` builder (`adminConfig` / `metricsConfig` / `zipkinConfig`), so each `AdminConfig` / `MetricsConfig` / `ZipkinConfig` construction is defined **once** instead of duplicated.

Public API (`newAdminConfig`/`newMetricsConfig`/`newZipkinConfig`) is unchanged — callers in `Agent`/`Proxy` and the 22-assertion `ConfigWrappersTest` are untouched.

## Verification
Behavior-preserving — `ConfigWrappersTest` + `DataClassTest` pass and the full `./gradlew build` is green (the one transient `:test` failure during development was a known harness flake; a clean re-run passed). Coverage ~94%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)