### PR TITLE
Split docs workflow into separate build and deploy jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Build the docs site + KDocs and upload the Pages artifact. Kept separate from
+  # the deploy job so that recovering a failed deploy means re-running only the
+  # deploy job (via "Re-run failed jobs"), which does NOT re-upload the artifact.
+  # actions/deploy-pages hard-fails when a run contains more than one artifact
+  # named "github-pages", which is what re-running a combined build+deploy job did.
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/configure-pages@v5
@@ -48,5 +50,16 @@ jobs:
       - uses: actions/upload-pages-artifact@v4
         with:
           path: website/prometheus-proxy/site
+
+  # Deploy the artifact produced by the build job. Deliberately minimal (no
+  # checkout or build) so re-running just this job re-deploys the existing
+  # artifact without rebuilding or re-uploading it.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Summary

Harden the `Documentation` GitHub Pages workflow by splitting its single combined job into a `build` job and a `deploy` job.

**Why:** recovering a failed Pages deploy by re-running the previous single build+deploy job re-ran `upload-pages-artifact`, uploading a *second* `github-pages` artifact into the run. `actions/deploy-pages@v4` scans artifacts across the whole run and hard-fails when it finds more than one:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

This was hit while recovering from an unrelated transient GitHub Pages backend failure (`Deployment failed, try again later`) on the PR #193 merge.

## Changes

- **`build` job** — checkout, Zensical build, Dokka/KDoc generation, copy KDocs into the site, and `upload-pages-artifact`. `configure-pages` stays here since it can influence the build.
- **`deploy` job** — `needs: build`, carries the `github-pages` environment block, and runs only `deploy-pages`. No checkout/build/upload.

A transient deploy failure can now be recovered with **"Re-run failed jobs"**, which re-runs only `deploy` and re-uses the existing artifact instead of uploading a duplicate.

Triggers, top-level permissions, the `pages` concurrency group, action versions, and the pinned toolchain versions are all unchanged.

## Note

This makes the **"Re-run failed jobs"** path safe. Using **"Re-run all jobs"** still re-runs `build` and can re-introduce a duplicate artifact across attempts — for a failed deploy, use "Re-run failed jobs" or a fresh `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)