### PR TITLE
Apply low-severity code-review polish across proxy, agent, and common

### DIFF
--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -181,8 +181,9 @@ class Proxy(
   internal val agentContextManager = AgentContextManager(isTestMode)
   internal val scrapeRequestManager = ScrapeRequestManager()
 
-  // Per-process id (mirrors Agent.launchId) so proxy metric series can be disambiguated across
-  // restarts — e.g. proxy_start_time_seconds is labeled with it.
+  // Per-process id (mirrors Agent.launchId). Intentionally used to label only proxy_start_time_seconds,
+  // which is enough to detect a restart on a Prometheus target; the counters/histograms are left
+  // unlabeled since PromQL rate()/increase() already tolerate counter resets across restarts.
   internal val launchId = randomId(15)
 
   val proxyConfigVals: ConfigVals.Proxy2 get() = configVals.proxy

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -26,6 +26,7 @@ import com.pambrose.common.time.format
 import com.pambrose.common.util.MetricsUtils.newMapHealthCheck
 import com.pambrose.common.util.Version
 import com.pambrose.common.util.getBanner
+import com.pambrose.common.util.randomId
 import com.pambrose.common.util.simpleClassName
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.prometheus.common.BaseOptions.Companion.DEBUG
@@ -179,6 +180,10 @@ class Proxy(
   internal val pathManager by lazy { ProxyPathManager(this, isTestMode) }
   internal val agentContextManager = AgentContextManager(isTestMode)
   internal val scrapeRequestManager = ScrapeRequestManager()
+
+  // Per-process id (mirrors Agent.launchId) so proxy metric series can be disambiguated across
+  // restarts — e.g. proxy_start_time_seconds is labeled with it.
+  internal val launchId = randomId(15)
 
   val proxyConfigVals: ConfigVals.Proxy2 get() = configVals.proxy
 

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -285,12 +285,11 @@ internal class AgentHttpService(
       }
 
       // Setup authentication if username and password are specified
-      if (clientKey.hasAuth()) {
+      clientKey.credentials?.let { creds ->
         install(Auth) {
           basic {
             credentials {
-              // These are known to be non-null because of the hasAuth() check above
-              BasicAuthCredentials(clientKey.username!!, clientKey.password!!)
+              BasicAuthCredentials(creds.username, creds.password)
             }
           }
         }

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -127,11 +127,24 @@ internal class HttpClientCache(
     }
   }
 
+  // A basic-auth credential pair. Modeling username+password as a single non-nullable value object
+  // (rather than two independent nullables on ClientKey) makes the "both-or-neither" invariant
+  // unrepresentable to violate and removes the need for !! at the use sites.
+  data class Credentials(
+    val username: String,
+    val password: String,
+  )
+
   data class ClientKey(
-    val username: String?,
-    val password: String?,
+    val credentials: Credentials?,
   ) {
-    fun hasAuth() = username != null && password != null
+    // Convenience that enforces the both-or-neither auth gate in one place: credentials exist only
+    // when both username and password are present.
+    constructor(username: String?, password: String?) : this(
+      if (username != null && password != null) Credentials(username, password) else null,
+    )
+
+    fun hasAuth() = credentials != null
 
     override fun toString() = maskedKey()
 
@@ -144,7 +157,7 @@ internal class HttpClientCache(
     // remains and is by design: this ClientKey instance and the built HttpClient still hold the raw
     // credentials in memory — basic-auth requires them to issue requests — so this only removes the
     // extra long-lived plaintext copy, not all of them.
-    internal fun cacheKey() = if (hasAuth()) credentialDigest("$username:$password") else NO_AUTH
+    internal fun cacheKey() = credentials?.let { credentialDigest("${it.username}:${it.password}") } ?: NO_AUTH
 
     companion object {
       internal const val NO_AUTH = "__no_auth__"

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -270,20 +270,20 @@ abstract class BaseOptions protected constructor(
     assignConfigVals()
   }
 
+  // Renders a gRPC timeout/keepalive field for logging: the resolved value, or "default (<descriptor>)"
+  // when the field is still at the -1L "leave the gRPC built-in default in place" sentinel.
+  protected fun Long.grpcDefaultLabel(default: String): Any = if (this == -1L) "default ($default)" else this
+
   protected fun assignKeepAliveTimeSecs(defaultVal: Long) {
     if (keepAliveTimeSecs == -1L)
       keepAliveTimeSecs = KEEPALIVE_TIME_SECS.getEnv(defaultVal)
-    logger.info {
-      "grpc.keepAliveTimeSecs: ${if (keepAliveTimeSecs == -1L) "unset (gRPC default)" else keepAliveTimeSecs}"
-    }
+    logger.info { "grpc.keepAliveTimeSecs: ${keepAliveTimeSecs.grpcDefaultLabel("gRPC default")}" }
   }
 
   protected fun assignKeepAliveTimeoutSecs(defaultVal: Long) {
     if (keepAliveTimeoutSecs == -1L)
       keepAliveTimeoutSecs = KEEPALIVE_TIMEOUT_SECS.getEnv(defaultVal)
-    logger.info {
-      "grpc.keepAliveTimeoutSecs: ${if (keepAliveTimeoutSecs == -1L) "unset (gRPC default)" else keepAliveTimeoutSecs}"
-    }
+    logger.info { "grpc.keepAliveTimeoutSecs: ${keepAliveTimeoutSecs.grpcDefaultLabel("gRPC default")}" }
   }
 
   protected fun assignAdminEnabled(defaultVal: Boolean) {

--- a/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
@@ -61,7 +61,7 @@ internal class AgentContext(
     private set
   var agentName: String by nonNullableReference("Unassigned")
     private set
-  var consolidated: Boolean by nonNullableReference(false)
+  var consolidated: Boolean by atomicBoolean(false)
     private set
 
   internal val desc: String

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -50,6 +50,7 @@ import java.io.IOException
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 
 /**
  * HTTP routing logic for the proxy's Ktor server.
@@ -199,7 +200,16 @@ internal object ProxyHttpRoutes {
           async { submitScrapeRequest(agentContext, proxy, path, queryParams, call.request) }
         }
         .awaitAll()
-        .onEach { response -> logActivityForResponse(path, response, proxy) }
+        .onEach { response ->
+          logActivityForResponse(path, response, proxy)
+          // Record latency labeled with the request outcome. This single site covers every outcome
+          // — including the timeout and agent-disconnected early returns the old per-request timer
+          // missed — since each branch yields a ScrapeRequestResponse with updateMsg + fetchDuration.
+          proxy.metrics {
+            val elapsedSecs = response.fetchDuration.toDouble(DurationUnit.SECONDS)
+            scrapeRequestLatency.labels(path, response.updateMsg).observe(elapsedSecs)
+          }
+        }
     }
 
   private fun logActivityForResponse(
@@ -364,7 +374,6 @@ internal object ProxyHttpRoutes {
 
     return ScrapeRequestWrapper(
       agentContext = agentContext,
-      proxy = proxy,
       pathVal = path,
       encodedQueryParamsVal = encodedQueryParams,
       authHeaderVal = authHeader,

--- a/src/main/kotlin/io/prometheus/proxy/ProxyMetrics.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyMetrics.kt
@@ -56,7 +56,7 @@ internal class ProxyMetrics(
     Histogram.build()
       .name("proxy_scrape_request_latency_seconds")
       .help("Proxy scrape request latency in seconds")
-      .labelNames("path")
+      .labelNames("path", "outcome")
       .buckets(.005, .01, .025, .05, .1, .25, .5, 1.0, 2.5, 5.0, 10.0)
       .register()
 
@@ -90,8 +90,9 @@ internal class ProxyMetrics(
   init {
     gauge {
       name("proxy_start_time_seconds")
+      labelNames(LAUNCH_ID)
       help("Proxy start time in seconds")
-    }.setToCurrentTime()
+    }.labels(proxy.launchId).setToCurrentTime()
 
     SamplerGaugeCollector(
       name = "proxy_agent_map_size",
@@ -125,6 +126,7 @@ internal class ProxyMetrics(
   }
 
   companion object {
+    private const val LAUNCH_ID = "launch_id"
     const val STAGE_CHUNK = "chunk"
     const val STAGE_SUMMARY = "summary"
     const val ENCODING_GZIPPED = "gzipped"

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -191,8 +191,7 @@ class ProxyOptions(
         if (handshakeTimeoutSecs == -1L)
           handshakeTimeoutSecs = HANDSHAKE_TIMEOUT_SECS.getEnv(proxyConfigVals.grpc.handshakeTimeoutSecs)
         requireGrpcTimeout(handshakeTimeoutSecs, "grpc.handshakeTimeoutSecs")
-        val hsTimeout = if (handshakeTimeoutSecs == -1L) "default (120)" else handshakeTimeoutSecs
-        logger.info { "grpc.handshakeTimeoutSecs: $hsTimeout" }
+        logger.info { "grpc.handshakeTimeoutSecs: ${handshakeTimeoutSecs.grpcDefaultLabel("120")}" }
 
         permitKeepAliveWithoutCalls =
           resolveBooleanOption(
@@ -206,27 +205,23 @@ class ProxyOptions(
         if (permitKeepAliveTimeSecs == -1L)
           permitKeepAliveTimeSecs = PERMIT_KEEPALIVE_TIME_SECS.getEnv(proxyConfigVals.grpc.permitKeepAliveTimeSecs)
         requireGrpcTimeout(permitKeepAliveTimeSecs, "grpc.permitKeepAliveTimeSecs")
-        val kaTime = if (permitKeepAliveTimeSecs == -1L) "default (300)" else permitKeepAliveTimeSecs
-        logger.info { "grpc.permitKeepAliveTimeSecs: $kaTime" }
+        logger.info { "grpc.permitKeepAliveTimeSecs: ${permitKeepAliveTimeSecs.grpcDefaultLabel("300")}" }
 
         if (maxConnectionIdleSecs == -1L)
           maxConnectionIdleSecs = MAX_CONNECTION_IDLE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionIdleSecs)
         requireGrpcTimeout(maxConnectionIdleSecs, "grpc.maxConnectionIdleSecs")
-        val idleVal = if (maxConnectionIdleSecs == -1L) "default (INT_MAX)" else maxConnectionIdleSecs
-        logger.info { "grpc.maxConnectionIdleSecs: $idleVal" }
+        logger.info { "grpc.maxConnectionIdleSecs: ${maxConnectionIdleSecs.grpcDefaultLabel("INT_MAX")}" }
 
         if (maxConnectionAgeSecs == -1L)
           maxConnectionAgeSecs = MAX_CONNECTION_AGE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionAgeSecs)
         requireGrpcTimeout(maxConnectionAgeSecs, "grpc.maxConnectionAgeSecs")
-        val ageVal = if (maxConnectionAgeSecs == -1L) "default (INT_MAX)" else maxConnectionAgeSecs
-        logger.info { "grpc.maxConnectionAgeSecs: $ageVal" }
+        logger.info { "grpc.maxConnectionAgeSecs: ${maxConnectionAgeSecs.grpcDefaultLabel("INT_MAX")}" }
 
         if (maxConnectionAgeGraceSecs == -1L)
           maxConnectionAgeGraceSecs =
             MAX_CONNECTION_AGE_GRACE_SECS.getEnv(proxyConfigVals.grpc.maxConnectionAgeGraceSecs)
         requireGrpcTimeout(maxConnectionAgeGraceSecs, "grpc.maxConnectionAgeGraceSecs")
-        val graceVal = if (maxConnectionAgeGraceSecs == -1L) "default (INT_MAX)" else maxConnectionAgeGraceSecs
-        logger.info { "grpc.maxConnectionAgeGraceSecs: $graceVal" }
+        logger.info { "grpc.maxConnectionAgeGraceSecs: ${maxConnectionAgeGraceSecs.grpcDefaultLabel("INT_MAX")}" }
 
         proxyConfigVals.apply {
           assignCommonOptions(
@@ -243,6 +238,9 @@ class ProxyOptions(
             trustCertCollectionFilePath = tls.trustCertCollectionFilePath,
           )
 
+          require(internal.scrapeRequestTimeoutSecs > 0) {
+            "internal.scrapeRequestTimeoutSecs must be > 0: ${internal.scrapeRequestTimeoutSecs}"
+          }
           logger.info { "internal.scrapeRequestTimeoutSecs: ${internal.scrapeRequestTimeoutSecs}" }
           logger.info { "internal.staleAgentCheckPauseSecs: ${internal.staleAgentCheckPauseSecs}" }
           logger.info { "internal.maxAgentInactivitySecs: ${internal.maxAgentInactivitySecs}" }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -95,16 +95,16 @@ internal class ProxyServiceImpl(
   }
 
   override suspend fun registerAgent(request: RegisterAgentRequest): RegisterAgentResponse {
-    var isValid = false
+    val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
+    if (agentContext == null) {
+      logger.error { "registerAgent() missing AgentContext agentId: ${request.agentId}" }
+    } else {
+      agentContext.assignProperties(request)
+      agentContext.markActivityTime(false)
+      logger.info { "Connected to $agentContext" }
+    }
 
-    proxy.agentContextManager.getAgentContext(request.agentId)
-      ?.apply {
-        isValid = true
-        assignProperties(request)
-        markActivityTime(false)
-        logger.info { "Connected to $this" }
-      } ?: logger.error { "registerAgent() missing AgentContext agentId: ${request.agentId}" }
-
+    val isValid = agentContext != null
     return registerAgentResponse {
       valid = isValid
       agentId = request.agentId
@@ -115,24 +115,23 @@ internal class ProxyServiceImpl(
   }
 
   override suspend fun registerPath(request: RegisterPathRequest): RegisterPathResponse {
-    var isValid = false
-    var failureReason = ""
+    val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
+    // addPath() returns null on success or a failure message; failureReason is null iff valid.
+    val failureReason =
+      if (agentContext == null) {
+        logger.error { "Missing AgentContext for agentId: ${request.agentId}" }
+        "Invalid agentId: ${request.agentId} (registerPath)"
+      } else {
+        proxy.pathManager.addPath(request.path, request.labels, agentContext)
+          .also { agentContext.markActivityTime(false) }
+      }
 
-    proxy.agentContextManager.getAgentContext(request.agentId)
-      ?.apply {
-        val addPathResult = proxy.pathManager.addPath(request.path, request.labels, this)
-        isValid = addPathResult == null
-        if (!isValid) failureReason = addPathResult!!
-        markActivityTime(false)
-      } ?: run {
-      failureReason = "Invalid agentId: ${request.agentId} (registerPath)"
-      logger.error { "Missing AgentContext for agentId: ${request.agentId}" }
-    }
-
+    val isValid = failureReason == null
     return registerPathResponse {
       pathId = if (isValid) PATH_ID_GENERATOR.fetchAndIncrement() else -1
       valid = isValid
       if (!isValid) {
+        // Smart-cast to non-null: isValid == false implies failureReason != null.
         reason = failureReason
       }
       pathCount = proxy.pathManager.pathMapSize

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
@@ -19,7 +19,6 @@
 package io.prometheus.proxy
 
 import com.pambrose.common.dsl.GuavaDsl.toStringElements
-import io.prometheus.Proxy
 import io.prometheus.common.Messages.EMPTY_AGENT_ID_MSG
 import io.prometheus.common.ScrapeResults
 import io.prometheus.grpc.scrapeRequest
@@ -33,7 +32,6 @@ import kotlin.time.TimeSource.Monotonic
 
 internal class ScrapeRequestWrapper(
   val agentContext: AgentContext,
-  proxy: Proxy,
   pathVal: String,
   encodedQueryParamsVal: String,
   authHeaderVal: String,
@@ -44,8 +42,6 @@ internal class ScrapeRequestWrapper(
   private val createTimeMark = clock.markNow()
   private val completeChannel = Channel<Boolean>()
   private val completed = AtomicBoolean(false)
-  private val requestTimer =
-    if (proxy.isMetricsEnabled) proxy.metrics.scrapeRequestLatency.labels(pathVal).startTimer() else null
 
   val scrapeRequest =
     scrapeRequest {
@@ -69,7 +65,6 @@ internal class ScrapeRequestWrapper(
 
   fun markComplete() {
     if (completed.compareAndSet(expectedValue = false, newValue = true)) {
-      requestTimer?.observeDuration()
       // Required
       closeChannel()
     }

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -325,13 +325,10 @@ class AgentContextManagerTest : StringSpec() {
     "invalidateAllAgentContexts should unblock awaitCompleted on buffered wrappers" {
       val manager = AgentContextManager(isTestMode = true)
       val context = AgentContext("remote-addr")
-      val mockProxy = mockk<Proxy>(relaxed = true)
-      every { mockProxy.isMetricsEnabled } returns false
-
       manager.addAgentContext(context)
 
       // Create a real ScrapeRequestWrapper so awaitCompleted() works end-to-end
-      val wrapper = ScrapeRequestWrapper(context, mockProxy, "/metrics", "", "", null, false)
+      val wrapper = ScrapeRequestWrapper(context, "/metrics", "", "", null, false)
       context.writeScrapeRequest(wrapper)
 
       val startTime = System.currentTimeMillis()

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -25,9 +25,7 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.mockk.every
 import io.mockk.mockk
-import io.prometheus.Proxy
 import io.prometheus.grpc.chunkedScrapeResponse
 import io.prometheus.grpc.headerData
 import kotlinx.coroutines.async

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
@@ -120,11 +120,9 @@ class AgentContextTest : StringSpec() {
 
     "invalidate should unblock awaitCompleted on buffered wrappers" {
       val context = AgentContext("remote-addr")
-      val mockProxy = mockk<Proxy>(relaxed = true)
-      every { mockProxy.isMetricsEnabled } returns false
 
       // Create a real ScrapeRequestWrapper so awaitCompleted() works end-to-end
-      val wrapper = ScrapeRequestWrapper(context, mockProxy, "/metrics", "", "", null, false)
+      val wrapper = ScrapeRequestWrapper(context, "/metrics", "", "", null, false)
 
       context.writeScrapeRequest(wrapper)
 

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
@@ -30,7 +30,6 @@ import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.prometheus.Proxy
 import io.prometheus.grpc.RegisterAgentRequest
 import kotlinx.coroutines.async
 import kotlin.time.Duration.Companion.seconds

--- a/src/test/kotlin/io/prometheus/proxy/ChunkedContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ChunkedContextTest.kt
@@ -178,6 +178,21 @@ class ChunkedContextTest : StringSpec() {
       }
     }
 
+    // The size guard is `>` (not `>=`), so content totalling exactly maxZippedContentSize must be
+    // accepted. This locks in the boundary against an off-by-one regression.
+    "applyChunk should accept content exactly at maxZippedContentSize" {
+      val response = createHeaderResponse()
+      val data = "exactly10!".toByteArray() // 10 bytes
+      val context = ChunkedContext(response, data.size.toLong()) // limit == exactly the data size
+
+      val checksum = CRC32().apply { update(data) }.value
+
+      // Must not throw at the exact boundary.
+      context.applyChunk(data, data.size, 1, checksum)
+      val scrapeResults = context.applySummary(1, data.size, checksum)
+      scrapeResults.srContentAsZipped.size shouldBe data.size
+    }
+
     // ==================== applySummary Tests ====================
 
     "applySummary should verify chunk count" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyMetricsTest.kt
@@ -19,6 +19,7 @@
 package io.prometheus.proxy
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -165,17 +166,21 @@ class ProxyMetricsTest : StringSpec() {
 
     // ==================== Histogram Operations Tests ====================
 
-    "scrapeRequestLatency should record observations with path label" {
+    "scrapeRequestLatency should record observations with path and outcome labels" {
       val proxy = createMockProxy()
       val metrics = ProxyMetrics(proxy)
 
-      metrics.scrapeRequestLatency.labels("test-path").observe(0.1)
-      metrics.scrapeRequestLatency.labels("test-path").observe(0.2)
-      metrics.scrapeRequestLatency.labels("test-path").observe(0.3)
+      // The histogram is labeled by (path, outcome) so latency can be broken down by result.
+      metrics.scrapeRequestLatency.labels("test-path", "success").observe(0.1)
+      metrics.scrapeRequestLatency.labels("test-path", "success").observe(0.2)
+      metrics.scrapeRequestLatency.labels("test-path", "timed_out").observe(0.3)
 
       val samples = CollectorRegistry.defaultRegistry.metricFamilySamples().toList()
       val latencyMetric = samples.find { it.name == "proxy_scrape_request_latency_seconds" }
       latencyMetric.shouldNotBeNull()
+      val outcomes = latencyMetric.samples.mapNotNull { it.labelValues.getOrNull(1) }.toSet()
+      outcomes shouldContain "success"
+      outcomes shouldContain "timed_out"
     }
 
     "scrapeResponseBytes should record observations with labels" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -267,7 +267,6 @@ class ProxyTest : StringSpec() {
 
       val wrapper = ScrapeRequestWrapper(
         agentContext = agentContext,
-        proxy = proxy,
         pathVal = "metrics",
         encodedQueryParamsVal = "",
         authHeaderVal = "",
@@ -294,7 +293,6 @@ class ProxyTest : StringSpec() {
 
       val wrapper = ScrapeRequestWrapper(
         agentContext = agentContext,
-        proxy = proxy,
         pathVal = "metrics",
         encodedQueryParamsVal = "",
         authHeaderVal = "",

--- a/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
@@ -28,42 +28,15 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
-import io.prometheus.Proxy
 import io.prometheus.common.ScrapeResults
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class ScrapeRequestWrapperTest : StringSpec() {
-  private fun createMockProxy(): Proxy {
-    val mockProxy = mockk<Proxy>(relaxed = true)
-    every { mockProxy.isMetricsEnabled } returns false
-    return mockProxy
-  }
-
-  private data class MetricsEnabledMocks(
-    val proxy: Proxy,
-    val timer: io.prometheus.client.Histogram.Timer,
-  )
-
-  private fun createMetricsEnabledMockProxy(): MetricsEnabledMocks {
-    val mockProxy = mockk<Proxy>(relaxed = true)
-    every { mockProxy.isMetricsEnabled } returns true
-    val mockHistogram = mockk<io.prometheus.client.Histogram>(relaxed = true)
-    val mockChild = mockk<io.prometheus.client.Histogram.Child>(relaxed = true)
-    val mockTimer = mockk<io.prometheus.client.Histogram.Timer>(relaxed = true)
-    val mockMetrics = mockk<ProxyMetrics>(relaxed = true)
-    every { mockProxy.metrics } returns mockMetrics
-    every { mockMetrics.scrapeRequestLatency } returns mockHistogram
-    every { mockHistogram.labels(any()) } returns mockChild
-    every { mockChild.startTimer() } returns mockTimer
-    return MetricsEnabledMocks(mockProxy, mockTimer)
-  }
-
   private fun createAgentContext(): AgentContext = AgentContext("test-remote-addr")
 
   private fun createWrapper(
-    proxy: Proxy = createMockProxy(),
     agentContext: AgentContext = createAgentContext(),
     path: String = "/metrics",
     encodedQueryParams: String = "",
@@ -72,7 +45,6 @@ class ScrapeRequestWrapperTest : StringSpec() {
     debugEnabled: Boolean = false,
   ) = ScrapeRequestWrapper(
     agentContext = agentContext,
-    proxy = proxy,
     pathVal = path,
     encodedQueryParamsVal = encodedQueryParams,
     authHeaderVal = authHeader,
@@ -200,16 +172,7 @@ class ScrapeRequestWrapperTest : StringSpec() {
       str shouldContain "/test/path"
     }
 
-    // ==================== markComplete with Metrics Tests ====================
-
-    "markComplete with metrics enabled should observe duration" {
-      val (mockProxy, _) = createMetricsEnabledMockProxy()
-
-      val wrapper = createWrapper(proxy = mockProxy)
-
-      // Should not throw — observeDuration called on the timer
-      wrapper.markComplete()
-    }
+    // ==================== markComplete Tests ====================
 
     "markComplete without metrics should not throw" {
       val wrapper = createWrapper()
@@ -266,7 +229,6 @@ class ScrapeRequestWrapperTest : StringSpec() {
       shouldThrow<IllegalArgumentException> {
         ScrapeRequestWrapper(
           agentContext = mockContext,
-          proxy = createMockProxy(),
           pathVal = "/metrics",
           encodedQueryParamsVal = "",
           authHeaderVal = "",
@@ -289,31 +251,9 @@ class ScrapeRequestWrapperTest : StringSpec() {
 
     // ==================== Bug #15: markComplete double-call protection ====================
 
-    // Bug #15: Before the fix, calling markComplete() twice would invoke
-    // requestTimer?.observeDuration() twice, recording a duplicate latency observation
-    // and skewing metrics. The fix uses an AtomicBoolean so observeDuration is only
-    // called once.
-
-    "Bug #15: markComplete with metrics should only observeDuration once" {
-      val (mockProxy, mockTimer) = createMetricsEnabledMockProxy()
-
-      val wrapper = ScrapeRequestWrapper(
-        agentContext = createAgentContext(),
-        proxy = mockProxy,
-        pathVal = "/metrics",
-        encodedQueryParamsVal = "",
-        authHeaderVal = "",
-        acceptVal = null,
-        debugEnabledVal = false,
-      )
-
-      wrapper.markComplete()
-      wrapper.markComplete()
-      wrapper.markComplete()
-
-      // observeDuration should only be called once despite three markComplete calls
-      io.mockk.verify(exactly = 1) { mockTimer.observeDuration() }
-    }
+    // Bug #15: markComplete() uses an AtomicBoolean so the channel is closed exactly once even when
+    // called multiple times. (Latency is now observed once per response in the routing layer rather
+    // than inside markComplete, so repeated markComplete calls can no longer skew the metric.)
 
     "Bug #15: markComplete should close channel only once" {
       val wrapper = createWrapper()


### PR DESCRIPTION
## Summary

Batches the remaining **low-severity** sub-bullets from the code review (idiom, observability, and a test-gap item) into one branch. No behavior changes beyond the new metric labels and the fail-fast config check.

### Idiom / API
- **`consolidated` parity** — `AgentContext.consolidated` uses `atomicBoolean(false)` like its sibling `valid` (was `nonNullableReference`, which boxes a `Boolean`).
- **`grpcDefaultLabel` helper** — one `protected fun Long.grpcDefaultLabel(default)` in `BaseOptions` replaces the `-1L`→label branch repeated 5× in `ProxyOptions` + 2× in `BaseOptions`, unifying the wording.
- **`isValid` captured-local** — `registerAgent`/`registerPath` derive `val isValid` from the context lookup (mirroring `unregisterPath`) instead of mutating a local inside `.apply`; drops the `!!`.
- **`Credentials` value object** — `ClientKey` models the basic-auth pair as a single non-null `Credentials?` (both-or-neither enforced in one secondary constructor), removing the `!!` in `AgentHttpService`. Call sites/tests unchanged.

### Observability / config
- **`scrapeRequestTimeoutSecs` bounds** — `require(... > 0)` in `ProxyOptions.assignConfigVals` (fail-fast instead of every scrape instantly "timed_out").
- **Latency `outcome` label** — `proxy_scrape_request_latency_seconds` is now `labelNames("path", "outcome")`, observed once per response in the routing layer using the existing `updateMsg`/`fetchDuration`. This covers **every** outcome — including the timeout and agent-disconnected branches the old per-request timer missed — and decouples `ScrapeRequestWrapper` from metrics. The `outcome` values reuse the same taxonomy already on `proxy_scrape_requests`'s `type` label.
- **Proxy `launch_id`** — `Proxy.launchId` (mirrors `Agent`); `proxy_start_time_seconds` is labeled with it for restart disambiguation. Intentionally scoped to start-time only (counters/histograms rely on `rate()`/`increase()` tolerating resets).

### Testing
- **ChunkedContext boundary** — acceptance test for `totalByteCount == maxZippedContentSize` (locks the `>` guard against a `>=` regression).

## Verification

- `./gradlew detekt lintKotlinMain lintKotlinTest` clean; full `./gradlew build` green (94.6% line coverage).
- `/simplify` pass applied as a follow-up commit (removed 3 dead imports orphaned by the latency relocation; clarified the `launch_id` scope comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)