### PR TITLE
Document the pre-shared agent token in the website docs

### DIFF
--- a/website/prometheus-proxy/docs/cli-reference.md
+++ b/website/prometheus-proxy/docs/cli-reference.md
@@ -11,6 +11,7 @@ icon: lucide/terminal
 | `--config, -c`       | `PROXY_CONFIG`                    |                                         |                          | Config file path or URL      |
 | `--port, -p`         | `PROXY_PORT`                      | `proxy.http.port`                       | 8080                     | HTTP listen port             |
 | `--agent_port, -a`   | `AGENT_PORT`                      | `proxy.agent.port`                      | 50051                    | gRPC listen port for agents  |
+| `--agent_token`      | `AGENT_TOKEN`                     | `proxy.agentToken`                      | ""                       | Pre-shared agent auth token  |
 | `--admin, -r`        | `ADMIN_ENABLED`                   | `proxy.admin.enabled`                   | false                    | Enable admin endpoints       |
 | `--admin_port, -i`   | `ADMIN_PORT`                      | `proxy.admin.port`                      | 8092                     | Admin listen port            |
 | `--debug, -b`        | `DEBUG_ENABLED`                   | `proxy.admin.debugEnabled`              | false                    | Enable debug servlet         |
@@ -60,6 +61,7 @@ icon: lucide/terminal
 | `--chunk`                     | `CHUNK_CONTENT_SIZE_KBS`          | `agent.chunkContentSizeKbs`                 | 32      | Chunking threshold (KB)            |
 | `--gzip`                      | `MIN_GZIP_SIZE_BYTES`             | `agent.minGzipSizeBytes`                    | 1024    | Min size for gzip (bytes)          |
 | `--tf_disabled`               | `TRANSPORT_FILTER_DISABLED`       | `agent.transportFilterDisabled`             | false   | Disable transport filter           |
+| `--agent_token`               | `AGENT_TOKEN`                     | `agent.agentToken`                          | ""      | Pre-shared token presented to proxy |
 | `--trust_all_x509`            | `TRUST_ALL_X509_CERTIFICATES`     | `agent.http.enableTrustAllX509Certificates` | false   | Disable SSL verification           |
 | `--https_truststore`          | `HTTPS_TRUST_STORE_PATH`          | `agent.http.trustStorePath`                 | ""      | Trust store for HTTPS targets      |
 | `--https_truststore_password` | `HTTPS_TRUST_STORE_PASSWORD`      | `agent.http.trustStorePassword`             | ""      | Password for the trust store       |

--- a/website/prometheus-proxy/docs/configuration/agent.md
+++ b/website/prometheus-proxy/docs/configuration/agent.md
@@ -56,6 +56,19 @@ Or specify on the command line:
 java -jar prometheus-agent.jar --proxy proxy-host.example.com:50051 --config agent.conf
 ```
 
+## Agent Authentication
+
+If the proxy requires a [pre-shared agent token](../security/index.md#agent-authentication-pre-shared-token),
+set the matching value on the agent. It is presented as a gRPC metadata header on every call and is
+never logged. Resolved from `--agent_token` → `AGENT_TOKEN` → `agent.agentToken`; empty (the default)
+sends no token.
+
+```hocon
+agent {
+  agentToken = "shared-secret"   // Must match the proxy's proxy.agentToken
+}
+```
+
 ## HTTP Client Settings
 
 Configure how the agent makes HTTP requests to scrape endpoints:

--- a/website/prometheus-proxy/docs/configuration/proxy.md
+++ b/website/prometheus-proxy/docs/configuration/proxy.md
@@ -23,6 +23,20 @@ Configure the gRPC service that agents connect to:
 --8<-- "ConfigExamples.txt:proxy-grpc-config"
 ```
 
+## Agent Authentication
+
+The agent gRPC port is unauthenticated by default. Set a
+[pre-shared token](../security/index.md#agent-authentication-pre-shared-token) so the proxy rejects
+agents that do not present a matching value (`UNAUTHENTICATED`). Resolved from `--agent_token` →
+`AGENT_TOKEN` → `proxy.agentToken`; empty (the default) disables the check and logs a startup warning
+unless mutual TLS is configured. The token is never logged.
+
+```hocon
+proxy {
+  agentToken = "shared-secret"   // Agents must present the same value
+}
+```
+
 ## Service Discovery
 
 Enable Prometheus HTTP service discovery:

--- a/website/prometheus-proxy/docs/security/index.md
+++ b/website/prometheus-proxy/docs/security/index.md
@@ -10,8 +10,16 @@ Prometheus Proxy is designed to be firewall-friendly:
 
 - The **agent** initiates an *outbound* gRPC connection to the proxy
 - **No inbound ports** need to be opened on the firewall
-- The proxy accepts connections only from registered agents
+- Agent connections can be authenticated with an optional
+  [pre-shared token](#agent-authentication-pre-shared-token) and/or [mutual TLS](tls.md)
 - Stale agent connections are automatically cleaned up
+
+!!! warning "The agent gRPC port is unauthenticated by default"
+
+    With neither a pre-shared agent token nor mutual TLS configured, any process that can reach the
+    agent port (default `50051`) can register as an agent. Set a token (below), require mutual TLS,
+    and/or restrict the port to trusted networks. The proxy logs a startup warning when the agent
+    port is left unauthenticated.
 
 ## TLS Encryption
 
@@ -25,6 +33,37 @@ mutual authentication.
 | **Mutual TLS**        | Server cert + key + CA cert | Client cert + key + CA cert |
 
 See [TLS Setup](tls.md) for detailed configuration instructions.
+
+## Agent Authentication (Pre-Shared Token)
+
+By default the proxy accepts agent gRPC connections with **no application-level authentication**. Set
+a shared **pre-shared token** so the proxy rejects agents that do not present it:
+
+| Side  | CLI             | Env Var       | Config             |
+|:------|:----------------|:--------------|:-------------------|
+| Proxy | `--agent_token` | `AGENT_TOKEN` | `proxy.agentToken` |
+| Agent | `--agent_token` | `AGENT_TOKEN` | `agent.agentToken` |
+
+Both sides must use the **same** value. When set, the agent attaches the token as a gRPC metadata
+header on every call and the proxy rejects any call with a missing or mismatched token
+(`UNAUTHENTICATED`). When the token is empty (the default), the open behavior is preserved and the
+proxy logs a startup warning — unless mutual TLS is configured, which already authenticates agents.
+The token is never logged.
+
+```bash
+# Proxy requiring a token
+java -jar prometheus-proxy.jar --agent_token "$AGENT_TOKEN"
+
+# Agent presenting the token
+java -jar prometheus-agent.jar --config myconfig.conf --agent_token "$AGENT_TOKEN"
+```
+
+!!! note "Token vs. mutual TLS"
+
+    A pre-shared token is a lightweight, app-level control that authenticates *that* a peer may
+    connect. [Mutual TLS](tls.md) additionally encrypts the channel and verifies a certificate
+    identity. They can be combined; for production, prefer mutual TLS and/or restrict the agent port
+    to trusted networks.
 
 ## Auth Header Forwarding
 


### PR DESCRIPTION
## Summary

PR #173 added optional **pre-shared agent-token authentication** (`--agent_token` / `AGENT_TOKEN` / `proxy.agentToken` / `agent.agentToken`) — the mitigation for the High-severity unauthenticated-agent-registration finding — but updated only `README.md` and the top-level `docs/security-agent-authentication.md`, not the Zensical website docs. This fills that gap (the other notable post-3.1.1 change, the HTTPS trust store, was already documented).

## Changes

- **`security/index.md`** — new **"Agent Authentication (Pre-Shared Token)"** section (CLI/env/config table, matching-value requirement, `UNAUTHENTICATED` rejection, startup warning, token-vs-mTLS note). Also added a warning that the agent gRPC port is unauthenticated by default and corrected the misleading "accepts connections only from registered agents" bullet.
- **`cli-reference.md`** — `--agent_token` rows in both the Proxy and Agent option tables.
- **`configuration/agent.md`** / **`configuration/proxy.md`** — "Agent Authentication" subsections for `agent.agentToken` / `proxy.agentToken`.

## Verification

`zensical build --clean` → **No issues found** (cross-references, tables, and admonitions valid). Generated `site/` output is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)