### PR TITLE
Add parameter-driven scaling container tests

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -1,9 +1,12 @@
 name: Container Tests
 
-# Runs the Testcontainers smoke test that builds the proxy/agent images from
-# etc/docker/*.df and verifies the full Prometheus -> proxy -> agent -> endpoint
-# scrape path. Slow (~1-2 min) so this is gated behind targeted triggers
-# rather than running on every PR. No untrusted event payloads are referenced.
+# Runs the full Testcontainers end-to-end suite (io.prometheus.containers.*): builds the
+# proxy/agent images from etc/docker/*.df and exercises the Prometheus -> proxy -> agent ->
+# endpoint scrape path across smoke, HTTP-surface, consolidated, large-payload, reconnect,
+# agent-token-auth, TLS/HTTPS, and parameter-driven scaling specs. The scaling spec runs its
+# small default table here (no SCALE_* overrides). Slow (several minutes) so this is gated
+# behind targeted triggers rather than running on every PR. No untrusted event payloads are
+# referenced.
 on:
   push:
     branches: [ master ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default help stop clean clean-all stubs build tibuild refresh jars \
-        tests mini-tests nh-tests ip-tests netty-tests tls-tests container-tests all-tests regen-certs \
+        tests mini-tests nh-tests ip-tests netty-tests tls-tests container-tests scaling-tests all-tests regen-certs \
         coverage coverage-html coverage-xml coverage-log coverage-verify \
         coverage-open coverage-packages coverage-clean reports gh-docs \
         gh-status tsconfig distro docker-push release tree depends lint detekt detekt-baseline \
@@ -86,6 +86,16 @@ container-tests: jars  ## Run the Testcontainers tests (needs Docker)
 	fi; \
 	echo "Using DOCKER_HOST=$$DOCKER_HOST"; \
 	DOCKER_HOST="$$DOCKER_HOST" RUN_CONTAINER_TESTS=true ./gradlew test --tests "io.prometheus.containers.*"
+
+scaling-tests: jars  ## Run the parameter-driven scaling container test (tune via SCALE_* vars; needs Docker)
+	@DOCKER_HOST="$$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)"; \
+	if [ -z "$$DOCKER_HOST" ]; then \
+		echo "Error: could not detect active Docker context. Is Docker running?" >&2; exit 1; \
+	fi; \
+	echo "Using DOCKER_HOST=$$DOCKER_HOST"; \
+	DOCKER_HOST="$$DOCKER_HOST" RUN_CONTAINER_TESTS=true \
+		$(foreach v,SCALE_AGENTS SCALE_ENDPOINTS_PER_AGENT SCALE_SERIES_PER_ENDPOINT SCALE_CONSOLIDATED_AGENTS SCALE_CONCURRENT SCALE_CONCURRENCY_LIMIT TEST_MAX_HEAP_SIZE,$(if $($(v)),$(v)="$($(v))" )) \
+		./gradlew test --tests "io.prometheus.containers.ContainersScalingTest"
 
 all-tests: tests container-tests  ## Run the full suite: all tests + the container tests
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,13 +163,19 @@ fun Project.configureTesting() {
 
     // Scale the test JVM heap to the harness load. LARGE+ generates multi-MB scrape payloads
     // and runs them through 2000+ sequential calls; the default 512m heap OOMs in bodyAsText().
+    // An explicit -PtestMaxHeapSize=… (or TEST_MAX_HEAP_SIZE env var) overrides the load-based default —
+    // useful for large `make scaling-tests` runs, which can hold thousands of scrape bodies at once.
+    val testMaxHeapOverride =
+      providers.gradleProperty("testMaxHeapSize").orNull
+        ?: System.getenv("TEST_MAX_HEAP_SIZE")
     maxHeapSize =
-      when (harnessConfig?.uppercase()) {
-        "XXLARGE" -> "8g"
-        "XLARGE" -> "4g"
-        "LARGE" -> "2g"
-        else -> "1g"
-      }
+      testMaxHeapOverride
+        ?: when (harnessConfig?.uppercase()) {
+          "XXLARGE" -> "8g"
+          "XLARGE" -> "4g"
+          "LARGE" -> "2g"
+          else -> "1g"
+        }
 
     testLogging {
       showStandardStreams = false

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,18 +27,37 @@ This document describes the test suite structure and how to run tests for the pr
 ### Make Targets
 
 ```bash
-make tests            # Rerun all checks (lint + tests); the container smoke test is SKIPPED
+make tests            # Rerun all checks (lint + tests); the container tests are SKIPPED
 make nh-tests         # Unit tests only (agent, proxy, common, misc — no harness)
 make ip-tests         # In-process integration tests only
 make netty-tests      # Netty integration tests only
 make tls-tests        # TLS integration tests only
-make container-tests  # Testcontainers smoke test only (needs Docker)
-make all-tests        # Full suite: `make tests` + `make container-tests`
+make container-tests  # Full Testcontainers end-to-end suite (needs Docker)
+make scaling-tests    # Parameter-driven scaling container test only (needs Docker)
+make all-tests        # Full suite: `make tests` + `make container-tests` + `make scaling-tests`
 ```
 
-The container smoke test (`io.prometheus.containers.*`) is gated on `RUN_CONTAINER_TESTS=true` and
-needs Docker, so a plain `make tests` / `./gradlew check` registers it as a SKIPPED placeholder. Use
-`make container-tests` to run it on its own, or `make all-tests` to run everything in one shot.
+The container tests (`io.prometheus.containers.*`) are gated on `RUN_CONTAINER_TESTS=true` and
+need Docker, so a plain `make tests` / `./gradlew check` registers each spec as a SKIPPED placeholder. Use
+`make container-tests` to run the whole suite on its own, `make scaling-tests` for just the scaling spec, or
+`make all-tests` to run everything in one shot.
+
+The `make scaling-tests` target forwards any `SCALE_*` environment variables to the test, so the scaling
+inputs can be tuned without recompiling — for example:
+
+```bash
+make scaling-tests SCALE_AGENTS=10 SCALE_ENDPOINTS_PER_AGENT=20 SCALE_CONSOLIDATED_AGENTS=3 \
+                   SCALE_SERIES_PER_ENDPOINT=2000 SCALE_CONCURRENT=true
+```
+
+Large runs hold many scrape bodies in memory at once. The forked test JVM defaults to a 1g heap; raise it with
+`TEST_MAX_HEAP_SIZE` (or `-PtestMaxHeapSize`), and cap the number of in-flight verification coroutines with
+`SCALE_CONCURRENCY_LIMIT` so memory stays bounded even at high path counts:
+
+```bash
+make scaling-tests SCALE_AGENTS=100 SCALE_ENDPOINTS_PER_AGENT=200 SCALE_SERIES_PER_ENDPOINT=5000 \
+                   SCALE_CONCURRENT=true SCALE_CONCURRENCY_LIMIT=64 TEST_MAX_HEAP_SIZE=8g
+```
 
 ## Frameworks and Libraries
 
@@ -230,6 +249,44 @@ Each integration test class runs a standard suite defined in `AbstractHarnessTes
   `timeoutTest()`
 - **HarnessConfig** — Enum defining test scale configs (MINI, SMALL, MEDIUM, LARGE, XLARGE, XXLARGE)
 - **HarnessConstants** — Test constants (ports, delays, config paths)
+
+### Container Tests (`containers/`)
+
+End-to-end Testcontainers specs that build the proxy and agent images from `etc/docker/*.df`, stand them up
+alongside `nginx:alpine` metrics stubs (and `prom/prometheus` where needed), and exercise the full
+Prometheus → proxy → agent → endpoint scrape path over real network transport. Every spec is gated on
+`RUN_CONTAINER_TESTS=true`; shared factories live in `containers/support/ContainerTestSupport.kt`.
+
+- **ContainersSmokeTest** — baseline: Prometheus scrapes a single metric through the proxy and agent
+- **ContainersProxyHttpTest** — HTTP surfaces: registered-path scrapes, 404/503 passthrough, admin servlets,
+  self-metrics, service discovery
+- **ContainersConsolidatedTest** — two consolidated agents register the same path; the proxy merges responses
+- **ContainersLargePayloadTest** — forces the chunked + gzipped scrape path with a large synthetic payload
+- **ContainersReconnectTest** — agent reconnects to a replacement proxy and scrapes resume
+- **ContainersAgentTokenAuthTest** — pre-shared agent-token authentication on the gRPC channel
+- **ContainersTlsTest** / **ContainersHttpsTargetTest** — server-only and mutual TLS on gRPC; HTTPS upstreams
+- **ContainersScalingTest** — parameter-driven scaling (see below)
+
+#### Scaling Test (`ContainersScalingTest`)
+
+A single parameter-driven spec that stands up a fresh topology per scenario and verifies every path is
+scrapable end-to-end, then asserts the proxy's own `proxy_agent_map_size` / `proxy_path_map_size` gauges match
+the expected counts. Each scenario (a `ScalingScenario`) scales four dimensions:
+
+| Dimension | `SCALE_*` env var | Default |
+|-----------|-------------------|---------|
+| Number of agents | `SCALE_AGENTS` | table |
+| Endpoints (paths) per agent | `SCALE_ENDPOINTS_PER_AGENT` | table |
+| Series per endpoint (payload size) | `SCALE_SERIES_PER_ENDPOINT` | table |
+| Consolidated fan-out agents (share one path) | `SCALE_CONSOLIDATED_AGENTS` | table |
+| Concurrent vs sequential scrape verification | `SCALE_CONCURRENT` | table |
+| Max in-flight checks when concurrent (0 = unbounded) | `SCALE_CONCURRENCY_LIMIT` | `0` |
+
+All agent configs and per-endpoint exposition payloads are generated at runtime (no fixture files). With no
+overrides, a small CI-safe default table runs (a baseline row, an agents × endpoints row, a large-payload row,
+and a consolidated-fan-out row). Setting **any** `SCALE_*` variable collapses the run to a single tuned
+scenario built from those values (with modest fallbacks), letting the inputs be dialed up via
+`make scaling-tests SCALE_...=...` without editing code.
 
 ## Testing Patterns
 

--- a/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
+++ b/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.prometheus.containers
+
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.string.shouldContain
+import io.prometheus.containers.support.ContainerTestSupport.NGINX_PORT
+import io.prometheus.containers.support.ContainerTestSupport.PROXY_HTTP_PORT
+import io.prometheus.containers.support.ContainerTestSupport.PROXY_METRICS_PORT
+import io.prometheus.containers.support.ContainerTestSupport.agentContainer
+import io.prometheus.containers.support.ContainerTestSupport.containerTestsEnabled
+import io.prometheus.containers.support.ContainerTestSupport.httpClient
+import io.prometheus.containers.support.ContainerTestSupport.logConsumer
+import io.prometheus.containers.support.ContainerTestSupport.proxyContainer
+import io.prometheus.containers.support.ContainerTestSupport.transferable
+import io.prometheus.containers.support.baseUrl
+import io.prometheus.containers.support.bodyOf
+import io.prometheus.containers.support.closeQuietly
+import io.prometheus.containers.support.stopQuietly
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A single parameter-driven spec that scales the system along its real load axes and verifies every path is
+ * scrapable end-to-end through the proxy. Each [ScalingScenario] stands up its own topology:
+ *
+ *  - **agents × endpoints/agent** — N agents, each registering M unique paths.
+ *  - **payload size per endpoint** — `seriesPerEndpoint` filler series, exercising the chunking/gzip path.
+ *  - **consolidated fan-out** — K agents sharing one `consolidated` path; one scrape merges across all K.
+ *  - **scrape concurrency** — the per-path checks run concurrently or sequentially.
+ *
+ * After the per-path checks it asserts the proxy's own `proxy_agent_map_size` / `proxy_path_map_size` gauges
+ * reflect the expected counts. A small default table runs in CI; setting any `SCALE_*` env var collapses the
+ * run to a single tuned scenario so the inputs can be dialed up without recompiling.
+ */
+class ContainersScalingTest : StringSpec() {
+  init {
+    if (!containerTestsEnabled()) {
+      "Scaling: N agents x M endpoints (set RUN_CONTAINER_TESTS=true to enable)".config(enabled = false) { }
+    } else {
+      withData(nameFn = { it.toString() }, scalingScenarios) { s ->
+        val network = Network.newNetwork()
+        val client = httpClient()
+        val stubs = mutableListOf<GenericContainer<*>>()
+        val agents = mutableListOf<GenericContainer<*>>()
+        val proxy =
+          proxyContainer(
+            network,
+            env = mapOf("METRICS_ENABLED" to "true"),
+            exposedPorts = listOf(PROXY_HTTP_PORT, PROXY_METRICS_PORT),
+          )
+        try {
+          // --- unique-path agents (dimensions: agents × endpoints, payload size) ---
+          for (a in 0 until s.agentCount) {
+            val stubAlias = "scale-stub-a$a"
+            val entries = (0 until s.endpointsPerAgent).map { e -> "scale_a${a}_e$e" to "ep_$e" }
+            stubs +=
+              nginxStub(network, stubAlias, waitPath = "/ep_${s.endpointsPerAgent - 1}") {
+                entries.forEachIndexed { e, (_, file) ->
+                  withCopyToContainer(
+                    transferable(endpointText(a, e, s.seriesPerEndpoint)),
+                    "/usr/share/nginx/html/$file",
+                  )
+                }
+              }
+            agents +=
+              agentContainer(
+                network,
+                alias = "scale-agent-a$a",
+                configText = agentConfig("scale-agent-a$a", stubAlias, entries),
+                waitTimes = s.endpointsPerAgent,
+              )
+          }
+
+          // --- consolidated fan-out agents (K agents share one path) ---
+          for (k in 0 until s.consolidatedAgents) {
+            val stubAlias = "scale-cons-stub-$k"
+            stubs +=
+              nginxStub(network, stubAlias, waitPath = "/c") {
+                withCopyToContainer(transferable(consolidatedText(k)), "/usr/share/nginx/html/c")
+              }
+            agents +=
+              agentContainer(
+                network,
+                alias = "scale-cons-agent-$k",
+                configText =
+                  agentConfig("scale-cons-agent-$k", stubAlias, listOf(CONSOLIDATED_PATH to "c"), consolidated = true),
+                waitLogRegex = ".*Registered .* as /$CONSOLIDATED_PATH.*",
+              )
+          }
+
+          stubs.forEach { it.start() }
+          proxy.start()
+          agents.forEach { it.start() }
+
+          // --- per-path correctness (run concurrently or sequentially per the scenario) ---
+          val checks = buildList<suspend () -> Unit> {
+            for (a in 0 until s.agentCount) {
+              for (e in 0 until s.endpointsPerAgent) {
+                add {
+                  eventually(60.seconds) {
+                    client.bodyOf(proxy.baseUrl(PROXY_HTTP_PORT) + "/scale_a${a}_e$e")
+                      .shouldContain("$SCALE_SENTINEL{agent=\"$a\",endpoint=\"$e\"} ${a * 1000 + e}")
+                  }
+                }
+              }
+            }
+            if (s.consolidatedAgents > 0)
+              add {
+                eventually(60.seconds) {
+                  val body = client.bodyOf(proxy.baseUrl(PROXY_HTTP_PORT) + "/$CONSOLIDATED_PATH")
+                  for (k in 0 until s.consolidatedAgents) {
+                    body shouldContain "scale_consolidated_metric{agent=\"$k\"} $k"
+                  }
+                }
+              }
+          }
+          if (s.concurrentScrapes) {
+            // A positive concurrencyLimit caps in-flight checks so a huge path count doesn't hold every
+            // scrape body in memory at once; 0 means unbounded (launch them all).
+            val gate = if (s.concurrencyLimit > 0) Semaphore(s.concurrencyLimit) else null
+            coroutineScope {
+              checks.forEach { check ->
+                launch { if (gate != null) gate.withPermit { check() } else check() }
+              }
+            }
+          } else {
+            for (check in checks) check()
+          }
+
+          // --- observability: the proxy's own gauges must reflect the expected counts ---
+          eventually(30.seconds) {
+            val metrics = client.bodyOf(proxy.baseUrl(PROXY_METRICS_PORT) + "/metrics")
+            metrics shouldContain "proxy_agent_map_size ${s.totalAgents}.0"
+            metrics shouldContain "proxy_path_map_size ${s.totalDistinctPaths}.0"
+          }
+        } finally {
+          client.close()
+          stopQuietly(*agents.toTypedArray(), proxy, *stubs.toTypedArray())
+          closeQuietly(network)
+        }
+      }
+    }
+  }
+}
+
+/** One scaling configuration; drives a single `withData` row and a single end-to-end topology. */
+data class ScalingScenario(
+  val agentCount: Int,
+  val endpointsPerAgent: Int,
+  val seriesPerEndpoint: Int,
+  val consolidatedAgents: Int,
+  val concurrentScrapes: Boolean,
+  val concurrencyLimit: Int = 0,
+) {
+  val totalAgents get() = agentCount + consolidatedAgents
+  val totalDistinctPaths get() = (agentCount * endpointsPerAgent) + (if (consolidatedAgents > 0) 1 else 0)
+
+  override fun toString() =
+    "$agentCount agents x $endpointsPerAgent endpoints, $seriesPerEndpoint series, " +
+      "$consolidatedAgents consolidated, ${if (concurrentScrapes) "concurrent" else "sequential"}" +
+      (if (concurrentScrapes && concurrencyLimit > 0) " (limit $concurrencyLimit)" else "")
+}
+
+private const val SCALE_SENTINEL = "scale_sentinel"
+private const val CONSOLIDATED_PATH = "scale_consolidated"
+
+private fun intEnv(
+  name: String,
+  default: Int,
+) = System.getenv(name)?.toIntOrNull() ?: default
+
+private fun boolEnv(
+  name: String,
+  default: Boolean,
+) = System.getenv(name)?.toBooleanStrictOrNull() ?: default
+
+/**
+ * A single tuned scenario when any `SCALE_*` override is present; otherwise a small CI-safe default table that
+ * touches each dimension (baseline, agents × endpoints, payload size, consolidated fan-out).
+ */
+private val scaleEnvVars =
+  listOf(
+    "SCALE_AGENTS",
+    "SCALE_ENDPOINTS_PER_AGENT",
+    "SCALE_SERIES_PER_ENDPOINT",
+    "SCALE_CONSOLIDATED_AGENTS",
+    "SCALE_CONCURRENT",
+    "SCALE_CONCURRENCY_LIMIT",
+  )
+
+private val scalingScenarios: List<ScalingScenario> =
+  if (scaleEnvVars.any { System.getenv(it) != null })
+    listOf(
+      ScalingScenario(
+        agentCount = intEnv("SCALE_AGENTS", 2),
+        endpointsPerAgent = intEnv("SCALE_ENDPOINTS_PER_AGENT", 2),
+        seriesPerEndpoint = intEnv("SCALE_SERIES_PER_ENDPOINT", 1),
+        consolidatedAgents = intEnv("SCALE_CONSOLIDATED_AGENTS", 0),
+        concurrentScrapes = boolEnv("SCALE_CONCURRENT", true),
+        concurrencyLimit = intEnv("SCALE_CONCURRENCY_LIMIT", 0),
+      ),
+    )
+  else
+    listOf(
+      ScalingScenario(1, 1, 1, 0, false),
+      ScalingScenario(2, 3, 1, 0, true),
+      ScalingScenario(2, 2, 2000, 0, false),
+      ScalingScenario(2, 1, 1, 3, true),
+    )
+
+/** `seriesPerEndpoint` filler series plus a sentinel line whose value is unique per (agent, endpoint). */
+private fun endpointText(
+  agent: Int,
+  endpoint: Int,
+  series: Int,
+): String =
+  buildString {
+    appendLine("# TYPE $SCALE_SENTINEL gauge")
+    repeat(series) { appendLine("scale_filler{a=\"$agent\",e=\"$endpoint\",s=\"$it\"} $it") }
+    appendLine("$SCALE_SENTINEL{agent=\"$agent\",endpoint=\"$endpoint\"} ${agent * 1000 + endpoint}")
+  }
+
+/** A single metric whose label/value identify which consolidated agent produced it, to prove the merge. */
+private fun consolidatedText(idx: Int): String =
+  "# TYPE scale_consolidated_metric gauge\nscale_consolidated_metric{agent=\"$idx\"} $idx\n"
+
+/** Build a HOCON agent config with one pathConfig per (proxyPath → nginxFile) entry. */
+private fun agentConfig(
+  name: String,
+  stubAlias: String,
+  entries: List<Pair<String, String>>,
+  consolidated: Boolean = false,
+): String =
+  buildString {
+    appendLine("agent {")
+    appendLine("  name = \"$name\"")
+    if (consolidated) appendLine("  consolidated = true")
+    appendLine("  proxy {")
+    appendLine("    hostname = \"proxy-host\"")
+    appendLine("    port = 50051")
+    appendLine("  }")
+    appendLine("  pathConfigs: [")
+    entries.forEach { (path, file) ->
+      appendLine("    {")
+      appendLine("      name: \"$path\"")
+      appendLine("      path: $path")
+      appendLine("      url: \"http://$stubAlias/$file\"")
+      appendLine("    }")
+    }
+    appendLine("  ]")
+    appendLine("  scrapeTimeoutSecs = 15")
+    appendLine("  internal {")
+    appendLine("    reconnectPauseSecs = 1")
+    appendLine("  }")
+    appendLine("}")
+  }
+
+/** An `nginx:alpine` stub whose document root is populated by [configure]; ready once [waitPath] serves 200. */
+private fun nginxStub(
+  network: Network,
+  alias: String,
+  waitPath: String,
+  configure: GenericContainer<Nothing>.() -> Unit,
+): GenericContainer<*> =
+  GenericContainer<Nothing>("nginx:alpine").apply {
+    withNetwork(network)
+    withNetworkAliases(alias)
+    withExposedPorts(NGINX_PORT)
+    withLogConsumer(logConsumer(alias))
+    configure()
+    waitingFor(Wait.forHttp(waitPath).forPort(NGINX_PORT))
+  }

--- a/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
+++ b/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
@@ -128,24 +128,34 @@ object ContainerTestSupport {
     image: ImageFromDockerfile = agentImage(),
     alias: String = AGENT_ALIAS,
     configResource: String = "containers/agent.conf",
+    configText: String? = null,
     env: Map<String, String> = emptyMap(),
     exposedPorts: List<Int> = emptyList(),
     classpathFiles: Map<String, String> = emptyMap(),
     hostFiles: Map<String, String> = emptyMap(),
     waitLogRegex: String = ".*Registered .* as /.*",
+    waitTimes: Int = 1,
     wait: WaitStrategy? = null,
   ): GenericContainer<*> =
     GenericContainer<Nothing>(image).apply {
       withNetwork(network)
       withNetworkAliases(alias)
       withEnv("AGENT_CONFIG", "/config/agent.conf")
-      withClasspathResourceMapping(configResource, "/config/agent.conf", BindMode.READ_ONLY)
+      // A runtime-generated config (configText) is injected directly; otherwise mount the classpath resource.
+      // The trailing Unit keeps the SELF-returning builder call out of value position (avoids a Nothing cast).
+      if (configText != null) {
+        withCopyToContainer(transferable(configText), "/config/agent.conf")
+        Unit
+      } else {
+        withClasspathResourceMapping(configResource, "/config/agent.conf", BindMode.READ_ONLY)
+        Unit
+      }
       classpathFiles.forEach { (resource, dest) -> withClasspathResourceMapping(resource, dest, BindMode.READ_ONLY) }
       hostFiles.forEach { (hostPath, dest) -> withCopyFileToContainer(MountableFile.forHostPath(hostPath), dest) }
       env.forEach { (key, value) -> withEnv(key, value) }
       if (exposedPorts.isNotEmpty()) withExposedPorts(*exposedPorts.toIntArray().toTypedArray())
       withLogConsumer(logConsumer(alias))
-      waitingFor(wait ?: Wait.forLogMessage(waitLogRegex, 1))
+      waitingFor(wait ?: Wait.forLogMessage(waitLogRegex, waitTimes))
     }
 
   fun prometheusContainer(
@@ -171,15 +181,16 @@ object ContainerTestSupport {
    * @return the exposition text and the number of metric (non-comment) lines it contains.
    */
   fun largeMetricsText(seriesCount: Int = LARGE_PAYLOAD_SERIES): Pair<String, Int> {
-    val sb =
-      StringBuilder()
-        .append("# HELP synthetic_metric Synthetic gauge used to exercise chunked, gzipped scrape responses.\n")
-        .append("# TYPE synthetic_metric gauge\n")
-    repeat(seriesCount) { i -> sb.append("synthetic_metric{series=\"").append(i).append("\"} ").append(i).append('\n') }
-    sb.append("# HELP ").append(SENTINEL_METRIC).append(" Final series; proves the whole payload survived chunking.\n")
-    sb.append("# TYPE ").append(SENTINEL_METRIC).append(" gauge\n")
-    sb.append(SENTINEL_METRIC).append(' ').append(SENTINEL_VALUE).append('\n')
-    return sb.toString() to (seriesCount + 1)
+    val text =
+      buildString {
+        appendLine("# HELP synthetic_metric Synthetic gauge used to exercise chunked, gzipped scrape responses.")
+        appendLine("# TYPE synthetic_metric gauge")
+        repeat(seriesCount) { i -> appendLine("synthetic_metric{series=\"$i\"} $i") }
+        appendLine("# HELP $SENTINEL_METRIC Final series; proves the whole payload survived chunking.")
+        appendLine("# TYPE $SENTINEL_METRIC gauge")
+        appendLine("$SENTINEL_METRIC $SENTINEL_VALUE")
+      }
+    return text to (seriesCount + 1)
   }
 
   fun transferable(text: String): Transferable = Transferable.of(text)


### PR DESCRIPTION
## Summary

Adds `ContainersScalingTest`, a single parameter-driven Testcontainers spec that scales the system along its real load axes and verifies every path is scrapable end-to-end through the proxy, then asserts the proxy's own `proxy_agent_map_size` / `proxy_path_map_size` gauges match the expected counts.

Each scenario stands up its own topology and scales four dimensions:

- **agents × endpoints/agent** — N agents, each registering M unique paths
- **payload size per endpoint** — series count (exercises chunking/gzip)
- **consolidated fan-out** — K agents sharing one path, responses merged
- **scrape concurrency** — concurrent vs sequential verification, with an optional `SCALE_CONCURRENCY_LIMIT` semaphore to bound in-flight checks at high path counts

A small CI-safe default table runs as part of `make container-tests` (and the `container-tests.yml` workflow). Setting any `SCALE_*` env var collapses the run to a single tuned scenario, so inputs can be dialed up without recompiling. Agent configs and per-endpoint exposition payloads are generated at runtime — no fixture files.

## Parameters

| Dimension | Env var |
|-----------|---------|
| Number of agents | `SCALE_AGENTS` |
| Endpoints per agent | `SCALE_ENDPOINTS_PER_AGENT` |
| Series per endpoint | `SCALE_SERIES_PER_ENDPOINT` |
| Consolidated fan-out agents | `SCALE_CONSOLIDATED_AGENTS` |
| Concurrent vs sequential | `SCALE_CONCURRENT` |
| Max in-flight checks (0 = unbounded) | `SCALE_CONCURRENCY_LIMIT` |

Example tuned run:

\`\`\`bash
make scaling-tests SCALE_AGENTS=100 SCALE_ENDPOINTS_PER_AGENT=200 SCALE_CONSOLIDATED_AGENTS=3 \
                   SCALE_SERIES_PER_ENDPOINT=5000 SCALE_CONCURRENT=true \
                   SCALE_CONCURRENCY_LIMIT=64 TEST_MAX_HEAP_SIZE=8g
\`\`\`

## Supporting changes

- **`agentContainer()`** — adds `configText` (runtime-generated HOCON injected via `withCopyToContainer`) and `waitTimes` (wait for N registrations); both backward-compatible, all existing callers unchanged.
- **`largeMetricsText()`** — switched to the `buildString {}` idiom.
- **`build.gradle.kts`** — honors `-PtestMaxHeapSize` / `TEST_MAX_HEAP_SIZE` to size the forked test JVM heap for large runs.
- **`Makefile`** — adds `make scaling-tests` (forwards `SCALE_*` and `TEST_MAX_HEAP_SIZE`).
- **`docs/TESTING.md`** — documents the container suite and the scaling knobs.
- **`container-tests.yml`** — comment updated to reflect the full suite.

## Testing

- Full container suite passes 31/31 (27 existing specs + 4 new scaling scenarios).
- All-dimensions tuned run and bounded-concurrency run verified locally.
- `detekt` / `lintKotlin` / `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)