### PR TITLE
Harden path and port validation across the proxy and options

### DIFF
--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -442,7 +442,14 @@ class Proxy(
             val labels = agentContextInfo.labels
             runCatching {
               val json = labels.toJsonElement()
-              json.jsonObject.forEach { (k, v) -> put(k, v) }
+              // Apply agent-supplied labels, but never let them clobber the proxy-computed reserved
+              // keys above (a colliding key could redirect the scrape target or spoof identity).
+              json.jsonObject.forEach { (k, v) ->
+                if (k in RESERVED_SD_LABEL_KEYS)
+                  logger.warn { "Ignoring agent label '$k' that collides with a reserved key for path $pathWithSlash" }
+                else
+                  put(k, v)
+              }
             }.onFailure { e ->
               logger.warn { "Invalid JSON in labels value: $labels - ${e.simpleClassName}: ${e.message}" }
             }
@@ -460,6 +467,9 @@ class Proxy(
 
   companion object {
     private val logger = logger {}
+
+    // Service-discovery label keys computed by the proxy; agent-supplied labels must not overwrite them.
+    private val RESERVED_SD_LABEL_KEYS = setOf("__metrics_path__", "agentName", "hostName")
 
     /**
      * JVM entry point for the standalone Proxy process.

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -295,6 +295,7 @@ class AgentOptions(
 
     if (scrapeTimeoutSecs == -1)
       scrapeTimeoutSecs = SCRAPE_TIMEOUT_SECS.getEnv(agentConfigVals.scrapeTimeoutSecs)
+    require(scrapeTimeoutSecs > 0) { "scrapeTimeoutSecs must be > 0: $scrapeTimeoutSecs" }
     logger.info { "scrapeTimeoutSecs: ${scrapeTimeoutSecs.seconds}" }
 
     if (scrapeMaxRetries == -1)

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -302,6 +302,7 @@ abstract class BaseOptions protected constructor(
   protected fun assignAdminPort(defaultVal: Int) {
     if (adminPort == -1)
       adminPort = ADMIN_PORT.getEnv(defaultVal)
+    require(adminPort in 1..65535) { "adminPort must be in 1..65535: $adminPort" }
     logger.info { "adminPort: $adminPort" }
   }
 
@@ -318,6 +319,7 @@ abstract class BaseOptions protected constructor(
   protected fun assignMetricsPort(defaultVal: Int) {
     if (metricsPort == -1)
       metricsPort = METRICS_PORT.getEnv(defaultVal)
+    require(metricsPort in 1..65535) { "metricsPort must be in 1..65535: $metricsPort" }
     logger.info { "metricsPort: $metricsPort" }
   }
 

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -76,7 +76,14 @@ internal class ProxyPathManager(
     agentContext: AgentContext,
   ): String? {
     require(path.isNotEmpty()) { EMPTY_PATH_MSG }
+    return multiSegmentPathError(path) ?: addValidatedPath(path, labels, agentContext)
+  }
 
+  private fun addValidatedPath(
+    path: String,
+    labels: String,
+    agentContext: AgentContext,
+  ): String? {
     synchronized(pathMap) {
       val agentInfo = pathMap[path]
       if (agentContext.consolidated) {
@@ -121,6 +128,17 @@ internal class ProxyPathManager(
       if (!isTestMode) logger.info { "Added path /$path for $agentContext" }
     }
     return null
+  }
+
+  // The scrape route is registered as get("/*"), which matches exactly one path segment. A path with
+  // an embedded slash (e.g. "app/metrics") would be advertised in service discovery yet 404 at scrape
+  // time, so reject it at registration. A single leading slash is tolerated because the agent may or
+  // may not have stripped it. Returns a failure reason, or null when the path is a single segment.
+  private fun multiSegmentPathError(path: String): String? {
+    val normalized = path.removePrefix("/")
+    if ('/' !in normalized) return null
+    return "Multi-segment path not supported (use a single path segment): /$normalized"
+      .also { logger.error { it } }
   }
 
   fun removePath(

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 class AgentOptionsTest : StringSpec() {
   init {
@@ -55,6 +56,21 @@ class AgentOptionsTest : StringSpec() {
     "scrapeTimeoutSecs should be settable via command line" {
       val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--timeout", "45"), false)
       options.scrapeTimeoutSecs shouldBe 45
+    }
+
+    // A non-positive scrapeTimeoutSecs makes withTimeout() cancel every scrape immediately, so it must
+    // fail fast at startup like the other numeric options (chunk, retries, client_timeout, etc.).
+    "scrapeTimeoutSecs of 0 should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        AgentOptions(listOf("--name", "test", "--proxy", "host", "--timeout", "0"), false)
+      }
+      exception.message shouldContain "scrapeTimeoutSecs"
+    }
+
+    "negative scrapeTimeoutSecs from config should be rejected" {
+      shouldThrow<IllegalArgumentException> {
+        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.scrapeTimeoutSecs=-5"), false)
+      }
     }
 
     "scrapeMaxRetries should be settable via command line" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -179,6 +179,26 @@ class ProxyOptionsTest : StringSpec() {
       shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--port", "70000")) }
     }
 
+    // adminPort/metricsPort were previously unvalidated, unlike proxyPort/proxyAgentPort, so an
+    // out-of-range value surfaced only as an opaque bind failure. Validate them consistently.
+    "adminPort of 0 should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--admin_port", "0")) }
+      exception.message shouldContain "adminPort"
+    }
+
+    "adminPort above 65535 should be rejected" {
+      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--admin_port", "70000")) }
+    }
+
+    "metricsPort of 0 should be rejected" {
+      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--metrics_port", "0")) }
+      exception.message shouldContain "metricsPort"
+    }
+
+    "metricsPort above 65535 should be rejected" {
+      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--metrics_port", "70000")) }
+    }
+
     "proxyAgentPort of 0 should be rejected" {
       val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--agent_port", "0")) }
       exception.message shouldContain "proxyAgentPort"

--- a/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
@@ -80,6 +80,32 @@ class ProxyPathManagerTest : StringSpec() {
       exception.message shouldContain "Empty path"
     }
 
+    // The scrape route is registered as get("/*"), which matches exactly one path segment, so a
+    // multi-segment path would be advertised in service discovery yet 404 at scrape time. Reject it
+    // at registration with a clear reason instead of silently registering an unreachable path.
+    "addPath should reject a multi-segment path" {
+      val proxy = createMockProxy()
+      val manager = ProxyPathManager(proxy, isTestMode = true)
+      val context = createMockAgentContext()
+
+      val reason = manager.addPath("app/metrics", """{"job":"test"}""", context)
+
+      reason.shouldNotBeNull()
+      reason shouldContain "single"
+      manager.pathMapSize shouldBe 0
+    }
+
+    "addPath should reject a multi-segment path that has a leading slash" {
+      val proxy = createMockProxy()
+      val manager = ProxyPathManager(proxy, isTestMode = true)
+      val context = createMockAgentContext()
+
+      val reason = manager.addPath("/app/metrics", """{"job":"test"}""", context)
+
+      reason.shouldNotBeNull()
+      manager.pathMapSize shouldBe 0
+    }
+
     "addPath should overwrite non-consolidated path" {
       val proxy = createMockProxy()
       val manager = ProxyPathManager(proxy, isTestMode = true)

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -137,6 +137,29 @@ class ProxyTest : StringSpec() {
       labels.containsKey("environment").shouldBeFalse()
     }
 
+    // Agent-supplied labels must not clobber the proxy-computed reserved keys (__metrics_path__,
+    // agentName, hostName). Reserved keys are written last/skipped so an agent cannot redirect the
+    // scrape target or spoof identity via a colliding label name.
+    "buildServiceDiscoveryJson should not let agent labels override reserved keys" {
+      val proxy = createTestProxy("-Dproxy.service.discovery.targetPrefix=proxy:$PROXY_HTTP_PORT")
+      val agentContext = createAgentContext(name = "agent-real", host = "real-host")
+      proxy.agentContextManager.addAgentContext(agentContext)
+      proxy.pathManager.addPath(
+        "metrics",
+        """{"__metrics_path__":"/evil","hostName":"spoofed","env":"prod"}""",
+        agentContext,
+      )
+
+      val json = proxy.buildServiceDiscoveryJson()
+
+      val labels = json[0].jsonObject["labels"]!!.jsonObject
+      // Proxy-computed reserved values win over the agent-supplied collisions.
+      labels["__metrics_path__"]!!.jsonPrimitive.content shouldBe "/metrics"
+      labels["hostName"]!!.jsonPrimitive.content shouldBe "real-host"
+      // Non-reserved custom labels are still applied.
+      labels["env"]!!.jsonPrimitive.content shouldBe "prod"
+    }
+
     // Bug #10: __metrics_path__ must include a leading slash per Prometheus SD convention
     "buildServiceDiscoveryJson should include leading slash in __metrics_path__" {
       val proxy = createTestProxy("-Dproxy.service.discovery.targetPrefix=proxy:$PROXY_HTTP_PORT")
@@ -153,18 +176,18 @@ class ProxyTest : StringSpec() {
       metricsPath[0] shouldBe '/'
     }
 
-    "buildServiceDiscoveryJson should not double-slash paths that already have slashes internally" {
+    // Multi-segment paths are rejected at registration: the get("/*") scrape route matches only a
+    // single segment, so such a path would be advertised yet 404. Confirm a rejected path never
+    // reaches the service-discovery document.
+    "buildServiceDiscoveryJson should omit a rejected multi-segment path" {
       val proxy = createTestProxy("-Dproxy.service.discovery.targetPrefix=proxy:$PROXY_HTTP_PORT")
       val agentContext = createAgentContext()
       proxy.agentContextManager.addAgentContext(agentContext)
-      // Paths in the pathMap never have a leading slash (stripped by HTTP handler),
-      // but they might contain internal slashes for nested paths
-      proxy.pathManager.addPath("app/metrics", "", agentContext)
 
-      val json = proxy.buildServiceDiscoveryJson()
+      val reason = proxy.pathManager.addPath("app/metrics", "", agentContext)
 
-      val labels = json[0].jsonObject["labels"]!!.jsonObject
-      labels["__metrics_path__"]!!.jsonPrimitive.content shouldBe "/app/metrics"
+      reason.shouldNotBeNull()
+      proxy.buildServiceDiscoveryJson().size shouldBe 0
     }
 
     // ==================== removeAgentContext Tests ====================


### PR DESCRIPTION
Batches four low-severity validation/robustness findings from the repo review. Each fix was written test-first (red → green); the full unit suite, in-process harness tests, `detekt`, and kotlinter all pass.

## Fixes

**#4 — Reject multi-segment registered paths** (`ProxyPathManager.kt`)
The scrape route is `get("/*")`, which matches exactly one path segment, so a path like `app/metrics` was advertised in service discovery yet **404'd at scrape time** — a silent permanent failure. `addPath()` now rejects embedded-slash paths at registration with a clear reason. It **returns** the reason (rather than throwing) so the agent receives `valid=false` instead of a gRPC exception that would propagate to `handleConnectionFailure` and trigger a reconnect loop. A single leading slash is still tolerated (the agent may or may not have stripped it). `addPath` delegates the map mutation to a new `addValidatedPath` to stay within the detekt `ReturnCount` limit.

**#5 — Agent labels can't override reserved service-discovery keys** (`Proxy.kt`)
`buildServiceDiscoveryJson()` wrote the reserved keys (`__metrics_path__`, `agentName`, `hostName`) first, then merged agent-supplied labels with `put()`, which overwrites. A colliding label key could redirect the scrape target or spoof identity. Colliding keys are now skipped with a warning; non-reserved labels still apply.

**#6 — Validate `scrapeTimeoutSecs > 0`** (`AgentOptions.kt`)
A non-positive value made `withTimeout()` cancel every scrape immediately (misleading per-scrape failures). It now fails fast at startup with a clear message, matching the other numeric options (`chunk`, `max_retries`, `client_timeout`, …).

**#8 — Validate `adminPort`/`metricsPort` in `1..65535`** (`BaseOptions.kt`)
These lacked the range check that `proxyPort`/`proxyAgentPort` already have, so an out-of-range value surfaced only as an opaque bind failure. Now consistent fail-fast validation.

## Behavior-change note
The pre-existing `ProxyTest` case `…double-slash paths that already have slashes internally` registered an internal-slash path and asserted only SD *formatting* — it never actually scraped the path (which would 404). It is repurposed to assert that a rejected multi-segment path is omitted from the service-discovery document. If nested/multi-segment scrape paths are ever a desired feature, that's a separate routing change (switch the route to a tailcard), not covered here.

## Tests added
- `ProxyPathManagerTest`: multi-segment path rejected (with and without leading slash)
- `ProxyTest`: reserved-key collision (agent labels don't override proxy-computed values); rejected multi-segment path omitted from SD
- `AgentOptionsTest`: `scrapeTimeoutSecs` of `0` and negative-from-config rejected
- `ProxyOptionsTest`: `adminPort`/`metricsPort` of `0` and `> 65535` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)