### PR TITLE
Bound agent response-body read and fold in reviewed cleanups

### DIFF
--- a/code-review.md
+++ b/code-review.md
@@ -67,6 +67,16 @@ essentially complete — verified against current `master`.
 - **Dead `Utils.decodeParams`** (`common/Utils.kt`): leftover from PR #160 with zero production
   callers; its decode-then-prepend behavior was exactly the bug #160 fixed. Removed along with its
   `URLDecoder`/`UTF_8` imports and the `UtilsTest` block.
+- **`keepAliveTimeSecs`/`keepAliveTimeoutSecs` skipped the gRPC-timeout bounds check** that item 27
+  added for the other timeouts (`BaseOptions.kt:277-291`): a `0` slipped past the `> -1L` guard in
+  `ProxyGrpcService` and died as an opaque Netty exception at startup. Now `require`d to be `-1`
+  (default) or `> 0`, mirroring `ProxyOptions.requireGrpcTimeout`. Added rejection + sentinel tests.
+- **`removeChunkedContextsForAgent` returned the pre-removal snapshot** (`AgentContextManager.kt:86`):
+  a concurrent `writeChunkedResponsesToProxy` completing a matching context between the `filter` and
+  the `remove` inflated the caller's "Reclaimed N" log. Now returns only the IDs actually removed via
+  `mapNotNull`.
+- **`ByteArrayOutputStream.toString(Charsets.UTF_8.name())`** (`ProxyUtils.kt:64`): switched to the
+  JDK 10+ `toString(Charset)` overload (no suppressed `UnsupportedEncodingException`).
 
 ---
 

--- a/code-review.md
+++ b/code-review.md
@@ -41,15 +41,17 @@ essentially complete — verified against current `master`.
   30 (unknown-scrapeId header-drop test), 31 (wrapped-timeout→408 test), plus the ChunkedContext
   exact-boundary acceptance test.
 
+- **12 — per-chunk `withContext(Dispatchers.IO)` over an in-memory `ByteArrayInputStream`**
+  (`AgentGrpcService.kt:381`): fixed 2026-06-12. The wrapper was pure per-iteration continuation
+  overhead (the enclosing coroutine already runs on IO and `ByteArrayInputStream.read()` never
+  blocks); the loop now reads directly. The now-unused `withContext` import was removed.
+
 **Still open / deferred:**
 
-- **12 — per-chunk `withContext(Dispatchers.IO)` over an in-memory `ByteArrayInputStream`**
-  (`AgentGrpcService.kt:381`): still present. Pure per-iteration continuation overhead (the enclosing
-  coroutine is already on IO and the read never blocks). Low priority; safe to drop the wrapper.
 - **13–15** (micro-opts) and the **`ScrapeResults` 11-arg remodel**: intentionally deferred
   (profiling-gated / cleanup-not-fix).
 
-**New finding fixed 2026-06-11 (not in the original 31):**
+**New findings fixed 2026-06-11/12 (not in the original 31):**
 
 - **Unbounded response-body buffering on the agent** (`AgentHttpService.kt:210-218`): `bodyAsText()`
   materialized the entire response into the heap *before* the post-read size check, so a target with
@@ -58,6 +60,13 @@ essentially complete — verified against current `master`.
   via `bodyAsChannel().readRemaining(...)`, so the size guard runs against a bounded buffer. Added two
   tests (full chunked body under the limit round-trips intact; multi-byte UTF-8 round-trips on the
   text path after the `bodyAsText`→`decodeToString` switch).
+- **Agent shutdown stalled on the reconnect rate-limiter** (`Agent.kt:321`): the reconnect loop's
+  `finally` called the non-interruptible `reconnectLimiter.acquire()` even after shutdown flipped
+  `isRunning` to false, stalling `shutDown()`/`awaitTerminated()` for up to `reconnectPauseSecs`.
+  Now guarded with `if (isRunning)` — there is no reconnect to pace when the agent is stopping.
+- **Dead `Utils.decodeParams`** (`common/Utils.kt`): leftover from PR #160 with zero production
+  callers; its decode-then-prepend behavior was exactly the bug #160 fixed. Removed along with its
+  `URLDecoder`/`UTF_8` imports and the `UtilsTest` block.
 
 ---
 

--- a/code-review.md
+++ b/code-review.md
@@ -1,0 +1,331 @@
+# Prometheus-Proxy Code Review — Prioritized Findings
+
+**Process:** 9 review dimensions → 53 raw findings → adversarial verifiers re-read the cited code for each → **44 confirmed, 9 rejected** as false positives.
+
+The adversarial layer killed several scary-sounding-but-wrong findings, e.g. a claimed `grpcStub` data race (refuted: structured concurrency's join-before-return already orders it), an "orphaned scrape request" hang (refuted: the await is timeout-bounded and `failAllScrapeRequests` runs before `invalidate()`), and a backlog double-decrement (refuted: paths are mutually exclusive). The verifiers' corrections are folded into the recommendations below (severities downgraded, mislabeled files/methods fixed).
+
+**Headline:** this is a mature, clean codebase — there are essentially no active production bugs. The findings are hardening, consistency, and polish. Exactly one leaks credentials in real logs today.
+
+---
+
+## ✅ Resolution status (updated 2026-06-11)
+
+The findings below were worked through across PRs #149–#163. As of 2026-06-11 the campaign is
+essentially complete — verified against current `master`.
+
+**Fixed (26 of the 31 numbered items + the lower-value sub-bullets):**
+
+- **Top priorities:** 1 (query-param value redaction in `sanitizeUrl`), 2 (`connectAgent` rethrows
+  JVM `Error`s + logs stack traces), 3 (`readConfig` honors `exitOnMissingConfig`, throws
+  `ConfigLoadException` for embedded agents).
+- **Concurrency & lifecycle:** 4 (`HttpClientCache` `closed` flag under lock), 5 (single-coroutine
+  invariant now documented at `ProxyServiceImpl.kt:227`), 6 (`removeChunkedContextsForAgent`
+  proactively reclaims chunk buffers on eviction).
+- **Error handling:** 7 (`writeResponsesToProxy` fail-fasts via `failScrapeRequest`), 8 (dropped
+  scrape results now increment a `"dropped"` metric), 9 (content-type parse failure raised to warn).
+- **Performance:** 10 (encode-once gzip via `ByteArray.zip()`), 11 (`unzip` returns a precomputed
+  byte count; metric no longer re-encodes the zipped payload).
+- **Idioms & API:** 16 (`chunkContentSizeKbs`/`Bytes` unit split), 17 (`PathConfig` data class),
+  18 (`assignCommonOptions` dedup), 22 (`Agent.run()` decomposed via `launchConnectionTask`); plus
+  lower-value: `consolidated` now `by atomicBoolean(false)`, `ClientKey` now wraps a `Credentials`
+  value object.
+- **Duplication:** 19 + 23 (`SslSettings` kept and **wired** into the new per-CA HTTPS trust store at
+  `AgentHttpService.kt:346` rather than deleted), 20 (commented-out CT/`__test__` blocks removed),
+  21 (`ConfigWrappers` overloads collapsed onto shared builders).
+- **Security & TLS:** 24 (query params appended verbatim, no decode — PR #160), 25 (basic-auth cache
+  key now a salted HMAC-SHA256 — PR #161).
+- **Observability & config:** 26 (`CallLogging` lowered to `Level.DEBUG`), 27 (`ProxyOptions`
+  port/timeout bounds validation), plus dead config keys `maxThreads`/`minThreads`/
+  `scrapeRequestCheckMillis` removed (PR #157).
+- **Testing gaps:** 28 (mutual-TLS rejection test), 29 (`resolveTimeoutSecs` precedence tests),
+  30 (unknown-scrapeId header-drop test), 31 (wrapped-timeout→408 test), plus the ChunkedContext
+  exact-boundary acceptance test.
+
+**Still open / deferred:**
+
+- **12 — per-chunk `withContext(Dispatchers.IO)` over an in-memory `ByteArrayInputStream`**
+  (`AgentGrpcService.kt:381`): still present. Pure per-iteration continuation overhead (the enclosing
+  coroutine is already on IO and the read never blocks). Low priority; safe to drop the wrapper.
+- **13–15** (micro-opts) and the **`ScrapeResults` 11-arg remodel**: intentionally deferred
+  (profiling-gated / cleanup-not-fix).
+
+**New finding fixed 2026-06-11 (not in the original 31):**
+
+- **Unbounded response-body buffering on the agent** (`AgentHttpService.kt:210-218`): `bodyAsText()`
+  materialized the entire response into the heap *before* the post-read size check, so a target with
+  no `Content-Length` (chunked transfer encoding) or an understated one could push the agent toward
+  OOM regardless of `maxContentLengthMBytes`. Fixed by reading at most `maxContentLength + 1` bytes
+  via `bodyAsChannel().readRemaining(...)`, so the size guard runs against a bounded buffer. Added two
+  tests (full chunked body under the limit round-trips intact; multi-byte UTF-8 round-trips on the
+  text path after the `bodyAsText`→`decodeToString` switch).
+
+---
+
+## 🔴 Top priorities
+
+### 1. Query-string secrets leak into agent logs at WARN
+`common/Utils.kt:39` — **security, medium**
+
+`sanitizeUrl` only redacts `user:pass@` userinfo (`Regex("(://)[^@/?#]+@")` stops at `?`), so `?token=…`/`?api_key=…` survive. The failure path logs the full URL at **WARN** (`ScrapeResults.kt:104/110/115`), so a token leaks into normal production logs whenever an authed endpoint is merely slow. With `debugEnabled` it's also echoed back to Prometheus in `srUrl`/`srFailureReason` and logged at `ProxyHttpRoutes.kt:99-101`.
+
+**Fix:** blanket-redact query-param *values* (not a key allowlist — allowlists miss custom names) at every logged/echoed URL site: `AgentHttpService.kt:102` (`logUrl`), `:156`, `:180` (`safeUrl`), the URL passed into `ScrapeResults.errorCode`, and `ProxyHttpRoutes.kt:99-101`. Never touch the raw URL used for the actual fetch (`AgentHttpService.kt:109/146`). Low effort, real payoff.
+
+### 2. `connectAgent()` swallows JVM `Error`s and retries fatal failures forever
+`agent/AgentGrpcService.kt:200-217` — **error-handling, medium**
+
+`runCatchingCancellable { … }.getOrElse { e -> … false }` collapses *everything* except `CancellationException` — including `OutOfMemoryError`, `StackOverflowError`, and structural NPE/config bugs — into a routine `false`, which the caller treats as "couldn't connect, will retry." This bypasses the codebase's own `handleConnectionFailure()` (`Agent.kt:368-394`) that exists to rethrow `Error`s so the agent terminates instead of running corrupted. The message-only log lambda also means **no stack trace** is ever captured.
+
+**Fix:** (a) pass the throwable so a stack trace is logged — `logger.error(e) { "Cannot connect…: ${e.simpleClassName}" }`; (b) `if (e is Error) throw e` before returning `false`, so fatal errors reach the existing `handleConnectionFailure()`. Transient network/`StatusException` failures keep returning `false`.
+
+### 3. `readConfig()` calls `exitProcess(1)` on parse failure even for embedded agents
+`common/BaseOptions.kt:400-426` — **error-handling / public-API, medium**
+
+Both the URL and file branches log on failure and fall through to an unconditional `exitProcess(1)`. The `exitOnMissingConfig` flag — documented (`Agent.kt:577-578`) as the embedded-vs-standalone switch and honored by the `isBlank()` branch — is **ignored** on the parse-failure path. A transient remote-config fetch blip, a locked file, or a HOCON syntax error will kill the **host application's JVM** when an agent is embedded via the public `startAsyncAgent()`.
+
+**Fix:** make the parse-failure path honor `exitOnMissingConfig` — log + `exitProcess(1)` when true; throw a dedicated `ConfigLoadException(cause)` when false so host apps can catch it. Also include the offending cause in the log for non-`FileNotFoundException` failures.
+
+---
+
+## Concurrency & lifecycle
+
+### 4. Embedded shutdown can leak an `HttpClient`; `HttpClientCache.close()` lacks a terminal flag
+`agent/HttpClientCache.kt:143-177, 270-293` and `Agent.kt:501-505` — **lifecycle, medium**
+
+Same defect from both ends. `close()` cancels the cleanup scope and clears the map but sets no `closed` flag. On the **embedded** stop path (`EmbeddedAgentInfo.shutdown()` → `Agent.stop()` → `shutDown()`), `shutDown()` runs on the caller's thread while in-flight scrape coroutines are still live on `Dispatchers.IO`; gRPC channel teardown doesn't cancel/join them. A scrape calling `getOrCreateClient()` *after* `close()` cleared the map will `createAndCacheClient()` a fresh Ktor client into the now-dead cache — the cleanup coroutine is cancelled, so that client (holding an event-loop/selector) leaks until JVM exit. Standalone Guava path is unaffected (structured concurrency completes the per-scrape `coroutineScope` before `shutDown()`).
+
+**Fix:** add a `closed` flag set inside the same `withLock` that clears the map (no TOCTOU gap). `getOrCreateClient()` checks it first and throws `IllegalStateException("HttpClientCache is closed")` — callers already wrap in try/finally and a failed scrape during shutdown is acceptable. Optionally also cancel/join the scrape scope in `Agent.shutDown()` before `agentHttpService.close()`.
+
+### 5. `writeChunkedResponsesToProxy` relies on an undocumented single-coroutine invariant
+`proxy/ProxyServiceImpl.kt:220-294` — **concurrency, low**
+
+The per-invocation `activeScrapeIds = mutableSetOf<Long>()` is mutated inside the `collect` lambda and post-collect cleanup. Safe **only** because grpc-kotlin confines a client-streaming RPC's `collect` to one coroutine — an implicit invariant. No `launch`/`async`/`flowOn` exists today, and the shared `chunkedContextMap` is already a `ConcurrentHashMap`, so this is not a bug.
+
+**Fix:** add a one-line comment documenting the confinement so a future fan-out refactor knows to swap in a thread-safe set. The "offload CRC32/baos off the gRPC thread" half is **not worth doing** without profiling evidence of thread starvation.
+
+### 6. Evicted agents don't proactively reclaim chunked contexts
+`proxy/ProxyServiceImpl.kt:220-322` (with `AgentContext.invalidate()` at `:109-119`) — **resource, low**
+
+`invalidate()` drains the scrape queue but never touches `chunkedContextMap`. A `ChunkedContext` (holding a `ByteArrayOutputStream` up to `maxZippedContentSizeMBytes`) for an evicted agent stays resident until its `writeChunkedResponsesToProxy` stream ends and the orphan-sweep runs. Self-healing and bounded; `chunking_map_check` surfaces it.
+
+**Fix:** low priority. If addressed, filter `chunkedContextMap` by `header.headerAgentId == agentId` in `removeAgentContext`/`invalidate`. At minimum, a KDoc note that reclamation is bounded by stream lifecycle, not eviction.
+
+---
+
+## Error handling
+
+### 7. `writeResponsesToProxy()` swallows per-response errors → slow 503 instead of fast fail
+`proxy/ProxyServiceImpl.kt:199-208` — **medium**
+
+If `toScrapeResults()`/`assignScrapeResults()` throws for one scrapeId, it's logged and the loop continues — the `ScrapeRequestWrapper` is never `markComplete()`'d, so the HTTP handler blocks until `scrapeRequestTimeoutSecs` and returns a misleading 503 "timed_out". The sibling `writeChunkedResponsesToProxy()` already calls `failScrapeRequest()` on every error path (lines 252/280/312); this non-chunked path is the outlier.
+
+**Fix:** in the `catch (e: Exception)` at line 205, add `proxy.scrapeRequestManager.failScrapeRequest(response.scrapeId, "Error processing scrape response: ${e.message}")`. Safe (no-ops on a missing wrapper) and brings the two paths into parity. Rare in practice — `toScrapeResults()` is pure protobuf copying — so frame as defensive fail-fast.
+
+### 8. Dropped scrape results on connection-close are invisible
+`agent/AgentConnectionContext.kt:54-64` — **medium**
+
+When `trySend()` returns `isClosed` (connection torn down mid-scrape), a fully-computed valid result is dropped with only a `warn` and no metric; the proxy-side wrapper then resolves via timeout. The `close()`-not-`cancel()` design deliberately bounds this to a narrow race, so it's an observability gap, not corruption.
+
+**Fix:** have `sendScrapeResults` return the `ChannelResult`/`Boolean` and increment `agent.metrics { scrapeResultCount.labels(agent.launchId, "dropped").inc() }` at the `Agent.kt:331` call site. Reuses the existing counter's `type` label; purely additive.
+
+### 9. Content-type parse failure logged only at debug
+`proxy/ProxyHttpRoutes.kt:279-288` — **low**
+
+A malformed `Content-Type` from a target endpoint falls back to `text/plain` with only a debug log; in production (debug off) this silent re-typing is invisible.
+
+**Fix:** raise to `warn` (or `info`), including path and the offending `srContentType`. Pure logging-verbosity change.
+
+---
+
+## Performance
+
+*All performance findings are bounded and off any tight inner loop (scrapes are seconds apart).*
+
+### 10. Response body encoded to bytes twice (measure, then gzip)
+`agent/AgentHttpService.kt:198-222` — **medium (downgraded)**
+
+`content.encodeToByteArray().size` does a full UTF-8 encode (array discarded), then `content.zip()` re-encodes the same String before compressing — two full encodings per gzipped scrape.
+
+**Fix:** encode once: `val bytes = content.encodeToByteArray()`, use `bytes.size` for the threshold and `bytes.zip()` for compression. **Caveat:** guava-utils only exposes `String.zip()`, so this requires adding a `ByteArray.zip()` overload to `com.pambrose:common-utils` (which the maintainer controls) or a small local gzip helper. Worth doing only if that overload can be added.
+
+### 11. Full payload re-encoded just to record a metric size
+`proxy/ProxyHttpRoutes.kt:328-331` — **medium (downgraded)**
+
+`scrapeResponseBytes.observe(contentText.toByteArray().size.toDouble())` allocates a complete UTF-8 byte array of the decoded payload only to read `.size`, then discards it.
+
+**Fix:** have `ProxyUtils.unzip` return the decoded `String` plus its already-computed `totalBytes` (computed for the zip-bomb guard anyway) and observe that. **Do not** use `contentText.length` — that's UTF-16 code units and corrupts the metric for non-ASCII. The encode is already gated behind `proxy.metrics{}`.
+
+### 12–15. Optional micro-optimizations (low — leave unless profiling says otherwise)
+
+- **Per-chunk `withContext(Dispatchers.IO)` over an in-memory stream** (`AgentGrpcService.kt:371-392`): the enclosing coroutine is already on IO and `ByteArrayInputStream.read()` never blocks, so the wrapper is pure per-iteration continuation overhead (no thread hop). Drop the wrapper, or slice the `zipped` array by index. Minor (large default chunk size → few iterations).
+- **Per-chunk `chunkBytes.toByteArray()` copy on reassembly** (`ProxyServiceImpl.kt:247`): pass the protobuf `ByteString` into `ChunkedContext.applyChunk` and use `writeTo(baos)` / `asReadOnlyByteBuffer()`. **Note:** pre-sizing is infeasible — `HeaderData` carries no total size and `summaryByteCount` arrives last. Dominated by gzip+network cost anyway.
+- **Eager `contentAsZipped.toByteArray()` in `toScrapeResults`** (`ScrapeResults.kt:83-95`): an `InputStream`-based `unzip` fed `ByteString.newInput()` avoids one copy on the small non-chunked path. Limited win.
+- **`mergeContentTexts` / `distinct()` allocations** (`ProxyHttpRoutes.kt:174-195` and `:151-163`): consolidated-mode string-copy chain and per-request `map`/`distinct`. Correct today; only matters under heavy consolidated load. A `results.size == 1` short-circuit on the `processRequests` path is the cheapest meaningful win if touched.
+
+---
+
+## Kotlin idioms & API
+
+### 16. `chunkContentSizeBytes` shifts units (KB → bytes) in place
+`agent/AgentOptions.kt:117-119, 260-269` — **medium**
+
+A single public-API mutable `Int` carries three meanings over its lifecycle: sentinel (-1), kilobytes (input/validation), then bytes (after `assignConfigVals`). The KDoc admits "converted in-place to bytes." An external reader can't tell the unit without knowing the lifecycle phase.
+
+**Fix:** split into two fields — keep the `@Parameter("--chunk")`-bound input as `chunkContentSizeKbs` (mirroring the env var and config key) and expose a derived `chunkContentSizeBytes` assigned once. This is a public CLI-field rename, so document/migrate accordingly.
+
+### 17. Stringly-typed `List<Map<String,String>>` path configs
+`agent/AgentPathManager.kt:51-74, 109-114` — **medium**
+
+`pathConfigs` uses magic string keys (`NAME`/`PATH`/`URL`/`LABELS`) and nullable lookups for values the tscfg validator guarantees non-null — including a dead `else logger.error{...}` branch for a logically-impossible null. `pathConfigs` is `private` and used only here.
+
+**Fix:** introduce `private data class PathConfig(val name, path, url, labels: String)`. `registerPaths()` collapses to `pathConfigs.forEach { registerPath(it.path, it.url, it.labels) }` (dead branch deleted), `toPlainText()` drops the `.orEmpty()`/`?.padEnd()` noise. Preserve the name's double-quote wrapping.
+
+### 18. Duplicated common-option assignment between AgentOptions and ProxyOptions
+`agent/AgentOptions.kt:294-326` (mirror in `proxy/ProxyOptions.kt:225-253`) — **medium**
+
+An identical block — eight `assign*` calls in the same order, the cert/key/trust + `validateTlsConfig` trio, and the log-level idiom — is copy-pasted because `ConfigVals.Agent` and `ConfigVals.Proxy2` are distinct generated types. Any new common option must be edited in two places and can drift.
+
+**Fix:** the `assign*` helpers are already `protected` on `BaseOptions` and take primitives, so add `protected fun assignCommonOptions(... primitives ...)` (centralizing ordering + `validateTlsConfig`) and `protected fun assignLogLevel(role, envVar, configDefault)`. Call sites read role-specific config values and pass primitives in. Keep role-specific `logger.info` lines at the call sites.
+
+### Lower-value idiom cleanups (low)
+
+- **`consolidated` uses `nonNullableReference(false)` (boxes a Boolean) while sibling `valid` uses `atomicBoolean(true)`** (`AgentContext.kt:64`): change to `var consolidated: Boolean by atomicBoolean(false)` for parity. The `isValid()`→property conversion is **not** worth it — it reads channel state and forms a deliberate `isValid()`/`isNotValid()` pair.
+- **`-1`/`-1L` sentinel label derivation repeated 5× in `ProxyOptions.assignConfigVals` (+2 in BaseOptions)** (`ProxyOptions.kt:190-223`): extract one `private fun Long.grpcDefaultLabel(default: String): String` and unify inconsistent wording. Keep the sentinel; the nullable-`Long?` remodel would break the public API.
+- **`isValid = true` assigned inside `getAgentContext(...)?.apply { … }`** (`ProxyServiceImpl.kt:97-114`): reads as mutating the receiver but actually writes a captured outer local. Compute `val isValid = ctx != null` and use `also` for side effects. Readability only.
+- **`ClientKey` models a credential pair as two independent nullables, forcing `!!`** (`HttpClientCache.kt:121-138`): a single `Credentials(username, password)?` value object removes both `!!` and the comment. **Must** preserve the current "both-or-neither" gate at construction.
+
+### Not worth restructuring now
+
+- **`ScrapeResults` 11-arg `sr`-prefixed class** (`ScrapeResults.kt:37-49`): the `sr` prefix is redundant and the zipped/text triple is an unenforced invariant duplicated across ~4 sites. A sealed `Payload` type would be the right model, but this is cleanup, not a fix — defer. Beware ByteArray structural equality if converting to a `data class`.
+
+---
+
+## Duplication & maintainability
+
+### 19. Delete dead `SslSettings` object and its test
+`agent/SslSettings.kt:27-74` — **low**
+
+The entire `internal object SslSettings` is unreferenced by production code (only `SslSettingsTest.kt` and one commented-out line exercise it); `@Suppress("unused")` confirms the author knows. ~74 LOC + ~168 test LOC of coverage noise.
+
+**Fix:** delete `SslSettings.kt` and `SslSettingsTest.kt`, remove the stale comment at `AgentHttpService.kt:256`, drop the `docs/TESTING.md` references (lines 69, 144). `internal`, so no public API impact. *Caveat:* if keystore-based trust is planned, wire `getTrustManager(file, password)` behind a real config flag instead — see item 23.
+
+### 20. Remove four commented-out "CT check" / `__test__` blocks
+`proxy/ProxyHttpRoutes.kt:70-73, 113-114, 156-159, 281-282` — **low**
+
+Stale debugging scaffolding. The `/__test__` block (70-73) wouldn't even compile (no `delay`/`Plain`/`OK` imports). Misleads readers into thinking content-type tracing is wired up.
+
+**Fix:** delete all four. If CT tracing is still wanted, replace with a single real `logger.debug { … }`.
+
+### 21. Collapse six near-identical `ConfigWrappers` overloads
+`common/ConfigWrappers.kt:26-102` — **low**
+
+Three pairs (`newAdminConfig`/`newMetricsConfig`/`newZipkinConfig`) have byte-identical bodies differing only in the tscfg-generated param type (`Proxy2.*` vs `Agent.*`). Metrics duplicates 7 field mappings twice. All six are live.
+
+**Fix:** extract `private fun adminConfig(...primitives...) = AdminConfig(...)` builders; each public overload destructures and delegates in one line. The deeper fix (sharing sub-schemas in `config.conf`) ripples into call sites and `DataClassTest` — defer. The `@Suppress("unused")` is warranted (linter can't trace static imports).
+
+### 22. Decompose `Agent.run()`; factor the 4× drain-and-decrement handler
+`Agent.kt:238-352` — **low**
+
+A 114-line nested `connectToProxy()` launches four child coroutines, each repeating the identical `invokeOnCompletion { val drained = connectionContext.close(); if (drained > 0) decrementBacklog(drained) }` and the `if (agent.isRunning) Status.fromThrowable(e)…` logging.
+
+**Fix:** extract `private fun CoroutineScope.launchConnectionTask(ctx, name, block: suspend CoroutineScope.() -> Unit): Job`. **The block must be `suspend CoroutineScope.() -> Unit`** (not `suspend () -> Unit`) — the scrape-processing task at line 316 calls an inner `launch {}` (line 327) against the scope receiver.
+
+---
+
+## Security & TLS
+
+### 23. `trustAllX509Certificates` is process-global all-or-nothing
+`agent/AgentHttpService.kt:254-259` — **medium**
+
+`TrustAllX509TrustManager` (empty `checkServerTrusted`) disables cert validation for **every** HTTPS scrape target. Well-mitigated: off by default, explicit opt-in, startup warning. The residual gap is that trusting one self-signed internal endpoint forces dropping validation for all.
+
+**Fix:** (1) document the process-global/all-or-nothing scope in option docs and README; (2) remove the misleading commented `// trustManager = SslSettings.getTrustManager()` at line 256 (wouldn't compile — real signature is `getTrustManager(fileName, password)`); (3) if per-target trust is wanted, add a config-driven trust store keyed per path. *(Ties into item 19 — delete SslSettings or wire it up here.)*
+
+### 24. Prometheus query params decoded-then-concatenated into the scrape URL
+`common/Utils.kt:41-54` — **low**
+
+`appendQueryParams` runs `URLDecoder.decode` on the whole `key=val&key=val` blob then concatenates, so an encoded delimiter inside one value expands into new params (or a `#` fragment). Not SSRF — the host is fixed by agent-side HOCON `pathConfigs` and Prometheus is trusted — but fragile.
+
+**Fix:** don't decode the blob. Append the already-encoded string directly, or re-apply via `URLBuilder(baseUrl).parameters.appendAll(parseQueryString(encodedQueryParams))` so each value is individually re-encoded. **Update `UtilsTest.kt:91-95`**, which asserts the splitting behavior.
+
+### 25. Basic-auth credentials stored as plaintext map keys, never zeroed
+`agent/HttpClientCache.kt:121-138` — **low**
+
+`cacheKey()` builds `"$username:$password"` as the live `ConcurrentHashMap` key, heap-resident as an immutable String for the cache lifetime (up to 30m) — contrast `SslSettings.getKeyStore` which zeroes the password array. Agent runs inside the firewall and basic-auth is low-grade, so this is defense-in-depth/consistency, not an exploitable leak.
+
+**Fix:** low priority. Prefer the existing Authorization-header path (`AgentHttpService.kt:170-171`) so creds never enter the URL-derived key. If caching must key on creds, use a salted HMAC digest. Document the residual limitation.
+
+---
+
+## Observability & config
+
+### 26. Per-request INFO call logging on by default → scrape-rate log spam
+`config/config.conf:22` — **medium**
+
+`requestLoggingEnabled = true` installs Ktor `CallLogging` at `Level.INFO` with a match-everything filter (`ProxyHttpConfig.kt:79-83`). A proxy fronting many targets emits a continuous INFO stream (one per scrape, ~15s each), burying real WARN/ERROR. The only knob is hard on/off. The per-request handler's own log is already `logger.debug`, making the INFO level here inconsistent.
+
+**Fix:** change `level = Level.INFO` to `level = Level.DEBUG` in `configureCallLogging()`. Smallest blast radius — keeps config default `true` (no test changes), quiets routine logging at the default INFO root, keeps WARN/ERROR visible, and lets operators opt in by raising the level. Avoid flipping the config default to `false` (would break `OptionsTest.kt:346-348`, `ConfigValsTest.kt:95`, and the docs snippet).
+
+### 27. `ProxyOptions` does no bounds validation on ports/timeouts (AgentOptions does)
+`proxy/ProxyOptions.kt:153-223` — **medium**
+
+`AgentOptions` guards nearly every resolved value with `require(... > 0)`; `ProxyOptions` does none. `proxyPort`/`proxyAgentPort` accept 0/negative, and the five gRPC timeout fields accept any value (only exact `-1L` is the "use default" sentinel; the `> -1L` guards in `ProxyGrpcService` pass `0`/`-5` straight to the builder). Result: opaque Ktor/gRPC builder exceptions instead of a clear startup error.
+
+**Fix:** add fail-fast checks in `assignConfigVals()` after each value resolves: `require(proxyPort in 1..65535)`, same for `proxyAgentPort`, and `require(field == -1L || field > 0)` for each gRPC timeout (preserving the sentinel the `> -1L` guards rely on). No behavior change for valid configs.
+
+### Lower-value config/observability (low)
+
+- **`scrapeRequestTimeoutSecs` has no env/CLI mapping and no bounds check** (`config/config.conf:76`): a central value (bounds how long a scrape blocks) reachable only via HOCON/`-D`; a `0`/negative makes every scrape return "timed_out" immediately (`withTimeoutOrNull` never suspends). **Cheapest high-value piece:** `require(internal.scrapeRequestTimeoutSecs > 0)` in `assignConfigVals`. Env/CLI exposure (mirror `HANDSHAKE_TIMEOUT_SECS`, name distinct from agent's `SCRAPE_TIMEOUT_SECS`) is optional.
+- **Dead config keys `maxThreads`/`minThreads`/`scrapeRequestCheckMillis`** (`config/config.conf:19-20, 77`): no main-source reader (`scrapeRequestCheckMillis` is stale since `awaitCompleted` replaced the polling loop). Remove + regenerate ConfigVals, **but** update the tests that reference them (`ConfigValsTest.kt:93-94/108`, `ProxyDynamicConfigTest.kt:54-56`, `ProxyHttpRoutesTest.kt:100`) in the same change or compilation breaks.
+- **No metric distinguishes proxy scrape failure modes** (`ProxyHttpRoutes.kt:112, 244-340`): the rich `updateMsg` taxonomy feeds only the count; the latency histogram has no outcome label, and the timeout (`:254`) and `ClosedSendChannelException` write-failure (`:244`) paths never record latency. (`failScrapeRequest`/agent-error paths already record via `markComplete()`; only those two early-returns are missing.) Add a status label to the histogram and observe on those two branches.
+- **Inconsistent `launch_id` labeling** (`ProxyMetrics.kt:30-94`): AgentMetrics tags every series with `launch_id`; ProxyMetrics tags none, so proxy counters reset silently on restart. Mostly consistency — PromQL `rate()`/`increase()` tolerate resets. If addressed, give Proxy its own `launchId` and at least label `proxy_start_time_seconds`.
+
+---
+
+## Testing gaps
+
+### 28. No negative-path mutual-TLS rejection test
+`src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt:45-90` — **medium**
+
+Both TLS harness tests only exercise the success path. Nothing asserts the proxy **rejects** an agent presenting no client cert when mutual auth is required. A regression silently disabling client-cert verification — a security boundary — would pass the entire suite.
+
+**Fix:** add `TlsMutualAuthRejectionTest`: proxy with `--trust` (mutual auth required), agent started **without** `--cert`/`--key`, asserting it fails to connect/register (expect `StatusException`/`SSLHandshakeException`, not a successful scrape). Needs no new fixtures.
+
+### 29. `cioTimeoutSecs` vs `httpClientTimeoutSecs` override resolution untested
+`agent/AgentHttpService.kt:242-252` — **medium**
+
+The precedence logic justifying the deprecated `cioTimeoutSecs` knob is never exercised — every test sets both to the default 90, so only the else-branch runs.
+
+**Fix:** extract `internal fun resolveTimeoutSecs(cio, httpClient, default = 90)` and unit-test both branches: (a) `cio` overridden, `httpClient` default → `cio` wins; (b) `httpClient` overridden → `httpClient` wins.
+
+### 30. "Unknown scrapeId" header-drop branch untested
+`proxy/ProxyServiceImpl.kt:226-236` — **medium**
+
+`ProxyServiceImplTest` hard-codes `containsScrapeRequest(any()) returns true` (line 72), so the guard that drops a chunked HEADER for a stale/timed-out scrapeId never runs. A regression creating a context unconditionally (leaking `ChunkedContext` entries) wouldn't be caught.
+
+**Fix:** add a test stubbing `containsScrapeRequest(scrapeId) returns false`, send a single HEADER, and assert `verify(exactly = 0) { contextManager.putChunkedContext(any(), any()) }` (the load-bearing assertion) and result is `EMPTY_INSTANCE`.
+
+### 31. Wrapped/nested timeout detection partially untested
+`agent/AgentHttpService.kt:111-134` — **medium**
+
+The `fetchContentFromUrl` cause-walk + `e is CancellationException && !isTimeout` guard exists to convert a `CancellationException`-whose-cause-is-a-timeout into a 408 rather than rethrowing. That exact case has **no** coverage (the `ScrapeResults.errorCode` cause-walk is well tested, but that's a different loop).
+
+**Fix:** add a test where `fetchContent` throws `CancellationException("timed out").apply { initCause(HttpRequestTimeoutException("url", 1000L)) }` and assert `srStatusCode == 408` and no rethrow. The generic-RuntimeException-wrapping case is already covered at the `errorCode` level — skip it.
+
+### Lower-value test gaps (low)
+
+- **ChunkedContext exact-boundary acceptance** (`ChunkedContext.kt:70-79`): rejection tests use 101 vs 100, but `totalByteCount == maxZippedContentSize` (should be accepted under `>`) is unverified — an off-by-one `>` → `>=` regression wouldn't be caught. Add an N-bytes-vs-limit-N acceptance test.
+- **`writeScrapeRequest`/`invalidate` send-failure race** (`AgentContext.kt:90-119`): **largely not worth it.** The finding's motivating hang scenario is *wrong* — the sole caller's `finally` (`ProxyHttpRoutes.kt:262`) unconditionally `closeChannel()`s, so no hang occurs in any interleaving. Only the bare "not directly tested" fact survives. Skip unless adding pure defense-in-depth coverage.
+
+---
+
+## Suggested sequencing
+
+1. **Item 1 (query-string secret redaction)** — the only finding that leaks credentials into production logs *today* at WARN. Small, isolated, highest real-world payoff.
+2. **Items 2 + 3 (swallowed Errors; embedded `exitProcess`)** — both are public-API robustness bugs with tiny, safe fixes that align code with its own documented intent.
+3. **Item 4 (HttpClientCache `closed` flag)** — closes the embedded-agent leak; a single guarded flag fixes both halves.
+4. **Items 26 + 27 + the `scrapeRequestTimeoutSecs` bounds check** — config/observability quick wins. The `Level.DEBUG` change and the `require(...)` validations are one-liners with near-zero risk and no test churn (except #27 if you also expose env vars).
+5. **Items 7 + 8 (fail-fast on response errors; drop metric)** — consistency/observability improvements that make degraded-agent behavior diagnosable.
+6. **Testing items 28–31** — lock in the security boundary (mutual-TLS rejection) and the three untested branches *before* refactoring near them; cheap and prevent silent regressions.
+7. **Items 16–18, 22 (idiom/duplication refactors)** — do these once behavioral fixes land. The two `assign*` extractions (18) and `AgentOptions` unit split (16) have the best maintainability return; the `Agent.run()` decomposition (22) pairs well with touching that file.
+8. **Dead-code deletions (19, 20) + low-value polish** — batch opportunistically. Decide SslSettings's fate (delete vs wire into item 23) as one call.
+9. **Skip / defer:** the gRPC-thread offload half of item 5, the `ScrapeResults` remodel, pre-sizing in the chunk-copy item, and the AgentContext race test (its premise is incorrect). The performance micro-opts (12–15) are profiling-gated.

--- a/docs/security-agent-authentication.md
+++ b/docs/security-agent-authentication.md
@@ -1,0 +1,135 @@
+# Security Finding: Unauthenticated Agent Registration / Path Hijacking
+
+**Status:** Open
+**Severity:** High (conditional on network exposure of the agent gRPC port)
+**Component:** Proxy gRPC service (agent-facing port, default `50051`)
+**Identified:** 2026-06 code review
+
+> This document records a known security limitation in the proxy's agent-facing
+> gRPC interface so it can be tracked and remediated deliberately. It is a design
+> gap, not a regression — the proxy has never performed application-level agent
+> authentication.
+
+## Summary
+
+The proxy accepts agent gRPC connections on port `50051` with **no application-level
+authentication**. Any process that can open a TCP connection to that port can register
+itself as an agent and register paths. Because path registration for a non-consolidated
+path **displaces** the existing owner of that path, a rogue agent can take over a path
+and serve arbitrary metrics to Prometheus in place of the legitimate agent.
+
+The only authentication mechanism available today is **mutual TLS**, which is opt-in and
+off by default.
+
+## Affected code
+
+The agent connection/registration chain performs no identity check beyond confirming that
+an `agentId` exists in the in-memory context map — and that map is populated by the
+transport filter the moment a TCP connection is accepted:
+
+- `proxy/ProxyServerTransportFilter.kt:32-41` — `transportReady()` constructs an
+  `AgentContext` and assigns the next `agentId` on every accepted transport, before any
+  application message is exchanged.
+- `proxy/ProxyServiceImpl.kt:70-79` — `connectAgent()` only checks that the agent's
+  `transportFilterDisabled` config matches the proxy's; it returns success unconditionally.
+  No token, shared secret, or client identity is required.
+- `proxy/ProxyServiceImpl.kt:97-115` — `registerAgent()` succeeds whenever the supplied
+  `agentId` is present in the context map (which the transport filter just populated).
+- `proxy/ProxyServiceImpl.kt:117-139` → `proxy/ProxyPathManager.kt:98-124` —
+  `registerPath()` → `addPath()`. For a non-consolidated registration against a path that
+  already has a non-consolidated owner, the proxy **overwrites** the path
+  (`pathMap[path] = AgentContextInfo(false, labels, mutableListOf(agentContext))`),
+  increments `agentDisplacementCount`, and invalidates the displaced agent's context if it
+  holds no other paths.
+
+## Preconditions
+
+The finding is exploitable only when **both** of the following hold:
+
+1. **Network reachability** — the attacker can reach the proxy's agent gRPC port
+   (default `50051`). In a correct deployment this port is exposed only to trusted agents
+   inside the firewall; the exposure is what elevates this to High.
+2. **No mutual TLS** — the proxy is not configured with a client trust store
+   (`trustCertCollectionFilePath`), so it does not require agents to present a client
+   certificate. TLS is opt-in: `isTlsEnabled` requires both `certChainFilePath` and
+   `privateKeyFilePath` to be set (`common/BaseOptions.kt:204-205`), and both default to
+   empty, i.e. plaintext.
+
+## Attack scenario
+
+1. Attacker reaches `proxy-host:50051` (e.g. the port is exposed to a wider network than
+   intended, or the attacker has a foothold on an adjacent host).
+2. Attacker runs a minimal gRPC client speaking the `ProxyService` protocol
+   (`src/main/proto/proxy_service.proto`). gRPC reflection is enabled by default
+   (`config/config.conf:7`, `proxy/ProxyGrpcService.kt:111-112`), so the service shape can
+   be enumerated with `grpcurl` rather than reading the source.
+3. Attacker calls `connectAgent` → `registerAgent` → `registerPath` for an existing path
+   such as `/node-exporter`.
+4. The proxy overwrites the path's owner with the attacker's context and invalidates the
+   legitimate agent (if it has no other paths).
+5. Prometheus scrapes `proxy-host:8080/node-exporter` and receives **attacker-controlled
+   metrics**. The attacker can fabricate values to mask an outage, hide an intrusion, or
+   trigger/suppress alerting and autoscaling decisions driven by those metrics.
+
+In **consolidated** mode the attacker cannot displace the existing owner
+(`ProxyPathManager.kt:91-95, 99-103` reject a consolidated/non-consolidated mismatch), but
+can still *join* a consolidated path and answer a fraction of scrape requests with
+fabricated data.
+
+## Impact
+
+- **Integrity of metrics** — Prometheus consumes attacker-controlled data for hijacked
+  paths. This is the primary risk: monitoring/alerting/autoscaling built on these metrics
+  can be misled.
+- **Availability** — the legitimate agent's context is invalidated on displacement, so it
+  must reconnect and re-register; an attacker re-registering in a loop can keep a path
+  effectively denied to the real agent.
+- **Information disclosure** — gRPC reflection lets an unauthenticated peer enumerate the
+  full RPC surface.
+
+There is **no confidentiality breach of secrets** from this finding alone — the proxy does
+not hand agent credentials or scrape-target secrets to connecting agents.
+
+## Current mitigations
+
+- **Mutual TLS** fully closes the finding when configured: set the proxy's
+  `trustCertCollectionFilePath` (and the TLS cert/key) so the proxy requires a valid client
+  certificate, and provision agents with certificates. See the `tls { … }` blocks in
+  `config/config.conf` and the TLS integration tests
+  (`src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt`,
+  `TlsMutualAuthRejectionTest`).
+- **Network segmentation** — restricting port `50051` to trusted agents (firewall rules,
+  private network, service mesh) removes the reachability precondition. This is the de facto
+  control today and should be documented as a hard requirement for any plaintext deployment.
+
+## Recommended remediation
+
+In rough priority order:
+
+1. **Optional pre-shared agent token (lowest-friction app-level auth).** Add a configurable
+   secret (e.g. `--agent-token` / `AGENT_TOKEN` / `proxy.agentToken`) that agents send in a
+   gRPC metadata header. A server interceptor (alongside `ProxyServerInterceptor`) rejects
+   any RPC lacking the correct token with `Status.UNAUTHENTICATED`. When the token is empty,
+   preserve today's open behavior for backward compatibility — but log a prominent startup
+   **warning** that the agent port is unauthenticated, mirroring the existing
+   `trustAllX509Certificates` warning pattern.
+2. **Document mutual TLS as the recommended production posture** and network segmentation as
+   the minimum bar for plaintext deployments (README + CLI/config docs).
+3. **Disable gRPC reflection by default** (`reflectionDisabled = true` in
+   `config/config.conf`), so an unauthenticated peer cannot trivially enumerate the API.
+   Operators who need reflection for tooling can opt back in.
+4. **Consider rejecting path displacement by default**, making overwrite an explicit,
+   configurable behavior. The current silent-overwrite is convenient for redeploys but is
+   the mechanism that turns missing auth into hijacking. (`agentDisplacementCount` already
+   exists as an observability hook for this event.)
+
+Items 1–3 are individually small and non-breaking; item 4 is a behavior change that needs
+its own design discussion.
+
+## References
+
+- gRPC service definition: `src/main/proto/proxy_service.proto`
+- Path management / displacement: `src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt`
+- Agent registration RPCs: `src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt`
+- Transport filter (agentId assignment): `src/main/kotlin/io/prometheus/proxy/ProxyServerTransportFilter.kt`
+- TLS configuration: `config/config.conf` (`tls { … }` blocks), `common/BaseOptions.kt`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ serialization = "1.11.0"
 config = "6.0.10"
 detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
-gradle-plugins = "1.0.14"
+gradle-plugins = "1.0.15"
 kover = "0.9.8"
 maven-publish = "0.36.0"
 protobuf = "0.10.0"
@@ -19,7 +19,7 @@ shadow = "9.4.2"
 taskinfo = "3.0.2"
 
 # gRPC / Protobuf
-grpc = "1.81.0"
+grpc = "1.82.0"
 gengrpc = "1.5.0"
 # Keep in sync with grpc
 protoc = "3.25.3"
@@ -49,7 +49,7 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "2.9.0"
+utils = "2.9.1"
 
 # Misc
 annotation = "1.3.2"

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -319,7 +319,11 @@ class Agent(
           }
         }.onFailure { e -> handleConnectionFailure(e) }
       } finally {
-        logger.info { "Waited ${reconnectLimiter.acquire().roundToInt().seconds} to reconnect" }
+        // Skip the rate-limiter wait once shutdown has flipped isRunning to false. acquire() is not
+        // interruptible, so blocking here would stall Agent.shutDown()/awaitTerminated() for up to
+        // reconnectPauseSecs; there is also no reconnect to pace when the agent is stopping.
+        if (isRunning)
+          logger.info { "Waited ${reconnectLimiter.acquire().roundToInt().seconds} to reconnect" }
       }
     }
   }

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -63,7 +63,6 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
@@ -378,7 +377,9 @@ internal class AgentGrpcService(
           val buffer = ByteArray(chunkContentSize)
           var readByteCount: Int
 
-          while (withContext(Dispatchers.IO) { bais.read(buffer) }.also { readByteCount = it } > 0) {
+          // bais is an in-memory ByteArrayInputStream, so read() never blocks; no Dispatchers.IO hop
+          // is needed (the enclosing coroutine already runs on IO).
+          while (bais.read(buffer).also { readByteCount = it } > 0) {
             totalChunkCount++
             totalByteCount += readByteCount
             checksum.update(buffer, 0, readByteCount)

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -40,11 +40,12 @@ import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.isSuccess
+import io.ktor.utils.io.readRemaining
 import io.prometheus.Agent
 import io.prometheus.agent.HttpClientCache.ClientKey
 import io.prometheus.common.ScrapeResults
@@ -54,6 +55,7 @@ import io.prometheus.common.Utils.sanitizeUrl
 import io.prometheus.grpc.ScrapeRequest
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import kotlinx.io.readByteArray
 import javax.net.ssl.X509TrustManager
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -206,14 +208,17 @@ internal class AgentHttpService(
       }
 
       val contentType = response.headers[CONTENT_TYPE].orEmpty()
-      val content = response.bodyAsText()
 
-      // Encode the body to UTF-8 bytes once and reuse it for both the size check and gzip
-      // compression. ByteArray.zip() avoids the second UTF-8 encode that String.zip() would do.
-      val contentBytes = content.encodeToByteArray()
+      // Read at most maxContentLength + 1 bytes straight from the response channel. A response with
+      // no Content-Length header (e.g. chunked transfer encoding) or an understated one bypasses the
+      // header guard above, and bodyAsText() would buffer the entire body into the heap before the
+      // size check below — a memory-exhaustion vector. readRemaining caps the read, so the guard
+      // runs against a bounded buffer. The bytes are reused for both the size check and gzip;
+      // ByteArray.zip() avoids the second UTF-8 encode that String.zip() would do.
+      val contentBytes = response.bodyAsChannel().readRemaining(maxContentLength + 1).readByteArray()
       val contentByteSize = contentBytes.size.toLong()
       if (contentByteSize > maxContentLength) {
-        val msg = "Content size $contentByteSize bytes exceeds maximum allowed size $maxContentLength"
+        val msg = "Content size exceeds maximum allowed size of $maxContentLength bytes"
         logger.warn { msg }
         return ScrapeResults(
           srAgentId = scrapeRequest.agentId,
@@ -232,7 +237,7 @@ internal class AgentHttpService(
         srStatusCode = statusCode,
         srContentType = contentType,
         srZipped = zipped,
-        srContentAsText = if (!zipped) content else "",
+        srContentAsText = if (!zipped) contentBytes.decodeToString() else "",
         srContentAsZipped = if (zipped) contentBytes.zip() else EMPTY_BYTE_ARRAY,
         srUrl = if (scrapeRequest.debugEnabled) safeUrl else "",
         scrapeCounterMsg = SUCCESS_MSG,

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -277,12 +277,20 @@ abstract class BaseOptions protected constructor(
   protected fun assignKeepAliveTimeSecs(defaultVal: Long) {
     if (keepAliveTimeSecs == -1L)
       keepAliveTimeSecs = KEEPALIVE_TIME_SECS.getEnv(defaultVal)
+    // -1L keeps the gRPC built-in default; any other non-positive value would surface as an opaque
+    // gRPC builder exception at startup, so fail fast with a clear message instead.
+    require(keepAliveTimeSecs == -1L || keepAliveTimeSecs > 0L) {
+      "grpc.keepAliveTimeSecs must be -1 (default) or > 0: $keepAliveTimeSecs"
+    }
     logger.info { "grpc.keepAliveTimeSecs: ${keepAliveTimeSecs.grpcDefaultLabel("gRPC default")}" }
   }
 
   protected fun assignKeepAliveTimeoutSecs(defaultVal: Long) {
     if (keepAliveTimeoutSecs == -1L)
       keepAliveTimeoutSecs = KEEPALIVE_TIMEOUT_SECS.getEnv(defaultVal)
+    require(keepAliveTimeoutSecs == -1L || keepAliveTimeoutSecs > 0L) {
+      "grpc.keepAliveTimeoutSecs must be -1 (default) or > 0: $keepAliveTimeoutSecs"
+    }
     logger.info { "grpc.keepAliveTimeoutSecs: ${keepAliveTimeoutSecs.grpcDefaultLabel("gRPC default")}" }
   }
 

--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -27,16 +27,11 @@ import io.prometheus.Proxy
 import kotlinx.serialization.json.Json
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
-import java.net.URLDecoder
-import kotlin.text.Charsets.UTF_8
 
 internal object Utils {
   private const val REDACTED = "***"
 
   internal fun getVersionDesc(asJson: Boolean = false): String = Proxy::class.versionDesc(asJson)
-
-  fun decodeParams(encodedQueryParams: String): String =
-    if (encodedQueryParams.isNotBlank()) "?${URLDecoder.decode(encodedQueryParams, UTF_8)}" else ""
 
   /**
    * Masks secrets in a URL before it is logged or echoed back to Prometheus.

--- a/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
@@ -83,11 +83,13 @@ internal class AgentContextManager(
    *
    * @return the scrape IDs that were removed
    */
-  fun removeChunkedContextsForAgent(agentId: String): List<Long> {
-    val scrapeIds = chunkedContextMap.entries.filter { (_, context) -> context.agentId == agentId }.map { it.key }
-    scrapeIds.forEach { chunkedContextMap.remove(it) }
-    return scrapeIds
-  }
+  fun removeChunkedContextsForAgent(agentId: String): List<Long> =
+    // Return only the IDs this call actually removed. A concurrent writeChunkedResponsesToProxy can
+    // complete (and remove) a matching context between the filter and the remove, so returning the
+    // pre-removal snapshot would over-count what was reclaimed in the caller's log.
+    chunkedContextMap.entries
+      .filter { (_, context) -> context.agentId == agentId }
+      .mapNotNull { (scrapeId, _) -> if (chunkedContextMap.remove(scrapeId) != null) scrapeId else null }
 
   fun findStaleAgents(maxInactivity: Duration): List<Pair<String, AgentContext>> =
     agentContextMap

--- a/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
@@ -61,7 +61,7 @@ internal object ProxyUtils {
           }
           baos.write(buffer, 0, len)
         }
-        return DecodedContent(baos.toString(Charsets.UTF_8.name()), totalBytes)
+        return DecodedContent(baos.toString(Charsets.UTF_8), totalBytes)
       }
     }
   }

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -1297,6 +1297,97 @@ class AgentHttpServiceTest : StringSpec() {
       }
     }
 
+    "fetchScrapeUrl reads the full chunked body (no Content-Length) when under the limit" {
+      // respondTextWriter streams with chunked transfer-encoding and no Content-Length, so the
+      // bounded readRemaining(maxContentLength + 1) path is exercised. The body is well under the
+      // 10 MB default limit, so it must be returned intact (not truncated at the read cap).
+      val content = "metric_a 1.0\nmetric_b 2.0\nmetric_c 3.0\n".repeat(50)
+      val server = embeddedServer(ServerCIO, port = 0) {
+        routing {
+          get("/metrics") {
+            call.respondTextWriter {
+              write(content)
+            }
+          }
+        }
+      }
+
+      try {
+        val port = server.startAndAwaitReady()
+
+        val mockAgent = createMockAgentWithPaths()
+        // minGzipSizeBytes is 1_000_000, so this small body stays on the non-zipped text path.
+        val service = AgentHttpService(mockAgent)
+
+        mockAgent.pathManager.registerPath("metrics", "http://localhost:$port/metrics")
+
+        val request = scrapeRequest {
+          agentId = "agent-1"
+          scrapeId = 204L
+          path = "metrics"
+          accept = ""
+          debugEnabled = false
+          encodedQueryParams = ""
+          authHeader = ""
+        }
+
+        val results = service.fetchScrapeUrl(request)
+
+        results.srStatusCode shouldBe 200
+        results.srValidResponse.shouldBeTrue()
+        results.srZipped.shouldBeFalse()
+        results.srContentAsText shouldBe content
+
+        service.close()
+      } finally {
+        server.stop(0, 0)
+      }
+    }
+
+    "fetchScrapeUrl decodes a multi-byte UTF-8 body correctly on the text path" {
+      // Guards the switch from bodyAsText() (response charset) to contentBytes.decodeToString()
+      // (always UTF-8): a multi-byte body under the gzip threshold must round-trip byte-for-byte.
+      val multiByte = "café_µ_世界 42.0\n".repeat(5) // mix of 2- and 3-byte UTF-8 chars
+      val server = embeddedServer(ServerCIO, port = 0) {
+        routing {
+          get("/metrics") {
+            call.respondText(multiByte)
+          }
+        }
+      }
+
+      try {
+        val port = server.startAndAwaitReady()
+
+        val mockAgent = createMockAgentWithPaths()
+        // minGzipSizeBytes is 1_000_000, so this stays on the non-zipped text path.
+        val service = AgentHttpService(mockAgent)
+
+        mockAgent.pathManager.registerPath("metrics", "http://localhost:$port/metrics")
+
+        val request = scrapeRequest {
+          agentId = "agent-1"
+          scrapeId = 205L
+          path = "metrics"
+          accept = ""
+          debugEnabled = false
+          encodedQueryParams = ""
+          authHeader = ""
+        }
+
+        val results = service.fetchScrapeUrl(request)
+
+        results.srStatusCode shouldBe 200
+        results.srValidResponse.shouldBeTrue()
+        results.srZipped.shouldBeFalse()
+        results.srContentAsText shouldBe multiByte
+
+        service.close()
+      } finally {
+        server.stop(0, 0)
+      }
+    }
+
     // ==================== Item 29: timeout resolution precedence ====================
     // resolveTimeoutSecs honors the deprecated cioTimeoutSecs only when it was explicitly
     // overridden (non-default) while httpClientTimeoutSecs was left at the default. Otherwise

--- a/src/test/kotlin/io/prometheus/common/UtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/UtilsTest.kt
@@ -28,7 +28,6 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeEmpty
 import io.prometheus.common.Utils.HostPort
 import io.prometheus.common.Utils.appendQueryParams
-import io.prometheus.common.Utils.decodeParams
 import io.prometheus.common.Utils.defaultEmptyJsonObject
 import io.prometheus.common.Utils.exceptionDetails
 import io.prometheus.common.Utils.parseHostPort
@@ -52,39 +51,6 @@ class UtilsTest : StringSpec() {
   init {
     afterTest {
       setLogLevel("test", originalLogLevel.levelStr.lowercase())
-    }
-
-    // ==================== decodeParams Tests ====================
-
-    "decodeParams should return empty string for blank input" {
-      decodeParams("") shouldBe ""
-      decodeParams("   ") shouldBe ""
-    }
-
-    "decodeParams should decode URL-encoded parameters" {
-      val encoded = "foo%3Dbar%26baz%3Dqux"
-      val result = decodeParams(encoded)
-
-      result shouldBe "?foo=bar&baz=qux"
-    }
-
-    "decodeParams should add question mark prefix" {
-      val result = decodeParams("simple")
-
-      result shouldBe "?simple"
-    }
-
-    "decodeParams should handle special characters" {
-      val encoded = "name%3DJohn%20Doe%26city%3DNew%20York"
-      val result = decodeParams(encoded)
-
-      result shouldBe "?name=John Doe&city=New York"
-    }
-
-    "decodeParams should handle already decoded strings" {
-      val result = decodeParams("key=value")
-
-      result shouldBe "?key=value"
     }
 
     // ==================== appendQueryParams Tests ====================

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -195,6 +195,22 @@ class ProxyOptionsTest : StringSpec() {
       options.handshakeTimeoutSecs shouldBe -1L
     }
 
+    "a zero gRPC keepalive time should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--keepalive_time_secs", "0")) }
+      exception.message shouldContain "keepAliveTimeSecs"
+    }
+
+    "a zero gRPC keepalive timeout should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--keepalive_timeout_secs", "0")) }
+      exception.message shouldContain "keepAliveTimeoutSecs"
+    }
+
+    "the -1 sentinel should be accepted for gRPC keepalive timeouts" {
+      val options = ProxyOptions(listOf("--keepalive_time_secs", "-1", "--keepalive_timeout_secs", "-1"))
+      options.keepAliveTimeSecs shouldBe -1L
+      options.keepAliveTimeoutSecs shouldBe -1L
+    }
+
     // ==================== Constructor Variants Tests ====================
 
     "list constructor should work" {


### PR DESCRIPTION
## Summary

Hardens the agent's HTTP scrape path against memory exhaustion and folds in several small, verified cleanups surfaced by a multi-dimension code review. Also bumps three dependencies and adds a review resolution-status doc.

## Primary fix — bounded response-body read (prevents OOM)

`buildScrapeResults()` called `bodyAsText()`, which buffered the **entire** response into the heap *before* the post-read size check. A scrape target with no `Content-Length` (chunked transfer encoding) or an understated one could push the agent toward OOM regardless of `maxContentLengthMBytes`.

Now reads at most `maxContentLength + 1` bytes via `bodyAsChannel().readRemaining(...)`, so the size guard runs against a bounded buffer. The success path uses `contentBytes.decodeToString()` (UTF-8), consistent with the existing gzip path. The oversized read is released cleanly because it happens inside Ktor's managed `client.get { response -> }` block.

Added tests: a full chunked body under the limit round-trips intact, and multi-byte UTF-8 round-trips on the text path (guards the `bodyAsText` → `decodeToString` charset change).

## Reviewed cleanups

- **`AgentGrpcService`** — dropped the redundant `withContext(Dispatchers.IO)` around the in-memory `ByteArrayInputStream.read()` chunk loop (no-op thread hop; the coroutine is already on IO), plus the now-unused import.
- **`Agent.run()`** — guard `reconnectLimiter.acquire()` with `if (isRunning)`, so the non-interruptible rate-limiter no longer stalls `shutDown()`/`awaitTerminated()` for up to `reconnectPauseSecs` during shutdown.
- **`Utils`** — deleted dead `decodeParams()` (zero production callers since #160; its decode-then-prepend was the very bug #160 fixed) plus its imports and `UtilsTest` block.
- **`BaseOptions`** — validate `keepAliveTimeSecs`/`keepAliveTimeoutSecs` (`-1` default or `> 0`), closing the gap item 27 left for the keepAlive timeouts; a `0` otherwise reaches the gRPC builder as an opaque Netty exception. Added rejection + sentinel tests.
- **`AgentContextManager.removeChunkedContextsForAgent`** — return only the IDs actually removed, so the caller's "Reclaimed N" log stays accurate when a concurrent `writeChunkedResponsesToProxy` removes a matching context.
- **`ProxyUtils`** — use `ByteArrayOutputStream.toString(Charset)` instead of the `toString(name)` overload that suppresses `UnsupportedEncodingException`.

## Other

- **Dependency bumps:** grpc `1.81.0` → `1.82.0`, gradle-plugins `1.0.14` → `1.0.15`, common-utils `2.9.0` → `2.9.1`.
- **`code-review.md`** — resolution-status summary for the prior review campaign (PRs #149–#163) plus these new fixes.

## Verification

`formatKotlin`, `detekt`, `lintKotlinMain`, `lintKotlinTest`, `compileKotlin`, `compileTestKotlin` all clean. Affected test classes pass: `AgentHttpServiceTest`, `AgentGrpcServiceTest`, `UtilsTest`, `ProxyOptionsTest`, `AgentContextManagerTest`, `ProxyUtilsTest`. A full `./gradlew build` has not been run.

## Out of scope (tracked separately)

The high-severity finding from the review — **unauthenticated agent registration / path hijacking on gRPC :50051** — needs design (pre-shared token or required mTLS) and is intentionally left for its own PR, as are the gRPC-reflection default and CI/Docker hygiene items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)