### PR TITLE
Hash basic-auth credentials in the HttpClientCache cache key

### DIFF
--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.security.SecureRandom
 import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.decrementAndFetch
@@ -135,11 +138,29 @@ internal class HttpClientCache(
     // Mask credentials to avoid logging sensitive data
     internal fun maskedKey() = if (hasAuth()) "***:***" else NO_AUTH
 
-    // Internal key for cache lookup (not logged)
-    internal fun cacheKey() = if (hasAuth()) "$username:$password" else NO_AUTH
+    // Cache-map key derived from a salted HMAC of the credentials rather than the raw
+    // "username:password". This keeps the plaintext password out of the long-lived map key (which
+    // would otherwise sit on the heap for the cache lifetime, up to maxAge). Residual exposure
+    // remains and is by design: this ClientKey instance and the built HttpClient still hold the raw
+    // credentials in memory — basic-auth requires them to issue requests — so this only removes the
+    // extra long-lived plaintext copy, not all of them.
+    internal fun cacheKey() = if (hasAuth()) credentialDigest("$username:$password") else NO_AUTH
 
     companion object {
       internal const val NO_AUTH = "__no_auth__"
+
+      private const val SALT_BYTES = 16
+      private const val HMAC_ALGORITHM = "HmacSHA256"
+
+      // Per-process random salt: the digest is stable within a run (so equal credentials map to the
+      // same cache entry) but is not a plain, precomputable hash of the credentials.
+      private val SALT: ByteArray = ByteArray(SALT_BYTES).also { SecureRandom().nextBytes(it) }
+
+      private fun credentialDigest(credentials: String): String =
+        Mac.getInstance(HMAC_ALGORITHM)
+          .apply { init(SecretKeySpec(SALT, HMAC_ALGORITHM)) }
+          .doFinal(credentials.toByteArray(Charsets.UTF_8))
+          .joinToString("") { "%02x".format(it.toInt() and 0xFF) }
     }
   }
 
@@ -234,8 +255,9 @@ internal class HttpClientCache(
   private fun evictLeastRecentlyUsed() {
     val lruKey = accessOrder.entries.minByOrNull { it.value }?.key
     if (lruKey != null) {
-      // Mask the key if it contains credentials (not NO_AUTH)
-      val logKey = if (lruKey != ClientKey.NO_AUTH && ":" in lruKey) "***:***" else lruKey
+      // The cache key for authenticated clients is a salted digest (non-sensitive), but mask it
+      // anyway so eviction logs never expose a per-credential identifier; NO_AUTH is left as-is.
+      val logKey = if (lruKey == ClientKey.NO_AUTH) lruKey else "***:***"
       logger.info { "Evicting LRU HTTP client for key: $logKey" }
       removeEntry(lruKey)
     }

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -27,6 +27,8 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldMatch
+import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.mockk.every
@@ -361,22 +363,35 @@ class HttpClientCacheTest : StringSpec() {
 
     "should handle client key toString correctly" {
       // toString() should mask credentials for security
-      val key1 = ClientKey("user", "pass")
-      key1.toString() shouldBe "***:***"
-      // cacheKey() returns actual value for internal use
-      key1.cacheKey() shouldBe "user:pass"
+      ClientKey("user", "pass").toString() shouldBe "***:***"
+      ClientKey(null, "pass").toString() shouldBe NO_AUTH
+      ClientKey("user", null).toString() shouldBe NO_AUTH
+      ClientKey(null, null).toString() shouldBe NO_AUTH
+    }
 
-      val key2 = ClientKey(null, "pass")
-      key2.toString() shouldBe NO_AUTH
-      key2.cacheKey() shouldBe NO_AUTH
+    // Item 25: the cache key must not embed the plaintext password. The raw "user:pass" string was
+    // previously used as the live ConcurrentHashMap key, leaving the password resident on the heap
+    // for the cache lifetime. cacheKey() now returns a salted HMAC digest of the credentials.
+    "cacheKey should be a salted digest that never exposes the plaintext credentials" {
+      val digest = ClientKey("user", "s3cr3t").cacheKey()
 
-      val key3 = ClientKey("user", null)
-      key3.toString() shouldBe NO_AUTH
-      key3.cacheKey() shouldBe NO_AUTH
+      // Never the raw credentials; neither component appears in the key
+      digest shouldNotBe "user:s3cr3t"
+      digest shouldNotContain "s3cr3t"
+      digest shouldNotContain "user"
+      // HMAC-SHA256 hex encoding: 64 lowercase hex characters
+      digest shouldMatch "[0-9a-f]{64}"
 
-      val key4 = ClientKey(null, null)
-      key4.toString() shouldBe NO_AUTH
-      key4.cacheKey() shouldBe NO_AUTH
+      // Stable within the process so equal credentials reuse the same cache entry, while distinct
+      // credentials (differing in either component) map to distinct entries.
+      ClientKey("user", "s3cr3t").cacheKey() shouldBe digest
+      ClientKey("user", "other").cacheKey() shouldNotBe digest
+      ClientKey("other", "s3cr3t").cacheKey() shouldNotBe digest
+
+      // No-auth keys are left as the sentinel
+      ClientKey(null, "pass").cacheKey() shouldBe NO_AUTH
+      ClientKey("user", null).cacheKey() shouldBe NO_AUTH
+      ClientKey(null, null).cacheKey() shouldBe NO_AUTH
     }
 
     "should handle cache entry lifecycle properly" {


### PR DESCRIPTION
## Summary

Addresses code-review item #25. `ClientKey.cacheKey()` previously used the raw `"username:password"` string as the live `ConcurrentHashMap` key, leaving the plaintext password resident on the heap as an immutable `String` for the cache lifetime (up to `maxAge`).

This derives the cache key from a **per-process salted HMAC-SHA256 digest** of the credentials instead, so the plaintext password no longer sits in the long-lived map key.

## Details

- `cacheKey()` returns `credentialDigest("$username:$password")` (64-char hex) when authenticated, `NO_AUTH` otherwise.
- The salt is a 16-byte per-process `SecureRandom` value: the digest is stable within a run (equal credentials reuse the same cache entry) but is not a precomputable hash.
- The digest is non-sensitive, so the LRU eviction log is simplified to mask any non-`NO_AUTH` key as `***:***`.
- **Residual exposure is unchanged and by design:** the `ClientKey` instance and the built `HttpClient` still hold the raw credentials, since basic auth requires them to issue requests. This change only removes the extra long-lived plaintext copy in the map key.

## Tests

- Reworked the `toString` masking test and added `cacheKey should be a salted digest that never exposes the plaintext credentials`, asserting: no plaintext, 64-char hex, stability for equal creds, distinctness for differing creds, and `NO_AUTH` for partial/absent creds.
- `./gradlew detekt lintKotlinMain lintKotlinTest` clean; full `./gradlew build` green (94.2% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)