### PR TITLE
Bump version from 3.2.0 to 3.2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ The `ConfigVals` class is auto-generated from the HOCON schema using tscfg (`mak
 `group` and `version` live in `gradle.properties` (single source of truth). The version can be overridden on the command line for CI snapshot publishing:
 
 ```bash
-./gradlew build -PoverrideVersion=3.2.0-SNAPSHOT
+./gradlew build -PoverrideVersion=3.2.1-SNAPSHOT
 ```
 
 `-PoverrideVersion` keeps its `override` prefix because it intentionally only applies when supplied (so the `gradle.properties` default is never accidentally cleared).
@@ -186,7 +186,7 @@ Repository declarations are centralized in `settings.gradle.kts` via `dependency
 
 Snapshot and Maven Central release Make targets (`publish-snapshot`, `publish-maven-central`) require GPG environment variables and a keychain password entry; `make check-gpg-env` validates them up-front.
 
-When bumping the version, update `version` in `gradle.properties` and the `3.2.0` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
+When bumping the version, update `version` in `gradle.properties` and the `3.2.1` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ If you prefer to build the project from source:
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.2.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.2.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.2.0
+  pambrose/prometheus-agent:3.2.1
 ```
 
 ## 📋 Configuration Examples
@@ -229,8 +229,8 @@ scrape_configs:
 The docker images support multiple architectures (amd64, arm64, s390x, ppc64le):
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.2.0
-docker pull pambrose/prometheus-agent:3.2.0
+docker pull pambrose/prometheus-proxy:3.2.1
+docker pull pambrose/prometheus-agent:3.2.1
 ```
 
 ### Production Docker Setup
@@ -243,7 +243,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50051:50051 -p 8080:8080 \
         --env ADMIN_ENABLED=true \
         --env METRICS_ENABLED=true \
         --restart unless-stopped \
-        pambrose/prometheus-proxy:3.2.0
+        pambrose/prometheus-proxy:3.2.1
 ```
 
 Start an agent container with:
@@ -253,7 +253,7 @@ Start an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
         --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
         --restart unless-stopped \
-        pambrose/prometheus-agent:3.2.0
+        pambrose/prometheus-agent:3.2.1
 ```
 
 Or use docker-compose: see `etc/compose/proxy.yml` for a working example.
@@ -274,7 +274,7 @@ is in your current directory, run an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
     --env AGENT_CONFIG=prom-agent.conf \
-    pambrose/prometheus-agent:3.2.0
+    pambrose/prometheus-agent:3.2.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -536,7 +536,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50440:50440 -p 8080:8080 \
     --env PROXY_CONFIG=tls-no-mutual-auth.conf \
     --env ADMIN_ENABLED=true \
     --env METRICS_ENABLED=true \
-    pambrose/prometheus-proxy:3.2.0
+    pambrose/prometheus-proxy:3.2.1
 
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/testing/certs,target=/app/testing/certs \
@@ -544,7 +544,7 @@ docker run --rm -p 8083:8083 -p 8093:8093 \
     --env AGENT_CONFIG=tls-no-mutual-auth.conf \
     --env PROXY_HOSTNAME=mymachine.lan:50440 \
     --name docker-agent \
-    pambrose/prometheus-agent:3.2.0
+    pambrose/prometheus-agent:3.2.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -683,7 +683,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.2.0")
+  implementation("com.pambrose:prometheus-proxy:3.2.1")
 }
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@ by hand.
 
 1) Bump `version` in `gradle.properties` (the single source of truth).
 
-2) Update the `3.2.0` literals in `README.md` and `llms.txt` (the Docker tag examples and the Maven
+2) Update the `3.2.1` literals in `README.md` and `llms.txt` (the Docker tag examples and the Maven
    Central dependency block) to the new version.
 
 3) Update `CHANGELOG.md` and `RELEASE_NOTES.md` with the changes in this release.
@@ -24,8 +24,8 @@ by hand.
    entry it checks. To publish a snapshot instead, use `make publish-snapshot`.
 
 7) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases):
-   - **Tag**: the version with no `v` prefix (e.g. `3.2.0`).
-   - **Title**: the version with a `v` prefix (e.g. `v3.2.0`).
+   - **Tag**: the version with no `v` prefix (e.g. `3.2.1`).
+   - **Title**: the version with a `v` prefix (e.g. `v3.2.1`).
    - **Description**: summarize the changes and include a full-changelog link
      (e.g. `**Full Changelog**: https://github.com/pambrose/prometheus-proxy/compare/<prev>...<new>`).
    - Attach `build/libs/prometheus-agent.jar` and `build/libs/prometheus-proxy.jar`.

--- a/etc/compose/proxy.yml
+++ b/etc/compose/proxy.yml
@@ -1,6 +1,6 @@
 prometheus-proxy:
   autoredeploy: true
-  image: 'pambrose/prometheus-proxy:3.2.0'
+  image: 'pambrose/prometheus-proxy:3.2.1'
   ports:
     - '8080:8080'
     - '8082:8082'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle settings
 group=com.pambrose
-version=3.2.0
+version=3.2.1
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/llms.txt
+++ b/llms.txt
@@ -88,12 +88,12 @@ java -jar prometheus-agent.jar --proxy mymachine.local --config myapps.conf
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.2.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:3.2.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.2.0
+  pambrose/prometheus-agent:3.2.1
 ```
 
 ## Configuration
@@ -197,7 +197,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.2.0")
+  implementation("com.pambrose:prometheus-proxy:3.2.1")
 }
 ```
 

--- a/src/test/kotlin/website/DockerExamples.txt
+++ b/src/test/kotlin/website/DockerExamples.txt
@@ -1,14 +1,14 @@
 ; --8<-- [start:docker-proxy-basic]
 # Start a proxy container:
 docker run --rm -p 8080:8080 -p 50051:50051 \
-  pambrose/prometheus-proxy:3.2.0
+  pambrose/prometheus-proxy:3.2.1
 ; --8<-- [end:docker-proxy-basic]
 
 ; --8<-- [start:docker-agent-basic]
 # Start an agent with a remote config:
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:3.2.0
+  pambrose/prometheus-agent:3.2.1
 ; --8<-- [end:docker-agent-basic]
 
 ; --8<-- [start:docker-proxy-production]
@@ -21,7 +21,7 @@ docker run --rm \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
   --restart unless-stopped \
-  pambrose/prometheus-proxy:3.2.0
+  pambrose/prometheus-proxy:3.2.1
 ; --8<-- [end:docker-proxy-production]
 
 ; --8<-- [start:docker-agent-local-config]
@@ -31,7 +31,7 @@ docker run --rm \
   -p 8093:8093 \
   --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
   --env AGENT_CONFIG=prom-agent.conf \
-  pambrose/prometheus-agent:3.2.0
+  pambrose/prometheus-agent:3.2.1
 ; --8<-- [end:docker-agent-local-config]
 
 ; --8<-- [start:docker-compose-full]
@@ -39,7 +39,7 @@ version: '3.8'
 
 services:
   proxy:
-    image: pambrose/prometheus-proxy:3.2.0
+    image: pambrose/prometheus-proxy:3.2.1
     ports:
       - "8080:8080"    # HTTP scrape port
       - "50051:50051"  # gRPC agent port
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   agent:
-    image: pambrose/prometheus-agent:3.2.0
+    image: pambrose/prometheus-agent:3.2.1
     ports:
       - "8083:8083"    # Metrics port
       - "8093:8093"    # Admin port
@@ -81,7 +81,7 @@ docker run --rm \
   --env PROXY_CONFIG=tls.conf \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
-  pambrose/prometheus-proxy:3.2.0
+  pambrose/prometheus-proxy:3.2.1
 
 # Agent with TLS (no mutual auth):
 docker run --rm \
@@ -91,7 +91,7 @@ docker run --rm \
   --mount type=bind,source="$(pwd)"/tls.conf,target=/app/tls.conf \
   --env AGENT_CONFIG=tls.conf \
   --env PROXY_HOSTNAME=proxy-host:50440 \
-  pambrose/prometheus-agent:3.2.0
+  pambrose/prometheus-agent:3.2.1
 ; --8<-- [end:docker-tls]
 
 ; --8<-- [start:docker-env-vars]

--- a/src/test/kotlin/website/EmbeddedAgentExamples.txt
+++ b/src/test/kotlin/website/EmbeddedAgentExamples.txt
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:3.2.0")
+  implementation("com.pambrose:prometheus-proxy:3.2.1")
 }
 // --8<-- [end:gradle-dependency]
 
@@ -15,7 +15,7 @@ dependencies {
   <dependency>
     <groupId>com.pambrose</groupId>
     <artifactId>prometheus-proxy</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
   </dependency>
 </dependencies>
 <!-- --8<-- [end:maven-dependency] -->

--- a/src/test/kotlin/website/KubernetesExamples.txt
+++ b/src/test/kotlin/website/KubernetesExamples.txt
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: proxy
-          image: pambrose/prometheus-proxy:3.2.0
+          image: pambrose/prometheus-proxy:3.2.1
           ports:
             - { name: http, containerPort: 8080 }     # Prometheus scrapes here
             - { name: grpc, containerPort: 50051 }     # agents connect here
@@ -110,7 +110,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: pambrose/prometheus-agent:3.2.0
+          image: pambrose/prometheus-agent:3.2.1
           ports:
             - { name: metrics, containerPort: 8083 }
             - { name: admin, containerPort: 8093 }
@@ -163,7 +163,7 @@ spec:
           ports:
             - { name: metrics, containerPort: 9100 }
         - name: prometheus-agent
-          image: pambrose/prometheus-agent:3.2.0
+          image: pambrose/prometheus-agent:3.2.1
           env:
             - { name: PROXY_HOSTNAME, value: "proxy.example.com:50051" }
             - { name: AGENT_CONFIG, value: /app/agent.conf }

--- a/website/prometheus-proxy/docs/docker.md
+++ b/website/prometheus-proxy/docs/docker.md
@@ -7,8 +7,8 @@ icon: lucide/container
 Multi-platform images (amd64, arm64, s390x, ppc64le) are published on Docker Hub for every release.
 
 ```bash
-docker pull pambrose/prometheus-proxy:3.2.0
-docker pull pambrose/prometheus-agent:3.2.0
+docker pull pambrose/prometheus-proxy:3.2.1
+docker pull pambrose/prometheus-agent:3.2.1
 ```
 
 ## Basic Usage
@@ -77,4 +77,4 @@ docker pull pambrose/prometheus-agent:latest
 
 !!! tip "Pin versions in production"
 
-    Use explicit version tags (e.g., `3.2.0`) in production to avoid unexpected upgrades.
+    Use explicit version tags (e.g., `3.2.1`) in production to avoid unexpected upgrades.

--- a/website/prometheus-proxy/docs/getting-started.md
+++ b/website/prometheus-proxy/docs/getting-started.md
@@ -31,8 +31,8 @@ icon: lucide/play
     Multi-platform images (amd64, arm64, s390x) are available on Docker Hub:
 
     ```bash
-    docker pull pambrose/prometheus-proxy:3.2.0
-    docker pull pambrose/prometheus-agent:3.2.0
+    docker pull pambrose/prometheus-proxy:3.2.1
+    docker pull pambrose/prometheus-agent:3.2.1
     ```
 
 ## Start the Proxy
@@ -54,7 +54,7 @@ The proxy runs outside the firewall alongside your Prometheus server.
 
     ```bash
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.2.0
+      pambrose/prometheus-proxy:3.2.1
     ```
 
 ## Start the Agent
@@ -108,7 +108,7 @@ Each entry in `pathConfigs` maps:
       --mount type=bind,source="$(pwd)"/agent.conf,target=/app/agent.conf \
       --env AGENT_CONFIG=agent.conf \
       --env PROXY_HOSTNAME=proxy-host.example.com \
-      pambrose/prometheus-agent:3.2.0
+      pambrose/prometheus-agent:3.2.1
     ```
 
 === "Remote Config"

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -70,12 +70,12 @@ Get running in under a minute:
     ```bash
     # Start the proxy
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:3.2.0
+      pambrose/prometheus-proxy:3.2.1
 
     # Start the agent
     docker run --rm \
       --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-      pambrose/prometheus-agent:3.2.0
+      pambrose/prometheus-agent:3.2.1
     ```
 
 See the [Quick Start Guide](getting-started.md) for detailed instructions.


### PR DESCRIPTION
## Summary

Bumps the project version from **3.2.0** to **3.2.1**.

Updates `version` in `gradle.properties` (the single source of truth) along with every current-version reference across the repo:

- **Docker image tags + Maven Central coordinates** in `README.md` and `llms.txt`
- **`etc/compose/proxy.yml`** image tag
- **Website docs** — `index.md`, `getting-started.md`, `docker.md`
- **Website snippet sources** — `DockerExamples.txt`, `KubernetesExamples.txt`, `EmbeddedAgentExamples.txt`
- **Version-literal examples** in `docs/RELEASE.md` and `CLAUDE.md` (including the `-PoverrideVersion=3.2.1-SNAPSHOT` example)

## Intentionally left at 3.2.0

These reference 3.2.0 as a historical fact, not the current version, so they were not changed:

- `CHANGELOG.md` / `RELEASE_NOTES.md` — historical release entries
- `troubleshooting.md` ("3.2.0 or newer") and `cli-reference.md` ("removed in 3.2.0") — accurate statements about when a fix/removal landed

## Notes

- No `## [3.2.1]` section was added to `CHANGELOG.md`/`RELEASE_NOTES.md` yet — there's no release content to describe.
- Unrelated working-tree changes (`ContainersScalingTest.kt`, `docs/DOCKER_TESTING_SETUP.md`) were deliberately excluded from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)