### PR TITLE
CI/Docker hygiene, all-tests target, and observability status

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install zensical mkdocs-material
+      # Pinned for reproducible doc builds; bump deliberately when upgrading the toolchain.
+      - run: pip install zensical==0.0.45 mkdocs-material==9.7.6
       - run: zensical build --clean
         working-directory: website/prometheus-proxy
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default help stop clean clean-all stubs build tibuild refresh jars \
-        tests mini-tests nh-tests ip-tests netty-tests tls-tests container-tests regen-certs \
+        tests mini-tests nh-tests ip-tests netty-tests tls-tests container-tests all-tests regen-certs \
         coverage coverage-html coverage-xml coverage-log coverage-verify \
         coverage-open coverage-packages coverage-clean reports gh-docs \
         gh-status tsconfig distro docker-push release tree depends lint detekt detekt-baseline \
@@ -79,13 +79,15 @@ netty-tests:  ## Run Netty harness tests
 tls-tests:  ## Run TLS harness tests
 	./gradlew test --tests "io.prometheus.harness.Tls*"
 
-container-tests: jars  ## Run the Testcontainers smoke test (needs Docker)
+container-tests: jars  ## Run the Testcontainers tests (needs Docker)
 	@DOCKER_HOST="$$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)"; \
 	if [ -z "$$DOCKER_HOST" ]; then \
 		echo "Error: could not detect active Docker context. Is Docker running?" >&2; exit 1; \
 	fi; \
 	echo "Using DOCKER_HOST=$$DOCKER_HOST"; \
 	DOCKER_HOST="$$DOCKER_HOST" RUN_CONTAINER_TESTS=true ./gradlew test --tests "io.prometheus.containers.*"
+
+all-tests: tests container-tests  ## Run the full suite: all tests + the container tests
 
 regen-certs:  ## Regenerate the testing/certs TLS fixtures (CA + server + client; 2048-bit, 100-year validity)
 	@command -v openssl >/dev/null 2>&1 || { echo "Error: openssl not found on PATH" >&2; exit 1; }

--- a/code-review.md
+++ b/code-review.md
@@ -59,8 +59,8 @@ Resolution status section below; full write-ups further down.
 | Idioms | `ScrapeResults` 11-arg remodel | ⬜ deferred |
 | Config/obs | `scrapeRequestTimeoutSecs` bounds check | ✅ |
 | Config/obs | Dead config keys removed | ✅ |
-| Config/obs | Proxy scrape-failure-mode metric label | ⬜ open |
-| Config/obs | `launch_id` labeling on `ProxyMetrics` | ⬜ open |
+| Config/obs | Proxy scrape-failure-mode metric label | ✅ |
+| Config/obs | `launch_id` labeling on `ProxyMetrics` | ✅ (resolved by design) |
 | Tests | ChunkedContext exact-boundary acceptance | ✅ |
 | Tests | `writeScrapeRequest`/`invalidate` race test | ⬜ won't-do |
 
@@ -78,8 +78,10 @@ Resolution status section below; full write-ups further down.
 | Redundant defensive list copies in `ProxyPathManager` (`/simplify`) | ✅ |
 
 **Still open (own PRs):** the High-severity unauthenticated agent-registration / path-hijacking
-finding (see `docs/security-agent-authentication.md`), gRPC-reflection-on-by-default, detekt alpha
-pin + CI/Docker hygiene, and the two observability items above.
+finding (see `docs/security-agent-authentication.md`), gRPC-reflection-on-by-default, and the detekt
+alpha pin. Docker base-image digest pinning, no-op JVM-flag removal, and `docs.yml` pip pinning were
+completed 2026-06-13; the two observability items are resolved (failure-mode metric done;
+`launch_id` scope intentional).
 
 ---
 
@@ -399,13 +401,14 @@ limit used by the zip-bomb test, so only negatives are rejected). Rejection + ac
   half — not done, low value.)
 - [x] **Dead config keys `maxThreads`/`minThreads`/`scrapeRequestCheckMillis`**: removed + ConfigVals regenerated, with
   referencing tests updated (PR #157).
-- [ ] **No metric distinguishes proxy scrape failure modes** (`ProxyHttpRoutes.kt:112, 244-340`): the rich `updateMsg`
-  taxonomy feeds only the count; the latency histogram has no outcome label, and the timeout (`:254`) and
-  `ClosedSendChannelException` write-failure (`:244`) paths never record latency. Add a status label to the histogram
-  and observe on those two branches. **Open** — metric-schema change, own PR.
-- [ ] **Inconsistent `launch_id` labeling** (`ProxyMetrics.kt:30-94`): AgentMetrics tags every series with `launch_id`;
-  ProxyMetrics tags none, so proxy counters reset silently on restart. Mostly consistency — PromQL `rate()`/`increase()`
-  tolerate resets. **Open / accepted** — low priority.
+- [x] **No metric distinguishes proxy scrape failure modes** (`ProxyHttpRoutes.kt:205-211`): `scrapeRequestLatency` now
+  carries an `outcome` label and a single recording site observes latency for **every** response — including the
+  `timed_out`, `agent_disconnected`, and `missing_results` early returns that the old per-request timer missed — using
+  `response.updateMsg` as the outcome. Verified done 2026-06-13.
+- [x] **`launch_id` labeling on `ProxyMetrics`** — **resolved by design.** `proxy_start_time_seconds` is labeled with
+  `launch_id` (enough to detect a restart on a Prometheus target); the counters/histograms are intentionally left
+  unlabeled because PromQL `rate()`/`increase()` already tolerate counter resets across restarts. This deliberate scope
+  is documented at `Proxy.kt:184-186`, so tagging every series was **not** done.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,12 +27,18 @@ This document describes the test suite structure and how to run tests for the pr
 ### Make Targets
 
 ```bash
-make tests        # Rerun all checks (lint + tests)
-make nh-tests     # Unit tests only (agent, proxy, common, misc — no harness)
-make ip-tests     # In-process integration tests only
-make netty-tests  # Netty integration tests only
-make tls-tests    # TLS integration tests only
+make tests            # Rerun all checks (lint + tests); the container smoke test is SKIPPED
+make nh-tests         # Unit tests only (agent, proxy, common, misc — no harness)
+make ip-tests         # In-process integration tests only
+make netty-tests      # Netty integration tests only
+make tls-tests        # TLS integration tests only
+make container-tests  # Testcontainers smoke test only (needs Docker)
+make all-tests        # Full suite: `make tests` + `make container-tests`
 ```
+
+The container smoke test (`io.prometheus.containers.*`) is gated on `RUN_CONTAINER_TESTS=true` and
+needs Docker, so a plain `make tests` / `./gradlew check` registers it as a SKIPPED placeholder. Use
+`make container-tests` to run it on its own, or `make all-tests` to run everything in one shot.
 
 ## Frameworks and Libraries
 

--- a/etc/docker/agent.df
+++ b/etc/docker/agent.df
@@ -1,4 +1,6 @@
-FROM bellsoft/liberica-openjre-alpine:17
+# Pinned by digest for reproducible builds (tag kept for readability). Bump the digest periodically
+# to pick up base-image security patches: docker buildx imagetools inspect bellsoft/liberica-openjre-alpine:17
+FROM bellsoft/liberica-openjre-alpine:17@sha256:46d2697c9a83d968506f4da2d25439aa02cec887eba9b60e711a05bcba534f46
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
@@ -23,4 +25,6 @@ EXPOSE 8093
 
 CMD []
 
-ENTRYPOINT ["java", "-server", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-jar", "/app/prometheus-agent.jar"]
+# G1 is the default GC on JDK 17 and MaxGCPauseMillis/UseStringDeduplication are non-experimental,
+# so -XX:+UseG1GC and -XX:+UnlockExperimentalVMOptions were no-ops and have been removed.
+ENTRYPOINT ["java", "-server", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-jar", "/app/prometheus-agent.jar"]

--- a/etc/docker/proxy.df
+++ b/etc/docker/proxy.df
@@ -1,4 +1,6 @@
-FROM bellsoft/liberica-openjre-alpine:17
+# Pinned by digest for reproducible builds (tag kept for readability). Bump the digest periodically
+# to pick up base-image security patches: docker buildx imagetools inspect bellsoft/liberica-openjre-alpine:17
+FROM bellsoft/liberica-openjre-alpine:17@sha256:46d2697c9a83d968506f4da2d25439aa02cec887eba9b60e711a05bcba534f46
 LABEL maintainer="Paul Ambrose <pambrose@mac.com>"
 
 # Define the user to use in this instance to prevent using root that even in a container, can be a security risk.
@@ -26,4 +28,6 @@ EXPOSE 50440
 
 CMD []
 
-ENTRYPOINT ["java", "-server", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-jar", "/app/prometheus-proxy.jar"]
+# G1 is the default GC on JDK 17 and MaxGCPauseMillis/UseStringDeduplication are non-experimental,
+# so -XX:+UseG1GC and -XX:+UnlockExperimentalVMOptions were no-ops and have been removed.
+ENTRYPOINT ["java", "-server", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-jar", "/app/prometheus-proxy.jar"]


### PR DESCRIPTION
## Summary

Low-priority CI/Docker hygiene plus a Makefile/docs improvement and a documentation correction. No production code changes.

## Changes

### Docker (`etc/docker/{agent,proxy}.df`)
- **Pin the base image by digest** — `bellsoft/liberica-openjre-alpine:17@sha256:46d2697c…` (multi-arch manifest-list digest, verified to resolve), with a comment on how to bump for patches. Reproducible builds for the published images.
- **Drop no-op JVM flags** — removed `-XX:+UnlockExperimentalVMOptions` and `-XX:+UseG1GC` (G1 is the JDK 17 default; the kept `-XX:MaxGCPauseMillis=100` / `-XX:+UseStringDeduplication` are non-experimental).

### CI (`.github/workflows/docs.yml`)
- **Pin the docs toolchain** — `zensical==0.0.45`, `mkdocs-material==9.7.6` (current latest, made reproducible).

### Makefile
- **New `all-tests` target** — runs `tests` + `container-tests` (full suite incl. the Testcontainers smoke test).

### docs/TESTING.md
- Document `make container-tests` and `make all-tests`; note the container smoke test is gated on `RUN_CONTAINER_TESTS=true` + Docker and is SKIPPED in a plain `make tests`.

### code-review.md
- Mark the two observability items resolved against current `master`: the proxy scrape-failure-mode metric is **already implemented** (`outcome` label + a single latency-recording site covering every outcome incl. timeout/disconnect), and the `launch_id` scope is an **intentional documented decision** (`Proxy.kt:184-186` — only `proxy_start_time_seconds` is labeled; counters left unlabeled since PromQL tolerates resets).

## Tradeoff note

Digest + version pinning freezes the base image / doc toolchain until manually bumped — the standard reproducibility-vs-patch-following trade. Wiring Renovate/Dependabot to auto-bump these is the natural follow-up. (The separate PR #176 takes the opposite, auto-patching approach for the unpublished nginx example image, which is appropriate there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)