### PR TITLE
Complete ProxyOptions bounds validation (item 27)

### DIFF
--- a/code-review.md
+++ b/code-review.md
@@ -387,6 +387,11 @@ A 114-line nested `connectToProxy()` launches four child coroutines, each repeat
 
 **Fix:** add fail-fast checks in `assignConfigVals()` after each value resolves: `require(proxyPort in 1..65535)`, same for `proxyAgentPort`, and `require(field == -1L || field > 0)` for each gRPC timeout (preserving the sentinel the `> -1L` guards rely on). No behavior change for valid configs.
 
+**Completed 2026-06-12 (remaining elements):** ports, gRPC timeouts, and the `keepAlive*` pair are
+guarded; `internal.scrapeRequestTimeoutSecs`, `staleAgentCheckPauseSecs`, and `maxAgentInactivitySecs`
+now `require(> 0)`, and `maxUnzippedContentSizeMBytes` `require(>= 0)` (0 is a valid "reject-all"
+limit used by the zip-bomb test, so only negatives are rejected). Rejection + accept tests added.
+
 ### Lower-value config/observability (low)
 
 - [x] **`scrapeRequestTimeoutSecs` bounds check** (`ProxyOptions.kt:241`):

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -242,8 +242,21 @@ class ProxyOptions(
             "internal.scrapeRequestTimeoutSecs must be > 0: ${internal.scrapeRequestTimeoutSecs}"
           }
           logger.info { "internal.scrapeRequestTimeoutSecs: ${internal.scrapeRequestTimeoutSecs}" }
+
+          require(internal.staleAgentCheckPauseSecs > 0) {
+            "internal.staleAgentCheckPauseSecs must be > 0: ${internal.staleAgentCheckPauseSecs}"
+          }
           logger.info { "internal.staleAgentCheckPauseSecs: ${internal.staleAgentCheckPauseSecs}" }
+
+          require(internal.maxAgentInactivitySecs > 0) {
+            "internal.maxAgentInactivitySecs must be > 0: ${internal.maxAgentInactivitySecs}"
+          }
           logger.info { "internal.maxAgentInactivitySecs: ${internal.maxAgentInactivitySecs}" }
+
+          // 0 is a valid (degenerate) "reject all content" limit, so only negatives are invalid here.
+          require(internal.maxUnzippedContentSizeMBytes >= 0) {
+            "internal.maxUnzippedContentSizeMBytes must be >= 0: ${internal.maxUnzippedContentSizeMBytes}"
+          }
           logger.info { "internal.maxUnzippedContentSizeMBytes: ${internal.maxUnzippedContentSizeMBytes}" }
         }
 

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -211,6 +211,36 @@ class ProxyOptionsTest : StringSpec() {
       options.keepAliveTimeoutSecs shouldBe -1L
     }
 
+    // These internal config values are positive durations/sizes; a 0/negative would otherwise
+    // surface as silent misbehavior (busy-loop, immediate eviction, all-content-rejected) rather
+    // than a clear startup error.
+
+    "a non-positive staleAgentCheckPauseSecs should be rejected" {
+      val exception =
+        shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("-Dproxy.internal.staleAgentCheckPauseSecs=0")) }
+      exception.message shouldContain "staleAgentCheckPauseSecs"
+    }
+
+    "a non-positive maxAgentInactivitySecs should be rejected" {
+      val exception =
+        shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("-Dproxy.internal.maxAgentInactivitySecs=0")) }
+      exception.message shouldContain "maxAgentInactivitySecs"
+    }
+
+    // 0 is a valid "reject all content" limit (used by the zip-bomb test), so only negatives reject.
+    "a negative maxUnzippedContentSizeMBytes should be rejected" {
+      val exception =
+        shouldThrow<IllegalArgumentException> {
+          ProxyOptions(listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=-1"))
+        }
+      exception.message shouldContain "maxUnzippedContentSizeMBytes"
+    }
+
+    "a zero maxUnzippedContentSizeMBytes should be accepted (reject-all limit)" {
+      val options = ProxyOptions(listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=0"))
+      options.configVals.proxy.internal.maxUnzippedContentSizeMBytes shouldBe 0
+    }
+
     // ==================== Constructor Variants Tests ====================
 
     "list constructor should work" {


### PR DESCRIPTION
## Summary

Finishes code-review item 27 ("`ProxyOptions` does no bounds validation on ports/timeouts"). The ports, gRPC timeouts, and `keepAlive*` pair were already guarded and `scrapeRequestTimeoutSecs` had `require(> 0)` — but its three siblings resolved in `assignConfigVals()` were logged and never validated, so a misconfigured value surfaced as silent misbehavior rather than a clear startup error.

## Changes

`ProxyOptions.assignConfigVals()`:
- `require(staleAgentCheckPauseSecs > 0)` — a `0` busy-loops the stale-agent cleanup service
- `require(maxAgentInactivitySecs > 0)` — a `0`/negative evicts every agent immediately
- `require(maxUnzippedContentSizeMBytes >= 0)` — only negatives rejected

The `>= 0` on the size limit is deliberate: `ProxyHttpRoutesTest`'s zip-bomb test sets `maxUnzippedContentSizeMBytes=0` as a valid "reject-all" limit, so a `> 0` guard would break intended behavior. Only negatives (genuine misconfig) are rejected.

Tests (`ProxyOptionsTest`): rejection cases for the two durations and a negative size limit, plus an accept case confirming `maxUnzippedContentSizeMBytes=0` still works. `code-review.md` item 27 updated with a completion note.

## Verification

`formatKotlin`, `detekt`, `lintKotlinMain`, `lintKotlinTest` clean. Full `io.prometheus.proxy.*` package (incl. the zip-bomb test), `OptionsTest`, and `ConfigValsTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)