### PR TITLE
Finalize 3.2.0 release docs with all post-3.1.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project are documented in this file.
 
 ---
 
-## [3.2.0] - Unreleased
+## [3.2.0] - 2026-06-13
 
 ### New Features
 
 - Add an optional pre-shared agent token for authenticating agent gRPC connections: `--agent_token` / `AGENT_TOKEN` (config `proxy.agentToken` on the proxy, `agent.agentToken` on the agent). The agent sends the token as an `agent-token` gRPC metadata header; the proxy's `AgentTokenServerInterceptor` rejects any RPC with a missing or mismatched token (`Status.UNAUTHENTICATED`, constant-time comparison). Empty (the default) preserves today's open behavior and logs a startup warning unless mutual TLS is configured. Resolved CLI > env > config; the value is never logged
 - Add a per-CA HTTPS trust store for the agent's scrape client: `--https_truststore` / `--https_truststore_password` (env `HTTPS_TRUST_STORE_PATH` / `HTTPS_TRUST_STORE_PASSWORD`; config `agent.http.trustStorePath` / `agent.http.trustStorePassword`) verify HTTPS targets against a custom/private CA without disabling validation. Resolved CLI > env > config; password never logged; `--trust_all_x509` takes precedence; an empty path uses the JDK default trust store
 - Add `ContainersSmokeTest` (`io.prometheus.containers`) — Testcontainers-based end-to-end smoke test that builds the proxy/agent Docker images and verifies a Prometheus → proxy → agent → endpoint scrape, gated on `RUN_CONTAINER_TESTS=true`
+- Expand the container-test suite (`io.prometheus.containers`) beyond the smoke test with seven specs over real Netty/Docker — `ContainersProxyHttpTest` (404s, upstream-status passthrough, admin endpoints, proxy/agent `/metrics`, service discovery), `ContainersAgentTokenAuthTest` (token match + mismatch), `ContainersConsolidatedTest` (two-agent merge), `ContainersLargePayloadTest` (chunk + gzip reassembly), `ContainersReconnectTest` (agent reconnect after proxy replacement), `ContainersTlsTest` (server-only + mutual gRPC TLS), and `ContainersHttpsTargetTest` (trust-all positive/negative) — all gated on `RUN_CONTAINER_TESTS=true` and backed by a shared `support/ContainerTestSupport.kt`
+- Add `ContainersScalingTest` — a parameter-driven Testcontainers spec that scales the system along its real load axes (agents × endpoints per agent, series per endpoint, consolidated fan-out, and scrape concurrency), verifies every path is scrapable, and asserts the proxy's `proxy_agent_map_size` / `proxy_path_map_size` gauges match the expected counts; tunable via `SCALE_*` env vars without recompiling
 - Add `make container-tests` target with Docker context auto-detection so Testcontainers finds Docker Desktop's non-default socket on macOS
 - Add `.github/workflows/container-tests.yml` to run the smoke test on push to master, on `workflow_dispatch`, and on PRs touching packaging files
 - Add `make help` target listing every Make target with an auto-extracted description
@@ -68,24 +70,42 @@ All notable changes to this project are documented in this file.
 - Replace `distro: build $(MAKE) jars` with `distro: build jars` (drop the recursive sub-make)
 - Externalize the inline coverage-packages python to `scripts/coverage_packages.py`
 - Annotate every Make target with `## descriptions` and add `make help`
+- Add a `make all-tests` target that runs the full suite (`tests` + `container-tests`)
+- Add `make scaling-tests` (forwards `SCALE_*` and `TEST_MAX_HEAP_SIZE`) plus six curated scaling presets — `scaling-paths`, `scaling-agents`, `scaling-payload`, `scaling-consolidated`, `scaling-concurrency`, `scaling-soak` — and an `all-scaling` aggregate; these are dev/stress aids, not run by `all-tests` or CI
+- Honor `-PtestMaxHeapSize` / `TEST_MAX_HEAP_SIZE` to override the load-based forked-test JVM heap size for large scaling runs
+- Add `make regen-certs` to rebuild the `testing/certs` TLS fixtures (CA + server + client) at 2048-bit with 100-year validity, preserving the `*.test.google.fr` SAN the harness relies on; the committed fixtures were regenerated and the container TLS/HTTPS specs mount them (no runtime openssl)
+- Centralize scattered test port literals into a new `io.prometheus.common.TestPorts` object in the test source set, so unit/harness/container specs reference named constants and unit tests no longer pull in the Testcontainers support harness just for a port value
 - Document the double `./gradlew wrapper` invocation in `upgrade-wrapper`
 - Add missing `.PHONY` entries for `mini-tests` and the `coverage-*` family
 - Move `ContainersSmokeTest` from `io.prometheus.harness` to a dedicated `io.prometheus.containers` package
 - Switch the proxy/agent Docker images to the prebuilt `bellsoft/liberica-openjre-alpine:17` base (no build-time `apk add openjdk17-jre`, so builds are faster and not subject to Alpine-mirror stalls; genuine amd64 + arm64 multi-arch so the images run on Apple Silicon, unlike the amd64-only `eclipse-temurin:17-jre-alpine`)
+- Pin the `bellsoft/liberica-openjre-alpine:17` base image by digest in `etc/docker/{agent,proxy}.df` for reproducible builds (the tag is kept inline for readability), and drop the no-op `-XX:+UnlockExperimentalVMOptions` / `-XX:+UseG1GC` ENTRYPOINT flags (G1 is the JDK 17 default GC and the remaining flags are non-experimental)
+- Pin the documentation toolchain (`zensical==0.0.45`, `mkdocs-material==9.7.6`) in `.github/workflows/docs.yml` for reproducible doc builds
+- Harden the nginx reverse-proxy example image (`nginx/docker/Dockerfile`): switch the base from `nginx` (Debian) to `nginx:1.29-alpine` to clear a Snyk OS-package CVE while keeping the gRPC module, and add `RUN apk upgrade --no-cache` to pull patched Alpine package revisions (libxml2, xz-libs, libssl3/libcrypto3) at build time
 - Run tests in CI and upload kover coverage to Codecov on each push and pull request
 - Scope `netty-tcnative` and `jul-to-slf4j` as `runtimeOnly` (no compile-time references; still bundled in the fat JARs via `runtimeClasspath`)
 - Drop the unused `kotlinx-datetime` dependency (catalog entry, library, and a commented-out usage), removing a transitive dependency the code never referenced
 
 ### Dependency Updates
 
-| Dependency          | Old    | New    |
-|---------------------|--------|--------|
-| gRPC                | 1.81.0 | 1.82.0 |
-| testcontainers      | —      | 2.0.5  |
-| Typesafe Config     | 1.4.8  | 1.4.9  |
-| BuildConfig plugin  | 6.0.9  | 6.0.10 |
-| common-utils        | 2.8.1  | 2.9.1  |
-| gradle-plugins      | 1.0.12 | 1.0.15 |
+| Dependency             | Old           | New              |
+|------------------------|---------------|------------------|
+| Kotlin                 | 2.3.21        | 2.4.0            |
+| Gradle wrapper         | 9.5.0         | 9.5.1            |
+| Ktor                   | 3.4.3         | 3.5.0            |
+| gRPC                   | 1.80.0        | 1.82.0           |
+| Shadow plugin          | 8.3.7         | 9.4.2            |
+| detekt                 | 1.23.8        | 2.0.0-alpha.3    |
+| Typesafe Config        | 1.4.6         | 1.4.9            |
+| BuildConfig plugin     | 6.0.9         | 6.0.10           |
+| common-utils           | 2.8.1         | 2.9.1            |
+| gradle-plugins         | 1.0.14        | 1.0.15           |
+| Logback                | 1.5.32        | 1.5.34           |
+| SLF4J                  | 2.0.17        | 2.0.18           |
+| kotlin-logging         | 8.0.01        | 8.0.4            |
+| Dropwizard metrics     | 4.2.38        | 4.2.39           |
+| MockK                  | 1.14.9        | 1.14.11          |
+| Testcontainers         | —             | 2.0.5            |
 
 Pin `protobuf`/`protoc` (4.34.1 → 3.25.3) and `netty-tcnative` (2.0.77.Final → 2.0.75.Final) **down** to
 the versions the gRPC 1.82.0 artifacts expect, keeping the generated stubs and native TLS binary-compatible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,11 @@ make nh-tests        # Unit tests only (agent, proxy, common, misc — no harnes
 make ip-tests        # In-process integration tests only
 make netty-tests     # Netty integration tests only
 make tls-tests       # TLS integration tests only
-make container-tests # Testcontainers smoke test (proxy + agent + nginx + Prometheus); needs Docker
-make coverage        # Run tests + generate HTML coverage report
+make container-tests # Full Testcontainers end-to-end suite (proxy + agent + nginx + Prometheus); needs Docker
+make all-tests       # Full suite: `make tests` + `make container-tests`
+make scaling-tests   # Parameter-driven scaling container test (tune via SCALE_* vars); needs Docker
+make regen-certs     # Regenerate the testing/certs TLS fixtures (CA + server + client; 2048-bit)
+make coverage        # Run tests + generate HTML and XML coverage reports
 make coverage-xml    # XML coverage report (for Codacy/Coveralls/etc.)
 make coverage-log    # Print coverage % to console
 make tsconfig        # Regenerate ConfigVals from config/config.conf via tscfg
@@ -141,10 +144,19 @@ Integration tests in `src/test/kotlin/io/prometheus/harness/`:
 - `TlsNoMutualAuthTest` / `TlsWithMutualAuthTest` — TLS communication tests
 - `support/HarnessSetup.kt` — base class that sets up proxy+agent in test mode
 
-Container tests in `src/test/kotlin/io/prometheus/containers/`:
-- `ContainersSmokeTest` — Testcontainers-based end-to-end test that builds the proxy and agent images from `etc/docker/*.df`, stands them up alongside an `nginx:alpine` metrics stub and a `prom/prometheus` container, and verifies the full Prometheus → proxy → agent → endpoint scrape path. Requires Docker; gated on `RUN_CONTAINER_TESTS=true` (set automatically by `make container-tests`). Default `./gradlew test` registers a single placeholder marked SKIPPED.
+Container tests in `src/test/kotlin/io/prometheus/containers/` — a full Testcontainers suite that builds the proxy and agent images from `etc/docker/*.df`, stands them up alongside an `nginx:1.29-alpine` metrics stub and a `prom/prometheus` container, and verifies the full Prometheus → proxy → agent → endpoint scrape path. Shared container/network/HTTP/PromQL factories live in `support/ContainerTestSupport.kt`. The specs are:
+- `ContainersSmokeTest` — baseline single-metric scrape through proxy and agent
+- `ContainersProxyHttpTest` — proxy/agent HTTP surfaces (registered-path scrapes, 404/503 passthrough, admin servlets, `/metrics`, service discovery)
+- `ContainersConsolidatedTest` — two consolidated agents register the same path; proxy merges responses
+- `ContainersLargePayloadTest` — forces the chunked + gzipped scrape path with a large synthetic payload
+- `ContainersReconnectTest` — agent reconnects to a replacement proxy and scrapes resume
+- `ContainersAgentTokenAuthTest` — pre-shared agent-token authentication on the gRPC channel (match + mismatch)
+- `ContainersTlsTest` / `ContainersHttpsTargetTest` — TLS on the gRPC channel and HTTPS upstream targets
+- `ContainersScalingTest` — parameter-driven N-agents × M-endpoints scaling (tune via `SCALE_*` env vars / `make scaling-tests`)
 
-Unit tests in `src/test/kotlin/io/prometheus/{agent,proxy,common}/`.
+All container specs require Docker and are gated on `RUN_CONTAINER_TESTS=true` (set automatically by `make container-tests` / `make scaling-tests`). Default `./gradlew test` registers placeholders marked SKIPPED.
+
+Unit tests in `src/test/kotlin/io/prometheus/{agent,proxy,common}/`. Shared test constants live in `src/test/kotlin/io/prometheus/common/TestPorts.kt` (`TestPorts` object) — canonical proxy/agent/Prometheus/nginx port numbers used across the unit, harness, and container suites; reference these instead of hard-coding port literals in new tests.
 
 `EnvVars.getEnv()` reads `java.lang.System.getenv()`, which can't be set in-process, so its parse-and-throw branches aren't reachable by setting an env var in a test. The numeric/boolean parsing is therefore extracted into `internal` companion helpers (`parseBooleanStrict` / `parseIntStrict` / `parseLongStrict`) that the tests call directly. When adding a new typed `getEnv` overload, follow this pattern so the invalid-value path stays testable.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/prometheus-proxy)](https://github.com/pambrose/prometheus-proxy/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/prometheus-proxy)](https://central.sonatype.com/artifact/com.pambrose/prometheus-proxy)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0-red?logo=kotlin)](http://kotlinlang.org)
 [![codecov](https://codecov.io/gh/pambrose/prometheus-proxy/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/prometheus-proxy)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/422df508473443df9fbd8ea00fdee973)](https://app.codacy.com/gh/pambrose/prometheus-proxy/dashboard)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ## 3.2.0
 
-_Unreleased_
+_Released 2026-06-13_
 
 ### Highlights
 
@@ -49,6 +49,8 @@ _Unreleased_
 
 - New `--https_truststore` / `--https_truststore_password` agent options (env `HTTPS_TRUST_STORE_PATH` / `HTTPS_TRUST_STORE_PASSWORD`; config `agent.http.trustStorePath` / `agent.http.trustStorePassword`) — verify HTTPS scrape targets against a custom/private CA without disabling validation. Resolved CLI > env > config; the password is never logged. `--trust_all_x509` takes precedence, and an empty path uses the JDK default trust store
 - New `ContainersSmokeTest` (`io.prometheus.containers`) — Testcontainers-based end-to-end test, gated on `RUN_CONTAINER_TESTS=true`. Default `./gradlew test` runs see a single SKIPPED placeholder
+- Expanded container-test suite (`io.prometheus.containers`) — beyond the smoke test, seven Testcontainers specs now exercise the full stack over real Netty/Docker: `ContainersProxyHttpTest` (404s, upstream-status passthrough, admin `ping`/`version`/`healthcheck`/`threaddump`, proxy & agent `/metrics`, service discovery), `ContainersAgentTokenAuthTest` (token match + mismatch), `ContainersConsolidatedTest` (two-agent path merge), `ContainersLargePayloadTest` (chunk + gzip reassembly), `ContainersReconnectTest` (agent reconnect after proxy replacement), `ContainersTlsTest` (server-only and mutual gRPC TLS), and `ContainersHttpsTargetTest` (trust-all positive/negative). All share a new `support/ContainerTestSupport.kt` (image/network/container factories, HTTP and PromQL helpers) and stay gated on `RUN_CONTAINER_TESTS=true`
+- New `ContainersScalingTest` — a single parameter-driven spec that scales the system along its real load axes (agents × endpoints per agent, series per endpoint, consolidated fan-out, and scrape concurrency), verifies every path is scrapable end-to-end, and asserts the proxy's own `proxy_agent_map_size` / `proxy_path_map_size` gauges match the expected counts. A CI-safe default table runs under `make container-tests`; setting any `SCALE_*` env var collapses the run to one tuned scenario so the load can be dialed up without recompiling
 - New `make container-tests` target — auto-detects Docker Desktop's active context (`docker context inspect`) and exports `DOCKER_HOST` so Testcontainers finds non-default sockets on macOS
 - New `.github/workflows/container-tests.yml` — runs the smoke test on push to master, on `workflow_dispatch`, and on PRs that touch packaging-relevant paths (`etc/docker/**`, `build.gradle.kts`, `gradle/libs.versions.toml`, `src/shadow/**`, the test sources/resources, and the workflow file)
 - New `make help` target with auto-extracted descriptions from `## …` annotations on each target
@@ -75,24 +77,42 @@ _Unreleased_
 - Replace `distro: build $(MAKE) jars` with a plain `distro: build jars` prerequisite list (no recursive sub-make)
 - Externalize the inline coverage-packages python script to `scripts/coverage_packages.py` (typed, error-on-missing-report)
 - Annotate every Make target with a `## description` and add a `make help` target that awk-extracts them
+- Add a `make all-tests` target that runs the full suite — the in-JVM tests plus the Docker-backed `container-tests`
+- Add `make scaling-tests` (forwarding `SCALE_*` and `TEST_MAX_HEAP_SIZE`) and six curated scaling presets — `scaling-paths`, `scaling-agents`, `scaling-payload`, `scaling-consolidated`, `scaling-concurrency`, and `scaling-soak`, each hammering a different subsystem — wired together under `all-scaling`. These are dev/stress aids only and are not run by `all-tests` or CI
+- Honor `-PtestMaxHeapSize` / `TEST_MAX_HEAP_SIZE` to size the forked test JVM heap, overriding the harness-load-based default so large `make scaling-tests` runs (which can hold thousands of scrape bodies at once) don't OOM
+- Add `make regen-certs` to rebuild the `testing/certs` TLS fixtures (CA + server + client) from scratch at 2048-bit with 100-year validity, preserving the `*.test.google.fr` SAN the TLS harness relies on; the committed fixtures were regenerated and the container TLS/HTTPS specs mount them directly (no runtime openssl)
+- Centralize the test suite's scattered port literals into a single `io.prometheus.common.TestPorts` object (test source set), so unit/harness/container specs reference named constants instead of duplicating magic numbers and unit tests no longer pull in the Testcontainers support harness just for a port value
 - Document the double `./gradlew wrapper` invocation in `upgrade-wrapper` as Gradle's documented two-run upgrade procedure
 - Fill in missing `.PHONY` entries for `mini-tests` and the `coverage-*` family
 - Move the Testcontainers smoke test out of `io.prometheus.harness` into a dedicated `io.prometheus.containers` package so the make target is a clean wildcard rather than a `Containers*` prefix match
 - Switch the proxy/agent Docker images to the prebuilt `bellsoft/liberica-openjre-alpine:17` base instead of `alpine` + `apk add openjdk17-jre`. Builds no longer download the JRE from the Alpine mirror at build time (faster and not subject to intermittent mirror stalls), and the base is genuinely multi-arch (amd64 + arm64), so the images run on Apple Silicon — the `eclipse-temurin:17-jre-alpine` alternative was amd64-only. Still Alpine-based, so the existing busybox `adduser` step is unchanged
+- Pin the proxy/agent `bellsoft/liberica-openjre-alpine:17` base image by digest in `etc/docker/{agent,proxy}.df` for reproducible builds (the tag is kept inline for readability), and drop the no-op `-XX:+UnlockExperimentalVMOptions` / `-XX:+UseG1GC` flags from the container ENTRYPOINT — G1 is the JDK 17 default GC and `MaxGCPauseMillis` / `UseStringDeduplication` are non-experimental, so the unlock flag did nothing
+- Pin the docs toolchain to `zensical==0.0.45` and `mkdocs-material==9.7.6` in `.github/workflows/docs.yml` so the published site builds reproducibly; bump deliberately when upgrading the toolchain
+- Harden the nginx reverse-proxy example image (`nginx/docker/Dockerfile`): the base image moved from the Debian-based `nginx` to `nginx:1.29-alpine` (clearing a Snyk OS-package CVE while retaining the gRPC module), and a `RUN apk upgrade --no-cache` step pulls the patched Alpine package revisions Snyk flagged — libxml2 `2.13.9-r1`, xz-libs `5.8.3-r0`, and libssl3/libcrypto3 `3.5.7-r0` — from the same Alpine branch at build time
 - Run the test suite in CI and upload kover coverage to Codecov on each push and pull request
 - Scope `netty-tcnative` and `jul-to-slf4j` as `runtimeOnly` (neither is referenced at compile time; the native TLS provider and the JUL→SLF4J bridge are still bundled into the fat JARs via `runtimeClasspath`)
 - Drop the unused `kotlinx-datetime` dependency (catalog entry, library, and a commented-out usage) — the code never referenced it
 
 ### Dependency Updates
 
-| Dependency          | Old    | New    |
-|---------------------|--------|--------|
-| gRPC                | 1.81.0 | 1.82.0 |
-| testcontainers      | —      | 2.0.5  |
-| Typesafe Config     | 1.4.8  | 1.4.9  |
-| BuildConfig plugin  | 6.0.9  | 6.0.10 |
-| common-utils        | 2.8.1  | 2.9.1  |
-| gradle-plugins      | 1.0.12 | 1.0.15 |
+| Dependency             | Old           | New              |
+|------------------------|---------------|------------------|
+| Kotlin                 | 2.3.21        | 2.4.0            |
+| Gradle wrapper         | 9.5.0         | 9.5.1            |
+| Ktor                   | 3.4.3         | 3.5.0            |
+| gRPC                   | 1.80.0        | 1.82.0           |
+| Shadow plugin          | 8.3.7         | 9.4.2            |
+| detekt                 | 1.23.8        | 2.0.0-alpha.3    |
+| Typesafe Config        | 1.4.6         | 1.4.9            |
+| BuildConfig plugin     | 6.0.9         | 6.0.10           |
+| common-utils           | 2.8.1         | 2.9.1            |
+| gradle-plugins         | 1.0.14        | 1.0.15           |
+| Logback                | 1.5.32        | 1.5.34           |
+| SLF4J                  | 2.0.17        | 2.0.18           |
+| kotlin-logging         | 8.0.01        | 8.0.4            |
+| Dropwizard metrics     | 4.2.38        | 4.2.39           |
+| MockK                  | 1.14.9        | 1.14.11          |
+| Testcontainers         | —             | 2.0.5            |
 
 `protobuf` / `protoc` (4.34.1 → 3.25.3) and `netty-tcnative` (2.0.77.Final → 2.0.75.Final) are pinned
 **down** to the versions the gRPC 1.82.0 artifacts ship — not the newer releases `make versions` flags —

--- a/src/test/kotlin/website/ConfigExamples.txt
+++ b/src/test/kotlin/website/ConfigExamples.txt
@@ -178,5 +178,5 @@ agent.logLevel = "debug"
 # PROXY_LOG_LEVEL=debug
 # AGENT_LOG_LEVEL=debug
 
-# Available levels: all, trace, debug, info, warn, error, off
+# Available levels: trace, debug, info, warn, error, off
 ; --8<-- [end:log-level-config]

--- a/website/prometheus-proxy/docs/cli-reference.md
+++ b/website/prometheus-proxy/docs/cli-reference.md
@@ -99,7 +99,9 @@ icon: lucide/terminal
 
 Available log levels for both proxy and agent:
 
-`all`, `trace`, `debug`, `info`, `warn`, `error`, `off`
+`trace`, `debug`, `info`, `warn`, `error`, `off`
+
+The deprecated `all` level was removed in 3.2.0 — use `trace` for the most verbose output.
 
 ## Dynamic Properties
 

--- a/website/prometheus-proxy/docs/configuration/agent.md
+++ b/website/prometheus-proxy/docs/configuration/agent.md
@@ -86,6 +86,14 @@ scenarios). Configure cache behavior:
 --8<-- "ConfigExamples.txt:agent-cache-config"
 ```
 
+## Scraping HTTPS Endpoints
+
+For HTTPS scrape targets signed by a private or internal CA, point the agent at a trust store that
+contains that CA (`--https_truststore` / `HTTPS_TRUST_STORE_PATH` / `agent.http.trustStorePath`, with
+the matching `*_password`) so certificates are still validated. An empty path uses the JDK default
+trust store, and `--trust_all_x509` (which disables verification entirely) takes precedence. See
+[Scraping HTTPS Endpoints](../security/index.md#scraping-https-endpoints) for details.
+
 ## Scrape Settings
 
 ```hocon


### PR DESCRIPTION
## Summary

Finalizes the documentation for the **3.2.0** release (dated **2026-06-13**) by folding in every item committed since `3.1.1` that landed after the prior doc reconciliation (PR #172). The CHANGELOG/RELEASE_NOTES `3.2.0` sections were already largely complete; this fills the remaining gaps and corrects the dependency tables.

## CHANGELOG.md & RELEASE_NOTES.md
- `Unreleased` → `2026-06-13` release date
- **Expanded container-test suite** — 7 new specs (ProxyHttp, AgentTokenAuth, Consolidated, LargePayload, Reconnect, Tls, HttpsTarget) plus the parameter-driven `ContainersScalingTest`
- **New make targets** — `all-tests`, `scaling-tests` + 6 presets + `all-scaling`, `regen-certs`, the `TEST_MAX_HEAP_SIZE` knob, and the `TestPorts` centralization
- **Docker/CI hygiene** — base-image digest pinning + dropped no-op G1 flags in `etc/docker/*.df`, pinned `docs.yml` pip deps, and nginx example image hardening (`nginx:1.29-alpine` + Alpine CVE patch)
- **Rebuilt the dependency tables** — added Kotlin (2.3.21→2.4.0), Gradle (9.5.0→9.5.1), Ktor (3.4.3→3.5.0), Shadow (8.3.7→9.4.2), detekt (1.23.8→2.0.0-alpha.3) and patch bumps, and corrected the intermediate "old" baselines (gRPC 1.80.0 not 1.81.0; Typesafe 1.4.6 not 1.4.8; gradle-plugins 1.0.14 not 1.0.12)

## Other files
- **README.md** — fixed the stale Kotlin badge (2.3.21 → 2.4.0)
- **Website** — removed the deprecated `all` log level from the CLI reference and the rendered config snippet (it now fails fast at startup); added an HTTPS trust store cross-reference to the agent config page
- **CLAUDE.md** — refreshed the make-targets list and rewrote the container-test structure to list all 9 specs + `TestPorts`
- **llms.txt** — verified already current; no changes needed

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)