### PR TITLE
Document EnvVars parse-failure test coverage in 3.2.0 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project are documented in this file.
 
 - Code-review cleanup with no behavior change: extracted shared common-option assignment between `AgentOptions` / `ProxyOptions`, decomposed `Agent.run()`'s connection tasks behind one helper, collapsed the duplicated `ConfigWrappers` overloads, modeled basic-auth credentials as a `Credentials` value object, split the chunk-size field into a KB input plus derived bytes, replaced the stringly-typed path config with a typed `PathConfig`, and unified gRPC-default log formatting behind one helper
 - Added a mutual-TLS rejection test and coverage for timeout-override resolution, the unknown-`scrapeId` header drop, wrapped-timeout detection, and the chunk-size boundary; encode the gzipped response body once (was twice); removed the dead `SslSettings` scaffolding (now wired into the HTTPS trust store) and stale commented-out blocks
+- Covered the previously-untested `EnvVars.getEnv(Int)` / `getEnv(Long)` invalid-value error paths: extracted `parseIntStrict` / `parseLongStrict` companion helpers (mirroring the existing `parseBooleanStrict`) so the parse-and-throw branches are testable without setting process env vars, and dropped a redundant default-fallback test
 
 ### Build & Tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ Container tests in `src/test/kotlin/io/prometheus/containers/`:
 
 Unit tests in `src/test/kotlin/io/prometheus/{agent,proxy,common}/`.
 
+`EnvVars.getEnv()` reads `java.lang.System.getenv()`, which can't be set in-process, so its parse-and-throw branches aren't reachable by setting an env var in a test. The numeric/boolean parsing is therefore extracted into `internal` companion helpers (`parseBooleanStrict` / `parseIntStrict` / `parseLongStrict`) that the tests call directly. When adding a new typed `getEnv` overload, follow this pattern so the invalid-value path stays testable.
+
 ## Documentation Site
 
 Documentation is built with [Zensical](https://zensical.org) (static site generator) and lives in `website/prometheus-proxy/`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,7 @@ _Unreleased_
 
 - Full code-review cleanup pass with no behavior change: extracted the shared common-option assignment between `AgentOptions` and `ProxyOptions`, decomposed `Agent.run()`'s four connection tasks behind one `launchConnectionTask` helper, collapsed the six duplicated `ConfigWrappers` overloads onto shared builders, modeled basic-auth credentials as a `Credentials` value object, split the agent chunk-size field into a KB input plus a derived bytes value, replaced the stringly-typed `PathConfig` map with a typed data class, and unified the gRPC-default log formatting behind a single `grpcDefaultLabel` helper
 - Added a negative-path mutual-TLS rejection test plus unit coverage for timeout-override resolution, the chunked unknown-`scrapeId` header drop, wrapped-timeout detection, and the chunk-size boundary; encode the gzipped response body only once (was twice); deleted the dead `SslSettings` scaffolding (now wired into the new HTTPS trust store) and stale commented-out blocks
+- Closed a test-coverage gap on `EnvVars`: the `getEnv(Int)` / `getEnv(Long)` invalid-value error paths were unreachable from tests because `System.getenv()` can't be set in-process. Extracted `parseIntStrict` / `parseLongStrict` companion helpers (matching the existing `parseBooleanStrict` seam) and tested them directly for boundaries, signs, `Int`-overflow rejection, and non-numeric/whitespace input; removed a redundant default-fallback test
 
 ### Build & Tooling
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to the EnvVars coverage work (#169, #170).

- **CHANGELOG.md** — bullet under `[3.2.0] - Unreleased` → Code Quality.
- **RELEASE_NOTES.md** — parallel narrative bullet under 3.2.0 → Code Quality.
- **CLAUDE.md** — durable note in Test Structure: `System.getenv()` can't be set in-process, so env-var parsing is extracted into `parse*Strict` companion helpers and tested directly; follow the pattern for new `getEnv` overloads.

**README.md and llms.txt intentionally unchanged** — the work is test-only with no user-facing surface, and their `3.2.0` references are version literals that are already current.

No code changes; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)