### PR TITLE
Drive embedded Agent.stop() through the Guava lifecycle to stop the zombie reconnect loop

### DIFF
--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -496,10 +496,14 @@ class Agent(
     super.shutDown()
   }
 
-  // This is called from EmbeddedAgentInfo to allow external callers to shutdown
-  // the agent without needing access to the full Agent instance.
+  // Called from EmbeddedAgentInfo to let external callers shut the agent down without access to the
+  // full Agent instance. Must drive the Guava service lifecycle (stopSync) rather than invoking the
+  // shutDown() hook directly: stopSync() transitions the service to STOPPING (flipping isRunning to
+  // false) so the run() loop exits, then Guava invokes the shutDown() hook exactly once for cleanup,
+  // and blocks until the service reaches TERMINATED. Calling shutDown() directly would tear down the
+  // channel/servlets but leave isRunning true, so the run loop would reconnect forever.
   fun stop() {
-    shutDown()
+    stopSync()
   }
 
   override fun toString() =

--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -100,6 +100,36 @@ class AgentTest : StringSpec() {
       result.shouldBeFalse()
     }
 
+    // ==================== Embedded shutdown lifecycle Tests ====================
+
+    // Regression: the documented embedded shutdown path (EmbeddedAgentInfo.shutdown() -> Agent.stop())
+    // must drive the Guava service lifecycle so the run() loop actually exits. Previously stop() called
+    // the shutDown() hook directly, which tore down the gRPC channel/servlets but never flipped
+    // isRunning, leaving the run loop reconnecting forever (a zombie thread). This starts a real Agent,
+    // lets its run loop spin (failing to reach the absent in-process proxy), then asserts shutdown()
+    // terminates the service rather than leaving it running.
+    "EmbeddedAgentInfo.shutdown() should terminate the agent service, not leave the run loop reconnecting" {
+      val agent =
+        Agent(
+          options = AgentOptions(listOf("--proxy", "localhost:$PROXY_AGENT_PORT"), exitOnMissingConfig = false),
+          inProcessServerName = "embedded-stop-test-${System.nanoTime()}",
+          testMode = true,
+        ) { startAsync() }
+      val info = EmbeddedAgentInfo(agent)
+
+      try {
+        // The run() loop is active, repeatedly failing to connect to the absent in-process proxy.
+        eventually(5.seconds) { agent.isRunning.shouldBeTrue() }
+
+        // shutdown() must block until the service has terminated (per its documented contract).
+        info.shutdown()
+
+        agent.isRunning.shouldBeFalse()
+      } finally {
+        runCatching { if (agent.isRunning) agent.stopSync() }
+      }
+    }
+
     // ==================== updateScrapeCounter Tests ====================
 
     "updateScrapeCounter should not fail for empty type" {


### PR DESCRIPTION
## Problem

The documented embedded shutdown path — `EmbeddedAgentInfo.shutdown()` → `Agent.stop()` — called the Guava lifecycle hook `shutDown()` **directly**, bypassing `stopAsync()`/`stopSync()`.

`Agent` extends Guava's `AbstractExecutionThreadService`; its `run()` loop terminates only when the inherited `isRunning` flag flips false, and only `stopAsync()`/`stopSync()` flip it. Calling `shutDown()` directly tore down the gRPC channel, servlets, metrics, and HTTP clients but **never transitioned the Guava service state**. The `while (isRunning)` loop then waited `reconnectPauseSecs` and rebuilt a fresh gRPC channel to re-register with the proxy — **forever**. A zombie thread spinning on a torn-down agent, logging reconnect errors every few seconds.

It also broke the `EmbeddedAgentInfo.shutdown()` contract, which promises it "blocks the calling thread until the Agent has finished shutting down" (it returned immediately while the run thread kept looping).

The standalone agent (JVM shutdown hook → `stopAsync().awaitTerminated()`) and the test harness (`stopSync()`) were unaffected — only the embedded public-API path bypassed the state machine.

## Fix

Route `stop()` through `stopSync()`. Guava transitions the service to `STOPPING` (flipping `isRunning` to false) so the run loop exits, then invokes the `shutDown()` hook exactly once for cleanup, and blocks until `TERMINATED`. This makes the embedded path behave like the already-working standalone/harness paths; no behavior change for them.

## Test

Adds a non-mocked regression test that starts a **real** `Agent`, lets its run loop spin against an absent in-process proxy, then asserts `EmbeddedAgentInfo.shutdown()` terminates the service. Confirmed it fails on the old code (`isRunning` stays `true`) and passes with the fix. The existing `EmbeddedAgentInfoTest` only mocked `Agent` and verified `stop()` was called, so the real termination path was never exercised.

## Verification

- New test: RED on old code (`true should equal false` at the `isRunning` assertion) → GREEN after fix
- `AgentTest`, `EmbeddedAgentInfoTest`, `AgentGrpcServiceTest`, in-process harness tests: pass
- Full unit suite (`make nh-tests`): pass
- `detekt`, `lintKotlinMain`, `lintKotlinTest`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)