### PR TITLE
Remove redundant EnvVars default-fallback test

### DIFF
--- a/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
@@ -302,23 +302,10 @@ class EnvVarsTest : StringSpec() {
       actualNames shouldBe expectedNames
     }
 
-    "getEnv Int and Long return the default when the env var is unset" {
-      // System.getenv() can't be set in-process, so getEnv()'s default branch is exercised here and
-      // its parse-and-throw branch is covered directly via parseIntStrict / parseLongStrict below.
-      val intResult = EnvVars.PROXY_PORT.getEnv(8080)
-      val longResult = EnvVars.HANDSHAKE_TIMEOUT_SECS.getEnv(120L)
-
-      if (System.getenv("PROXY_PORT") == null) {
-        intResult shouldBe 8080
-      }
-      if (System.getenv("HANDSHAKE_TIMEOUT_SECS") == null) {
-        longResult shouldBe 120L
-      }
-    }
-
     // ==================== parseIntStrict validation ====================
-    // Covers the throw branch of getEnv(Int), which getEnv() reaches only when a real env var holds
-    // a non-numeric value — not settable in-process, so the extracted helper is tested directly.
+    // getEnv(Int)'s default branch (unset env var) is covered above by "getEnv should return default
+    // int when env var not set". Its parse-and-throw branch is reached only when a real env var holds
+    // a non-numeric value — not settable in-process — so the extracted helper is tested directly here.
 
     "parseIntStrict should parse valid integers including boundaries and signs" {
       EnvVars.parseIntStrict("TEST", "0") shouldBe 0


### PR DESCRIPTION
## Summary

Follow-up `/simplify` cleanup on the EnvVars coverage work (#169).

The `"getEnv Int and Long return the default when the env var is unset"` test duplicated the existing `"getEnv should return default int/long when env var not set"` tests — same env vars (`PROXY_PORT`, `HANDSHAKE_TIMEOUT_SECS`), same assertion. Once the new `parseIntStrict`/`parseLongStrict` tests covered the `getEnv()` throw branches directly, this block no longer had a unique purpose. Removed it and folded its rationale into the section comment above the helper tests.

No behavior change; net −13 lines of test code.

## Verification

- `./gradlew test --tests "io.prometheus.common.EnvVarsTest"` — passes
- `./gradlew detekt lintKotlinTest` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)