### PR TITLE
Harden harness scrape-test timeouts against CPU contention

### DIFF
--- a/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
+++ b/src/test/kotlin/io/prometheus/harness/HarnessConfig.kt
@@ -50,7 +50,10 @@ enum class HarnessConfig(
     parallelQueryCount = 10,
     concurrentClients = 100,
     addRemoveReps = 1000,
-    proxyCallTimeoutSecs = 60,
+    // 1000 sequential scrapes take ~29s on an idle machine; under full-suite/CI CPU
+    // contention that can more than double. 150s leaves ~5x headroom over the isolated
+    // baseline so the phase no longer brushes its own withTimeout ceiling under load.
+    proxyCallTimeoutSecs = 150,
   ),
   LARGE(
     httpServerCount = 10,

--- a/src/test/kotlin/io/prometheus/harness/support/AbstractHarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/AbstractHarnessTests.kt
@@ -18,11 +18,23 @@ package io.prometheus.harness.support
 
 import com.pambrose.common.util.simpleClassName
 import io.kotest.core.spec.style.StringSpec
+import io.prometheus.harness.HarnessConstants.HARNESS_CONFIG
+import kotlin.time.Duration.Companion.seconds
 
 abstract class AbstractHarnessTests(
   private val argsProvider: () -> ProxyCallTestArgs,
 ) : StringSpec() {
   init {
+    // proxyCallTest runs a sequential and a parallel scrape phase, each guarded by
+    // withTimeout(HARNESS_CONFIG.proxyCallTimeoutSecs). Kotest's per-invocation timeout
+    // defaults to 60s, which would fire before the code's own guard under load — and it
+    // silently caps the LARGE+ configs, whose 120-480s budgets could otherwise never run.
+    // Raise the spec-level ceilings above the sum of both phases so the code's withTimeout
+    // stays the real limit (and failures surface with its message, not a Kotest cutoff).
+    val harnessTimeoutMillis = ((HARNESS_CONFIG.proxyCallTimeoutSecs * 2) + 60).seconds.inWholeMilliseconds
+    timeout = harnessTimeoutMillis
+    invocationTimeout = harnessTimeoutMillis
+
     "should scrape metrics through proxy" {
       HarnessTests.proxyCallTest(argsProvider())
     }


### PR DESCRIPTION
## Problem

The `should scrape metrics through proxy` harness test (in `AbstractHarnessTests`, exercised by the InProcess/Netty/TLS specs) intermittently fails under load with:

```
kotlinx.coroutines.TimeoutCancellationException: Coroutine "spec-scope-…" timed out waiting for 60000 ms
    at io.prometheus.harness.support.HarnessTests$proxyCallTest…(HarnessTests.kt:222)
```

## Root cause

The test runs **1000 sequential scrapes** (the default `MEDIUM` config) bounded by **two coincident 60-second ceilings**:

1. The code's own `withTimeout(HARNESS_CONFIG.proxyCallTimeoutSecs.seconds)` — `MEDIUM.proxyCallTimeoutSecs = 60`
2. Kotest's **default 60s per-invocation timeout** (the one that actually fires in the stack trace)

Measured on an idle machine, the sequential phase takes **~29s against the 60s budget** — only ~2× headroom. Under full-suite / CI CPU contention a ~2× throughput drop is routine, so the phase occasionally crosses 60s. This is pre-existing timing sensitivity (not tied to any dependency version) and it's why the failure is intermittent.

## Fix

- Raise `MEDIUM.proxyCallTimeoutSecs` **60 → 150** — ~5× headroom over the observed ~29s baseline.
- Raise the spec-level Kotest `timeout` / `invocationTimeout` in `AbstractHarnessTests` to `(proxyCallTimeoutSecs * 2) + 60s`, derived from the active config, so the code's own `withTimeout` stays the real ceiling and a genuine slowdown fails with *its* message instead of a raw Kotest cutoff.

This second change also fixes a **latent bug**: Kotest's 60s default was silently capping the `LARGE`/`XLARGE`/`XXLARGE` configs, whose declared 120–480s `withTimeout` budgets could never actually take effect through this path.

## Verification

- Proxy-call timeout now logs `2m 30s`; sequential phase completes in ~33s.
- `TlsNoMutualAuthTest` (all 7) and `InProcessTestNoAdminMetricsTest` (all 7) pass.
- Compiles against master's dependency set; `detekt` and `lintKotlinTest` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)