### PR TITLE
Append encoded query params verbatim instead of URL-decoding them

### DIFF
--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -73,19 +73,26 @@ internal object Utils {
         if (eq < 0) param else param.substring(0, eq + 1) + REDACTED
       }
 
+  /**
+   * Appends an already-URL-encoded query string (as produced by Ktor's `formUrlEncode()`, i.e. raw
+   * `=`/`&` delimiters with percent-encoded keys/values) to [baseUrl].
+   *
+   * The encoded string is appended verbatim rather than URL-decoded first: decoding the whole blob
+   * would turn an encoded delimiter inside a value (e.g. `%26`, `%23`) into a real `&`/`#`, splitting
+   * one parameter into several or starting a fragment.
+   */
   fun appendQueryParams(
     baseUrl: String,
     encodedQueryParams: String,
   ): String {
     if (encodedQueryParams.isBlank()) return baseUrl
-    val decodedParams = URLDecoder.decode(encodedQueryParams, UTF_8)
     val separator =
       when {
         '?' !in baseUrl -> "?"
         baseUrl.endsWith("?") || baseUrl.endsWith("&") -> ""
         else -> "&"
       }
-    return "$baseUrl$separator$decodedParams"
+    return "$baseUrl$separator$encodedQueryParams"
   }
 
   internal fun String.defaultEmptyJsonObject() = ifEmpty { "{}" }

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -435,7 +435,7 @@ class AgentHttpServiceTest : StringSpec() {
           path = "metrics"
           accept = ""
           debugEnabled = false
-          encodedQueryParams = "foo%3Dbar"
+          encodedQueryParams = "foo=bar"
           authHeader = ""
         }
 
@@ -477,7 +477,7 @@ class AgentHttpServiceTest : StringSpec() {
           path = "metrics"
           accept = ""
           debugEnabled = false
-          encodedQueryParams = "foo%3Dbar"
+          encodedQueryParams = "foo=bar"
           authHeader = ""
         }
 

--- a/src/test/kotlin/io/prometheus/common/UtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/UtilsTest.kt
@@ -88,23 +88,35 @@ class UtilsTest : StringSpec() {
     }
 
     // ==================== appendQueryParams Tests ====================
+    // The input is an already-encoded query string (formUrlEncode output): raw =/& delimiters with
+    // percent-encoded keys/values. appendQueryParams appends it verbatim, preserving the encoding.
 
-    "appendQueryParams should append query params to base url without query" {
-      val url = appendQueryParams("http://localhost:8080/metrics", "foo%3Dbar%26baz%3Dqux")
+    "appendQueryParams should append an encoded query string to a base url without query" {
+      val url = appendQueryParams("http://localhost:8080/metrics", "foo=bar&baz=qux")
 
       url shouldBe "http://localhost:8080/metrics?foo=bar&baz=qux"
     }
 
-    "appendQueryParams should append query params to base url with existing query" {
-      val url = appendQueryParams("http://localhost:8080/metrics?existing=1", "foo%3Dbar")
+    "appendQueryParams should append to a base url with an existing query using &" {
+      val url = appendQueryParams("http://localhost:8080/metrics?existing=1", "foo=bar")
 
       url shouldBe "http://localhost:8080/metrics?existing=1&foo=bar"
     }
 
-    "appendQueryParams should handle base url ending with delimiter" {
-      val url = appendQueryParams("http://localhost:8080/metrics?", "foo%3Dbar")
+    "appendQueryParams should not add a separator when the base url already ends with ? or &" {
+      appendQueryParams("http://localhost:8080/metrics?", "foo=bar") shouldBe
+        "http://localhost:8080/metrics?foo=bar"
+    }
 
-      url shouldBe "http://localhost:8080/metrics?foo=bar"
+    "appendQueryParams should return the base url unchanged for blank params" {
+      appendQueryParams("http://localhost:8080/metrics", "") shouldBe "http://localhost:8080/metrics"
+    }
+
+    // The fix: an encoded delimiter inside a value must stay encoded, not be decoded into a real
+    // & (which would split one param into two) or # (which would start a URL fragment).
+    "appendQueryParams should preserve encoded delimiters inside a value" {
+      appendQueryParams("http://localhost:8080/metrics", "q=a%26b%23c") shouldBe
+        "http://localhost:8080/metrics?q=a%26b%23c"
     }
 
     // ==================== lowercase Tests ====================


### PR DESCRIPTION
Code-review cleanup #24.

`Utils.appendQueryParams` ran `URLDecoder.decode` on the whole encoded query string before concatenating it onto the scrape URL. The input is already a valid encoded query string (Ktor `formUrlEncode()` output — raw `=`/`&` delimiters, percent-encoded values), so decoding it then re-concatenating turns an **encoded delimiter inside a value** (e.g. `%26`, `%23`) into a real `&`/`#`, splitting one parameter into several or starting a URL fragment.

Fix: append the encoded string verbatim and let the encoding stand. The `?`/`&` separator logic is unchanged.

## Behavior
- Ordinary params (no special chars): resulting URL is **identical**.
- Values with encoded special characters: now forwarded **correctly encoded** to the target instead of decoded/corrupted.

Not SSRF — the scrape host is fixed by agent-side HOCON `pathConfigs`, and Prometheus is trusted — but the old pattern was fragile.

## Tests
- `UtilsTest`: rewrote the three cases to use realistic `formUrlEncode` input, added a blank-params case, and a **preservation** case (`q=a%26b%23c` stays encoded) that pins the fix.
- `AgentHttpServiceTest`: the two query tests used the unrealistic `foo%3Dbar` (encoded `=` delimiter) that only passed because of the old decode; switched to real `foo=bar`.

Full `./gradlew build` green; coverage ~94.2%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)