### PR TITLE
Cap scaling-test container memory and scale it to the Docker VM

### DIFF
--- a/docs/DOCKER_TESTING_SETUP.md
+++ b/docs/DOCKER_TESTING_SETUP.md
@@ -1,0 +1,117 @@
+# Docker Host Setup for the Container Tests
+
+The Testcontainers end-to-end suite (`io.prometheus.containers.*`, run via `make container-tests`,
+`make scaling-tests`, and the `make scaling-*` presets) stands up many JVM containers at once. The
+**heavy scaling presets need more RAM than a stock Docker Desktop install allocates**, so a new machine
+must bump the Docker VM's memory before those targets will pass. This document explains why, what to
+change, and how to verify it.
+
+For everything else about the test suite, see [`TESTING.md`](TESTING.md).
+
+## Why the default is not enough
+
+Each proxy and agent container is a JVM. Testcontainers does **not** set a per-container memory limit by
+default, so an uncapped JVM sizes its max heap to **25% of the Docker VM's RAM** (`-XX:MaxRAMPercentage=25`)
+— about **2 GiB per JVM on a stock 8 GB Docker Desktop VM**.
+
+The connection-stress presets fan out to dozens of JVMs at once. `make scaling-agents`, for example,
+starts **~81 containers**: 40 agents + 40 nginx stubs + 1 proxy (**41 JVMs**). With uncapped 2 GiB heaps
+that is ~80 GiB of potential heap on an 8 GB VM, so the VM is wildly over-committed and the Linux
+OOM-killer inside the VM reaps the proxy mid-scrape. The symptom in the test output is:
+
+```
+the server prematurely closed the connection      # proxy under memory pressure
+...
+java.net.ConnectException: Connection refused      # proxy container was OOM-killed
+```
+
+`ContainersScalingTest` now caps each container's memory so the JVMs auto-size their heaps to the cgroup
+limit instead of the host's RAM (see [How the test adapts](#how-the-test-adapts-to-the-vm-size) below), but
+the cap is still divided across all the agents — so the **size of the Docker VM sets how comfortably the big
+presets run**.
+
+## Recommended Docker VM memory
+
+| Workload | Make target(s) | Docker VM memory |
+|----------|----------------|------------------|
+| Default suite (1–2 agents per scenario) | `make container-tests`, `make all-tests` | **8 GB** (the Docker Desktop default) is fine |
+| Connection / fan-out stress (40+ agents) | `make scaling-agents`, `make scaling-soak`, `make all-scaling` | **16 GB recommended** |
+| Everything, comfortably | all of the above | **16 GB** |
+
+CPUs and disk: the defaults are fine. The container suite is memory-bound, not CPU-bound; any modern
+multi-core allocation works.
+
+## Configuring a new machine
+
+### Option A — Docker Desktop GUI (simplest)
+
+1. Open **Docker Desktop → Settings (gear icon) → Resources**.
+2. Set **Memory limit** to **16 GB** (slide the **Memory** slider).
+3. Click **Apply & restart** and wait for Docker to come back up.
+
+### Option B — settings file + restart (scriptable / headless)
+
+Docker Desktop on macOS stores its settings in
+`~/Library/Group Containers/group.com.docker/settings-store.json`. Add (or edit) the `MemoryMiB` key —
+the value is in MiB, so 16 GiB = `16384`:
+
+```jsonc
+{
+  // …existing keys…
+  "MemoryMiB": 16384,
+  // …existing keys…
+}
+```
+
+> The current `settings-store.json` uses PascalCase keys (`AnalyticsEnabled`, `SettingsVersion`, …); the
+> memory key matching that format is **`MemoryMiB`**. (Older Docker Desktop versions used a `settings.json`
+> with a camelCase `memoryMiB` — if your install still uses that file, use the camelCase form there.)
+
+Then restart Docker Desktop for the change to take effect (this stops any running containers):
+
+```bash
+osascript -e 'quit app "Docker"'   # or: killall Docker
+open -a Docker
+```
+
+### Verify
+
+After the GUI apply-and-restart or the file edit + restart, confirm the new allocation:
+
+```bash
+docker info --format '{{.MemTotal}}' | awk '{printf "%.2f GiB\n", $1/1073741824}'
+# e.g. 15.60 GiB  (16384 MiB minus a small amount of VM overhead)
+```
+
+A 16384 MiB setting reports as ~15.6 GiB because the VM reserves a little for itself — that is expected.
+
+## How the test adapts to the VM size
+
+`ContainersScalingTest` reads the Docker VM's memory at runtime and gives each proxy/agent container an
+explicit memory limit, so the cap **scales to whatever host runs it** — no per-machine code edits:
+
+- The proxy gets a fixed, generous cap.
+- The remaining ~70% of the VM is divided across the agents, clamped to a workable per-agent range.
+
+So the same `make scaling-agents` run that gets ~160 MiB per agent on an 8 GB VM gets ~266 MiB per agent on
+a 16 GB VM — enough headroom that a connected, actively-scraped agent does not GC-thrash. (If an agent is
+squeezed too tight it can stall, drop its heartbeat stream, and have its paths evicted by the proxy; a
+scrape of that path then returns `404`. More VM memory removes that risk.)
+
+The logic lives in `ContainersScalingTest.kt` (`dockerVmMib`, `agentMemoryMib()`, `withMemoryMib()`). The
+only thing the host must provide is enough total RAM; the test sizes the per-container caps from it.
+
+## Prerequisites checklist for a new machine
+
+- [ ] Docker Desktop (or a Docker engine) installed and running.
+- [ ] Docker VM memory set to **16 GB** for the heavy scaling presets (see above); 8 GB is fine for the
+      default `make container-tests`.
+- [ ] `docker info` succeeds (the Makefile auto-detects `DOCKER_HOST` from the active Docker context).
+- [ ] The fat JARs build (`make container-tests` / `make scaling-tests` build them first via the `jars` target).
+
+Then:
+
+```bash
+make container-tests   # full end-to-end suite (8 GB OK)
+make scaling-agents    # 40-agent connection-stress preset (16 GB recommended)
+```

--- a/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
+++ b/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.wait.strategy.Wait
@@ -68,12 +69,13 @@ class ContainersScalingTest : StringSpec() {
         val client = httpClient()
         val stubs = mutableListOf<GenericContainer<*>>()
         val agents = mutableListOf<GenericContainer<*>>()
+        val agentMemMib = s.agentMemoryMib()
         val proxy =
           proxyContainer(
             network,
             env = mapOf("METRICS_ENABLED" to "true"),
             exposedPorts = listOf(PROXY_HTTP_PORT, PROXY_METRICS_PORT),
-          )
+          ).withMemoryMib(PROXY_MEM_MIB)
         try {
           // --- unique-path agents (dimensions: agents × endpoints, payload size) ---
           for (a in 0 until s.agentCount) {
@@ -94,7 +96,7 @@ class ContainersScalingTest : StringSpec() {
                 alias = "scale-agent-a$a",
                 configText = agentConfig("scale-agent-a$a", stubAlias, entries),
                 waitTimes = s.endpointsPerAgent,
-              )
+              ).withMemoryMib(agentMemMib)
           }
 
           // --- consolidated fan-out agents (K agents share one path) ---
@@ -111,7 +113,7 @@ class ContainersScalingTest : StringSpec() {
                 configText =
                   agentConfig("scale-cons-agent-$k", stubAlias, listOf(CONSOLIDATED_PATH to "c"), consolidated = true),
                 waitLogRegex = ".*Registered .* as /$CONSOLIDATED_PATH.*",
-              )
+              ).withMemoryMib(agentMemMib)
           }
 
           stubs.forEach { it.start() }
@@ -189,6 +191,47 @@ data class ScalingScenario(
 
 private const val SCALE_SENTINEL = "scale_sentinel"
 private const val CONSOLIDATED_PATH = "scale_consolidated"
+
+// --- container memory caps -----------------------------------------------------------------------
+// Testcontainers sets no cgroup memory limit, so an uncapped JVM container sizes its max heap to 25%
+// of the *Docker VM's* RAM (≈2 GiB on a stock 8 GB Desktop VM). The connection-stress presets fan out
+// to 40+ agent JVMs, so the uncapped heaps over-commit the VM and the kernel OOM-kills the proxy
+// mid-scrape (the failure shows up as "server prematurely closed the connection" → "Connection
+// refused"). Giving each JVM container an explicit memory limit makes the JVM auto-size its heap to
+// the cgroup limit instead, so the whole fan-out fits the host.
+//
+// The cap must also be large enough that a connected, actively-scraped agent does not GC-thrash: too
+// tight (≈ its working set) and the agent stalls, drops its heartbeat stream, and the proxy evicts its
+// paths — a scrape then 404s. So the budget is a fraction of the *actual* Docker VM, divided across the
+// agents and clamped to a workable range: a 40-agent fan-out on an 8 GB VM lands near the floor, the
+// same fan-out on a 16 GB VM gets roomy headroom, and a few-agent / large-payload preset gets ample heap.
+private const val BYTES_PER_MIB = 1024L * 1024L
+private const val PROXY_MEM_MIB = 512L
+private const val AGENT_MIN_MEM_MIB = 160L
+private const val AGENT_MAX_MEM_MIB = 768L
+
+/** Fraction of the Docker VM to hand to all proxy + agent JVMs; the rest covers the per-agent nginx
+ *  stubs and Docker overhead. */
+private const val VM_BUDGET_PERCENT = 70L
+
+/** Fallback Docker VM size (MiB) when the daemon can't be queried — a stock 8 GB Docker Desktop VM. */
+private const val DEFAULT_VM_MIB = 8L * 1024L
+
+/** Docker VM RAM (MiB), read once; the per-agent cap scales to this so the fan-out fits whatever host runs it. */
+private val dockerVmMib: Long by lazy {
+  runCatching { DockerClientFactory.instance().client().infoCmd().exec().memTotal }
+    .getOrNull()?.div(BYTES_PER_MIB) ?: DEFAULT_VM_MIB
+}
+
+/** Per-agent container memory cap: the non-proxy share of the VM budget split across every agent, clamped
+ *  to a range frugal enough for a big fan-out yet large enough for the chunking/gzip payload presets. */
+private fun ScalingScenario.agentMemoryMib(): Long =
+  ((dockerVmMib * VM_BUDGET_PERCENT / 100 - PROXY_MEM_MIB) / totalAgents.coerceAtLeast(1))
+    .coerceIn(AGENT_MIN_MEM_MIB, AGENT_MAX_MEM_MIB)
+
+/** Pin a JVM container's memory so its heap auto-sizes to the cgroup limit instead of 25% of host RAM. */
+private fun GenericContainer<*>.withMemoryMib(mib: Long): GenericContainer<*> =
+  apply { withCreateContainerCmdModifier { cmd -> cmd.hostConfig?.withMemory(mib * BYTES_PER_MIB) } }
 
 private fun intEnv(
   name: String,


### PR DESCRIPTION
## Summary

`make scaling-agents` and the other many-agent scaling presets failed because the Testcontainers JVMs run with no memory limit, so each sized its max heap to 25% of the Docker VM RAM (~2 GiB on a stock 8 GB VM). The ~41 JVMs over-committed the VM and the kernel OOM-killed the proxy mid-scrape (`server prematurely closed the connection` → `Connection refused`).

## Changes

- **`ContainersScalingTest`** — give each proxy/agent container an explicit cgroup memory limit so the JVM auto-sizes its heap to the limit instead of 25% of host RAM. The per-agent cap is 70% of the *actual* Docker VM memory (read at runtime via `DockerClientFactory`), divided across the agents and clamped to `[160, 768]` MiB. This fits an 8 GB VM and gives comfortable headroom on a 16 GB VM, avoiding the GC-thrash → heartbeat-drop → path-eviction (`404`) failure seen when agents are squeezed too tight.
- **`docs/DOCKER_TESTING_SETUP.md`** — new guide covering the Docker VM memory the container/scaling tests need and how to configure it on a new machine (Docker Desktop GUI + `settings-store.json`), with verification steps.

## Validation

`make scaling-agents` (40 agents × 2 endpoints, ~81 containers) now passes:
- Peak ~7.5 GiB of a 16 GiB VM, agents at ~70% of their cap (was 92–93% when squeezed), zero OOM events.
- Compiles clean; `detekt` + `lintKotlinTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
