### PR TITLE
Patch base-image Alpine CVEs in the nginx example Dockerfile

### DIFF
--- a/nginx/docker/Dockerfile
+++ b/nginx/docker/Dockerfile
@@ -1,4 +1,8 @@
 FROM nginx:1.29-alpine
+# Patch base-image Alpine OS packages flagged by Snyk (libxml2, xz-libs, openssl). The upstream
+# nginx:1.29-alpine tag still ships -r0 revisions; apk upgrade pulls the patched revisions from the
+# same Alpine branch (e.g. libxml2 2.13.9-r1, xz-libs 5.8.3-r0, libssl3/libcrypto3 3.5.7-r0).
+RUN apk upgrade --no-cache
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 50440


### PR DESCRIPTION
## Summary

Snyk flagged three base-image OS-package vulnerabilities in `nginx/docker/Dockerfile` (the `pambrose/nginx2` reverse-proxy example image), inherited from `nginx:1.29-alpine`, which still ships the unpatched `-r0` revisions:

| Package | Before | After | Severity |
|---|---|---|---|
| libxml2 | 2.13.9-r0 | 2.13.9-r1 | High — Access of Resource Using Incompatible Type (Type Confusion) |
| xz-libs | 5.8.2-r0 | 5.8.3-r0 | Medium — Heap-based Buffer Overflow |
| libssl3 / libcrypto3 | 3.5.6-r0 | 3.5.7-r0 | Low — CVE-2026-45445 |

## Fix

Add `RUN apk upgrade --no-cache` after the `FROM`, pulling the patched package revisions from the same Alpine 3.23 branch at build time — the standard remediation for base-image OS-package CVEs that "can only be fixed manually."

For this unpublished utility/example image, auto-following OS security patches is the right tradeoff (vs. the digest-pinning used for the published agent/proxy images, where reproducibility wins).

## Verification

Built the image and confirmed the upgraded versions:

```
libcrypto3-3.5.7-r0
libssl3-3.5.7-r0
libxml2-2.13.9-r1
xz-libs-5.8.3-r0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)