### PR TITLE
Tidy agent timer/timeout/stream code and make the cache concurrency test real

### DIFF
--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -383,8 +383,7 @@ class Agent(
 
   internal val proxyHost get() = "${grpcService.agentHostName}:${grpcService.agentPort}"
 
-  internal fun startTimer(agent: Agent): Histogram.Timer? =
-    metrics.scrapeRequestLatency.labels(agent.launchId, agentName).startTimer()
+  internal fun startTimer(): Histogram.Timer? = metrics.scrapeRequestLatency.labels(launchId, agentName).startTimer()
 
   override fun serviceName() = "$simpleClassName $agentName"
 

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -433,17 +433,29 @@ internal class AgentGrpcService(
       nonChunkedChannel.close()
       chunkedChannel.close()
     }
+
+    // Shared per-stream failure policy: run [block], and on a non-cancellation failure log it (tagged
+    // with [name]) while the agent is still running, then tear down the shared channels. Cancellation
+    // is propagated without closing (normal shutdown). Factored out of the three coroutines below so
+    // the failure handling lives in one place.
+    suspend fun runStreamTask(
+      name: String,
+      block: suspend () -> Unit,
+    ) {
+      runCatchingCancellable { block() }
+        .onFailure { e ->
+          if (agent.isRunning)
+            Status.fromThrowable(e).apply { logger.error(e) { "$name(): ${exceptionDetails(e)}" } }
+          if (e !is CancellationException) closeAll()
+        }
+    }
+
     coroutineScope {
       // Ends by connectionContext.close()
       launch(Dispatchers.IO) {
         try {
-          runCatchingCancellable {
+          runStreamTask("processScrapeResults") {
             processScrapeResults(agent, connectionContext, nonChunkedChannel, chunkedChannel)
-          }.onFailure { e ->
-            if (agent.isRunning)
-              Status.fromThrowable(e)
-                .apply { logger.error(e) { "processScrapeResults(): ${exceptionDetails(e)}" } }
-            if (e !is CancellationException) closeAll()
           }
         } finally {
           // Close channels when the producer finishes so consumers' consumeAsFlow() will complete.
@@ -455,24 +467,14 @@ internal class AgentGrpcService(
 
       // Ends by disconnection from server
       launch(Dispatchers.IO) {
-        runCatchingCancellable {
+        runStreamTask("writeResponsesToProxy") {
           grpcStub.writeResponsesToProxy(nonChunkedChannel.consumeAsFlow())
-        }.onFailure { e ->
-          if (agent.isRunning)
-            Status.fromThrowable(e)
-              .apply { logger.error(e) { "writeResponsesToProxy(): ${exceptionDetails(e)}" } }
-          if (e !is CancellationException) closeAll()
         }
       }
 
       launch(Dispatchers.IO) {
-        runCatchingCancellable {
+        runStreamTask("writeChunkedResponsesToProxy") {
           grpcStub.writeChunkedResponsesToProxy(chunkedChannel.consumeAsFlow())
-        }.onFailure { e ->
-          if (agent.isRunning)
-            Status.fromThrowable(e)
-              .apply { logger.error(e) { "writeChunkedResponsesToProxy(): ${exceptionDetails(e)}" } }
-          if (e !is CancellationException) closeAll()
         }
       }
     }

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -109,7 +109,7 @@ internal class AgentHttpService(
     req: ScrapeRequest,
     pathContext: AgentPathManager.PathContext,
   ): ScrapeResults {
-    val requestTimer = if (agent.isMetricsEnabled) agent.startTimer(agent) else null
+    val requestTimer = if (agent.isMetricsEnabled) agent.startTimer() else null
     // Add the incoming query params to the url
     val url = appendQueryParams(pathContext.url, req.encodedQueryParams)
     val logUrl = sanitizeUrl(url)
@@ -124,8 +124,7 @@ internal class AgentHttpService(
       } catch (e: Throwable) {
         // Catch regular exceptions and HttpRequestTimeoutException (which is a CancellationException)
         // but let other CancellationExceptions propagate (like system shutdown).
-        // Ktor often wraps the timeout exception, so we check the cause as well.
-        // We also check class names to handle cases where exceptions might be wrapped or mocked.
+        // Ktor often wraps the timeout exception, so we walk the cause chain as well.
         var isTimeout = e is HttpRequestTimeoutException || e is TimeoutCancellationException
         var curr: Throwable? = e
         while (!isTimeout && curr != null) {
@@ -352,10 +351,7 @@ internal class AgentHttpService(
     private const val UNSUCCESSFUL_MSG = "unsuccessful"
 
     private fun isTimeoutException(e: Throwable): Boolean =
-      e is HttpRequestTimeoutException ||
-        e is TimeoutCancellationException ||
-        e.javaClass.simpleName == "HttpRequestTimeoutException" ||
-        e.simpleClassName == "HttpRequestTimeoutException"
+      e is HttpRequestTimeoutException || e is TimeoutCancellationException
 
     private fun handleInvalidPath(scrapeRequest: ScrapeRequest): ScrapeResults {
       logger.warn { "Invalid path in fetchScrapeUrl(): ${scrapeRequest.path}" }

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -275,17 +276,23 @@ class HttpClientCacheTest : StringSpec() {
 
     "should handle concurrent access safely" {
       val key = ClientKey("user1", "pass1")
-      val entries = mutableListOf<CacheEntry>()
+      // Thread-safe: the coroutines below run on a real multi-threaded dispatcher.
+      val entries = ConcurrentLinkedQueue<CacheEntry>()
 
-      // Launch multiple coroutines to access the cache concurrently
+      // Launch on Dispatchers.IO (multi-threaded) and release all coroutines together via a start
+      // latch so they genuinely contend on the cache's mutex / ConcurrentHashMap, rather than merely
+      // interleaving on the single-threaded test dispatcher (which would not exercise thread-safety).
+      val startLatch = CountDownLatch(1)
       val jobs = (1..10).map {
-        launch {
+        launch(Dispatchers.IO) {
+          startLatch.await()
           val entry = cache.getOrCreateClient(key) { createMockHttpClient() }
           entries.add(entry)
           delay(50.milliseconds)
           cache.onFinishedWithClient(entry)
         }
       }
+      startLatch.countDown()
 
       // Wait for all jobs to complete
       jobs.joinAll()


### PR DESCRIPTION
Four agent-layer code-quality findings from the review. The first three are behavior-preserving refactors; the fourth strengthens a weak test.

## #11 — `Agent.startTimer` took a redundant `Agent` parameter
The only caller passed the instance to itself (`agent.startTimer(agent)`), and the body mixed the parameter's `launchId` with the receiver's `agentName` — a latent footgun where a future caller passing a different `Agent` would emit mislabeled `scrapeRequestLatency` metrics. Dropped the parameter; it now uses the receiver consistently (`launchId` + `agentName`).

## #12 — `isTimeoutException` had duplicate stringly-typed checks
It combined the real `is` checks with `e.javaClass.simpleName == "HttpRequestTimeoutException"` and `e.simpleClassName == "HttpRequestTimeoutException"` — two comparisons that are identical to each other and only fire for a *different* class sharing the simple name. Production uses the imported Ktor `HttpRequestTimeoutException` (not shadow-relocated), so the two `is` checks plus the existing cause-chain walk fully cover real and wrapped timeouts. Reduced to the two `is` checks; the timeout tests throw the real type and stay green.

## #13 — Triplicated failure-handling block in `writeResponsesToProxyUntilDisconnected`
The three writer coroutines each repeated the same `runCatchingCancellable { … }.onFailure { log if running; closeAll() unless cancelled }` boilerplate, differing only by log label. Factored into a local `runStreamTask(name, block)` helper so the failure policy lives in one place. The producer coroutine's channel-closing `finally` is unchanged.

## #14 — "should handle concurrent access safely" didn't test concurrency
The test launched 10 coroutines with a bare `launch{}`, which inherits Kotest's single-threaded test dispatcher — they only interleaved on one thread and never contended, and collected into a non-thread-safe `mutableListOf`. It now launches on `Dispatchers.IO` (multi-threaded), releases all coroutines together via a start latch so they genuinely contend on the cache's mutex/`ConcurrentHashMap`, and collects into a `ConcurrentLinkedQueue`. It passes — now actually demonstrating the cache's thread-safety.

## Verification
- `AgentTest`, `AgentGrpcServiceTest`, `AgentHttpServiceTest`, `HttpClientCacheTest`: pass (incl. the now-genuinely-concurrent test)
- In-process harness tests (exercise the `writeResponsesToProxyUntilDisconnected` path end-to-end): pass
- Full unit suite (`make nh-tests`): pass
- `detekt`, `lintKotlinMain`, `lintKotlinTest`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)