### PR TITLE
Improve pre-release version detection and bump utils to 2.9.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -393,20 +393,19 @@ fun Project.configureCoverage() {
 }
 
 fun Project.configureVersions() {
-  val unstableQualifiers = listOf("-RC", "-BETA", "-ALPHA", "-M")
+  // A pre-release qualifier is a `.` or `-` delimiter followed by a known unstable
+  // keyword. `m\d` matches milestones (`-M1`/`.M2`) without catching stable classifiers
+  // like `-macos`/`-MR1`, and the `[.-]` delimiter catches both dash-style (`-alpha`)
+  // and dot-style (Netty's `.Beta1`) qualifiers while leaving `-jre`/`.Final` stable.
+  val preReleaseQualifier =
+    Regex("""[.-](rc|beta|alpha|m\d|cr|snapshot|eap|dev|milestone|pre)""", RegexOption.IGNORE_CASE)
 
-  /**
-   * Returns `true` if [version] contains a pre-release qualifier (RC, BETA, ALPHA, or M).
-   */
-  fun isNonStable(version: String): Boolean {
-    val upper = version.uppercase()
-    return unstableQualifiers.any { it in upper }
-  }
+  fun isNonStable(version: String): Boolean = preReleaseQualifier.containsMatchIn(version)
 
-  tasks.withType<DependencyUpdatesTask> {
+  tasks.withType<DependencyUpdatesTask>().configureEach {
     notCompatibleWithConfigurationCache("the dependency updates plugin is not compatible with the configuration cache")
     // Reject a pre-release candidate only when the current version is stable. For
-    // dependencies, we intentionally track on a pre-release line (e.g. a detekt
+    // dependencies we intentionally track on a pre-release line (e.g. a detekt
     // alpha), newer pre-releases are still surfaced as available updates.
     rejectVersionIf {
       isNonStable(candidate.version) && !isNonStable(currentVersion)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "2.9.2"
+utils = "2.9.3"
 
 # Misc
 annotation = "1.3.2"


### PR DESCRIPTION
## Summary

- Replace the substring-based `isNonStable()` check in `configureVersions()` with a regex that only matches known unstable qualifiers (`rc`, `beta`, `alpha`, `m<digit>`, `cr`, `snapshot`, `eap`, `dev`, `milestone`, `pre`) when preceded by a `.` or `-` delimiter. This fixes false positives where stable classifiers like `-macos` or `.Final` were misclassified as pre-releases (a gap flagged in the prior code review).
- Match both dash-style (`-alpha`) and dot-style (Netty's `.Beta1`) qualifiers, while leaving `-jre`/`.Final` recognized as stable.
- Migrate the `DependencyUpdatesTask` configuration from `withType<...> {}` to `withType<...>().configureEach {}` for lazy configuration.
- Bump `common-utils` from `2.9.2` to `2.9.3`.

## Test plan

- [ ] `./gradlew detekt && ./gradlew lintKotlinMain && ./gradlew build -xtest`
- [ ] `./gradlew dependencyUpdates` surfaces newer pre-releases only when the current version is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)