### PR TITLE
Fix stale RELEASE.md and run detekt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Compile (no tests)
         run: ./gradlew clean build -xtest
 
-      - name: Lint
-        run: ./gradlew lintKotlinMain lintKotlinTest
+      - name: Lint and detekt
+        run: ./gradlew lintKotlinMain lintKotlinTest detekt
 
       # --continue lets the kover report tasks run even if some tests fail, preserving the
       # prior behavior where coverage was still uploaded on test failure.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,14 +1,34 @@
 # Release Creation
 
-1) Bump version in `build.gradle.kts`
+The version is defined once in `gradle.properties` (`version=…`) and read from there by Gradle, the
+`Makefile` (`VERSION`), and the Docker image tags. `BuildConfig.APP_RELEASE_DATE` and
+`BuildConfig.BUILD_TIME` are generated automatically on each build, so there is no release date to edit
+by hand.
 
-2) Update the release date in `Makefile`
+1) Bump `version` in `gradle.properties` (the single source of truth).
 
-3) Verify tests run cleanly before merge with: `make tests`
+2) Update the `3.2.0` literals in `README.md` and `llms.txt` (the Docker tag examples and the Maven
+   Central dependency block) to the new version.
 
-4) Build distro with: `make distro`
+3) Update `CHANGELOG.md` and `RELEASE_NOTES.md` with the changes in this release.
 
-5) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases)
-    and upload the *build/libs/prometheus-proxy.jar* and *build/libs/prometheus-agent.jar* files.
+4) Verify everything passes before merging: `make tests` (or `make all-tests` to also run the
+   Docker-based container suite).
 
-6) Build and push docker images with: `make docker-push`
+5) Build the standalone fat jars: `make distro`. This produces `build/libs/prometheus-agent.jar` and
+   `build/libs/prometheus-proxy.jar`.
+
+6) Publish the release artifact to Maven Central: `make publish-maven-central`
+   (runs `./gradlew publishAndReleaseToMavenCentral`). The required GPG environment is validated
+   automatically by the target's `_check-gpg-env` prerequisite — see the GPG variables and keychain
+   entry it checks. To publish a snapshot instead, use `make publish-snapshot`.
+
+7) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases):
+   - **Tag**: the version with no `v` prefix (e.g. `3.2.0`).
+   - **Title**: the version with a `v` prefix (e.g. `v3.2.0`).
+   - **Description**: summarize the changes and include a full-changelog link
+     (e.g. `**Full Changelog**: https://github.com/pambrose/prometheus-proxy/compare/<prev>...<new>`).
+   - Attach `build/libs/prometheus-agent.jar` and `build/libs/prometheus-proxy.jar`.
+
+8) Build and push the multi-arch Docker images: `make docker-push`. This tags both `:latest` and
+   `:<version>`; it refuses to push pre-release versions (`-SNAPSHOT`/`-rc`/`-beta`/`-alpha`) as `:latest`.


### PR DESCRIPTION
Addresses two review findings.

## #2 — `docs/RELEASE.md` was stale and would misdirect a release

`docs/RELEASE.md` is the authoritative release runbook (per CLAUDE.md), but it was wrong on four counts:
- Said to bump the version in `build.gradle.kts` — the version lives **only** in `gradle.properties` (the single source of truth).
- "Update the release date in `Makefile`" — that step no longer exists; `APP_RELEASE_DATE` is generated each build via a `ValueSource`.
- Never mentioned updating the version literals in `README.md` / `llms.txt`, which the project requires when bumping the version.
- Omitted the actual publish step (`make publish-maven-central`) entirely — it only described uploading jars to a GitHub release + `make docker-push`.

Rewritten to match the real flow, cross-checked against the `Makefile` targets: bump `gradle.properties`; update `README.md`/`llms.txt` + `CHANGELOG.md`/`RELEASE_NOTES.md`; `make tests` (or `make all-tests`); `make distro` (produces `build/libs/prometheus-{agent,proxy}.jar`); `make publish-maven-central` (GPG validated via its `_check-gpg-env` prerequisite); cut the GitHub release (tag without `v`, title with `v`, changelog link, attach the jars); `make docker-push`.

## #18 — CI never ran detekt

detekt is a configured quality gate (`config/detekt/detekt.yml`, and `make lint` runs it), but no workflow invoked it, so a regression could merge. Added `detekt` to the CI lint step:

```diff
-      - name: Lint
-        run: ./gradlew lintKotlinMain lintKotlinTest
+      - name: Lint and detekt
+        run: ./gradlew lintKotlinMain lintKotlinTest detekt
```

This mirrors the local `make lint` gate. Verified `detekt` passes cleanly on current `master`, so it won't break the build on merge.

## Verification
- `./gradlew lintKotlinMain lintKotlinTest detekt` (the exact new CI command): clean
- RELEASE.md steps cross-checked against the actual `Makefile` targets and jar output names

(Finding #19 — the Shadow `9.4.1`→`9.4.2` doc drift — is intentionally not included here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)