### PR TITLE
Use coroutineScope instead of runBlocking in TlsMutualAuthRejectionTest teardown

### DIFF
--- a/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
@@ -29,8 +29,8 @@ import io.prometheus.harness.HarnessConstants.CONFIG_ARG
 import io.prometheus.harness.support.exceptionHandler
 import io.prometheus.proxy.ProxyOptions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlin.time.Duration.Companion.seconds
 
 // Item 28: negative-path coverage for mutual TLS. The existing TlsWithMutualAuthTest /
@@ -83,7 +83,9 @@ class TlsMutualAuthRejectionTest : StringSpec() {
         // awaitInitialConnection returns false once the timeout elapses.
         agent.awaitInitialConnection(5.seconds).shouldBeFalse()
       } finally {
-        runBlocking {
+        // The test block is itself a suspend function, so suspend via coroutineScope rather than
+        // blocking the thread with runBlocking (mirrors the teardown in HarnessTests).
+        coroutineScope {
           for (service in listOf(proxy, agent)) {
             launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
           }


### PR DESCRIPTION
## Summary

`TlsMutualAuthRejectionTest` ran its proxy/agent teardown inside `runBlocking { … }`, but the Kotest `StringSpec` test block is itself a `suspend` function. Blocking the test thread with `runBlocking` from within a suspending context is an anti-pattern — it happens to work here only because the cleanup coroutines are dispatched to `Dispatchers.IO`.

This switches the teardown to `coroutineScope { … }`, which suspends instead of blocking while preserving the same structured-concurrency semantics (launch both `stopSync()` children, join before returning).

## Why coroutineScope

The repo already draws this line consistently — this file was the outlier:

- `support/HarnessTests.kt:183` / `:273` — teardown inside a **suspend** test body uses `coroutineScope` (identical `launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }` loop).
- `support/HarnessSetup.kt:62` — uses `runBlocking`, which is correct there because `takeDownProxyAndAgent()` is a **non-suspend** `fun`.

The change is behavior-preserving: the `exceptionHandler` on the child `launch` is ignored under both `runBlocking` and `coroutineScope` (child-coroutine exceptions propagate to the parent regardless).

## Verification

`lintKotlinTest` clean; `TlsMutualAuthRejectionTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)