### PR TITLE
Bump dependencies (utils 3.2.0, Kotlin 2.4.10, gRPC, Shadow, Kotest, logback)

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.4.0" />
+    <option name="version" value="2.4.10" />
   </component>
 </project>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,11 +172,11 @@ Documentation is built with [Zensical](https://zensical.org) (static site genera
 
 Snippets use dual `base_path` in zensical.toml: first resolves `.txt` files from `src/test/kotlin/website/`, second resolves project-root files like `examples/*.conf`.
 
-## Shadow JAR Workaround
+## Shadow JAR Service-File Merging
 
-The `agentJar` and `proxyJar` ShadowJar tasks include `src/shadow/resources/META-INF/services/` to re-register `io.grpc.NameResolverProvider` (DNS + UDS) and `io.grpc.LoadBalancerProvider` (PickFirst + HealthCheckingRoundRobin). Shadow 9.4.2's `mergeServiceFiles()` (and its `append()` transformer) silently drop entries when grpc-core and grpc-netty-shaded both ship a same-named service file, leaving the fat JAR without a DNS resolver — the gRPC client then defaults to the `unix` scheme on any non-IP hostname. The static files keep the providers registered without affecting the published Maven jar (they're under `src/shadow/`, not `src/main/`).
+ShadowJar's default `DuplicatesStrategy` (EXCLUDE) drops duplicate-named entries *before* merging transformers run, so `mergeServiceFiles()` silently loses entries when grpc-core and grpc-netty-shaded both ship a same-named `META-INF/services` file — leaving the fat JAR without a DNS resolver, so the gRPC client defaults to the `unix` scheme on any non-IP hostname. The `agentJar`/`proxyJar` tasks fix this with a `filesMatching()` block that sets `DuplicatesStrategy.INCLUDE` on `META-INF/services/**` and `META-INF/*.kotlin_module` only (everything else keeps first-wins EXCLUDE semantics), letting `ServiceFileTransformer` and `KotlinModuleMetadataTransformer` merge all copies.
 
-If gRPC versions change provider class names or add new providers, update those files to match.
+As a belt-and-braces guard against future Shadow regressions, the tasks also include `src/shadow/resources/META-INF/services/`, which pins `io.grpc.NameResolverProvider` (DNS + UDS) and `io.grpc.LoadBalancerProvider` (PickFirst + HealthCheckingRoundRobin). The static files don't affect the published Maven jar (they're under `src/shadow/`, not `src/main/`). If gRPC versions change provider class names, update those files to match.
 
 ## Publishing
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,18 +233,25 @@ fun Project.configureJars() {
   val mainOutput = sourceSets.main.get().output
   val runtimeClasspath = configurations.runtimeClasspath
 
-  // shadow 9.4.2's mergeServiceFiles() silently drops entries when multiple JARs ship a
-  // same-named META-INF/services file (its append() transformer is broken the same way),
-  // so without intervention the fat JAR loses grpc-core's DnsNameResolverProvider and
-  // PickFirstLoadBalancerProvider and the gRPC client defaults to the `unix` scheme on
-  // any non-IP hostname. Static service files under src/shadow/resources re-register the
-  // missing providers; kept out of src/main/resources so the published Maven jar is clean.
+  // Under ShadowJar's default EXCLUDE duplicates strategy, mergeServiceFiles() loses
+  // entries when multiple JARs ship a same-named META-INF/services file — the fat JAR
+  // then lacks grpc-core's DnsNameResolverProvider and the gRPC client defaults to the
+  // `unix` scheme on any non-IP hostname. The filesMatching() block below fixes the
+  // merge itself; the static service files under src/shadow/resources additionally
+  // pin the critical grpc providers as a guard against future Shadow regressions.
+  // Kept out of src/main/resources so the published Maven jar is clean.
   val shadowResources = file("src/shadow/resources")
 
   fun ShadowJar.configureFatJar(archiveName: String, mainClass: String) {
     archiveFileName.set(archiveName)
     manifest { attributes("Main-Class" to mainClass) }
     mergeServiceFiles()
+    // ShadowJar's default DuplicatesStrategy (EXCLUDE) drops duplicate entries before the
+    // merging transformers run, so allow duplicates through on the transformer-matched
+    // paths only; everything else keeps first-wins EXCLUDE semantics.
+    filesMatching(listOf("META-INF/services/**", "META-INF/*.kotlin_module")) {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     from(mainOutput)
     from(shadowResources)
     configurations.add(runtimeClasspath)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.6.1"
 jvm = "17"
 
 # Kotlin
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 serialization = "1.11.0"
 
 # Build plugins
@@ -50,7 +50,7 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "3.1.0"
+utils = "3.2.0"
 
 # Misc
 annotation = "1.3.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,12 +15,12 @@ gradle-plugins = "1.1.0"
 kover = "0.9.8"
 maven-publish = "0.37.0"
 protobuf = "0.10.0"
-shadow = "9.4.3"
+shadow = "9.5.1"
 taskinfo = "3.0.2"
 versions = "0.54.0"
 
 # gRPC / Protobuf
-grpc = "1.82.1"
+grpc = "1.82.2"
 gengrpc = "1.5.0"
 # Keep in sync with grpc
 protoc = "3.25.3"
@@ -42,7 +42,7 @@ zipkin = "6.3.1"
 
 # Logging
 logging = "8.0.4"
-logback = "1.5.37"
+logback = "1.5.38"
 slf4j = "2.0.18"
 
 # Config / CLI
@@ -50,13 +50,13 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "2.9.3"
+utils = "3.0.0"
 
 # Misc
 annotation = "1.3.2"
 
 # Testing
-kotest = "6.2.1"
+kotest = "6.2.2"
 mockk = "1.14.11"
 testcontainers = "2.0.5"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "3.0.0"
+utils = "3.1.0"
 
 # Misc
 annotation = "1.3.2"

--- a/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
@@ -16,7 +16,8 @@
 
 package io.prometheus.harness.support
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
+import com.pambrose.common.dsl.KtorDsl
+import com.pambrose.common.dsl.blockingGet
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -39,7 +40,7 @@ internal object BasicHarnessTests {
     caller: String,
   ) {
     logger.debug { "Calling missingPathTest() from $caller" }
-    blockingGet("$proxyPort/".withPrefix()) { response ->
+    KtorDsl.blockingGet("$proxyPort/".withPrefix()) { response ->
       response.status shouldBe HttpStatusCode.NotFound
     }
   }
@@ -49,7 +50,7 @@ internal object BasicHarnessTests {
     caller: String,
   ) {
     logger.debug { "Calling invalidPathTest() from $caller" }
-    blockingGet("$proxyPort/invalid_path".withPrefix()) { response ->
+    KtorDsl.blockingGet("$proxyPort/invalid_path".withPrefix()) { response ->
       response.status shouldBe HttpStatusCode.NotFound
     }
   }
@@ -87,7 +88,7 @@ internal object BasicHarnessTests {
     logger.debug { "Calling invalidAgentUrlTest() from $caller" }
 
     pathManager.registerPath(badPath, "33/metrics".withPrefix())
-    blockingGet("$proxyPort/$badPath".withPrefix()) { response ->
+    KtorDsl.blockingGet("$proxyPort/$badPath".withPrefix()) { response ->
       // Invalid agent URL causes IOException, which should return ServiceUnavailable (503)
       response.status shouldBe HttpStatusCode.ServiceUnavailable
     }

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
@@ -18,7 +18,8 @@
 
 package io.prometheus.harness.support
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
+import com.pambrose.common.dsl.KtorDsl
+import com.pambrose.common.dsl.blockingGet
 import com.pambrose.common.dsl.KtorDsl.get
 import com.pambrose.common.dsl.KtorDsl.httpClient
 import com.pambrose.common.dsl.KtorDsl.withHttpClient
@@ -126,7 +127,7 @@ internal object HarnessTests {
     try {
       pathManager.registerPath("/$proxyPath", "$agentPort/$agentPath".withPrefix())
 
-      blockingGet("$proxyPort/$proxyPath".withPrefix()) { response ->
+      KtorDsl.blockingGet("$proxyPort/$proxyPath".withPrefix()) { response ->
         response.status shouldBe HttpStatusCode.RequestTimeout
       }
 

--- a/src/test/kotlin/io/prometheus/misc/AdminDefaultPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminDefaultPathTest.kt
@@ -18,7 +18,8 @@
 
 package io.prometheus.misc
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
+import com.pambrose.common.dsl.KtorDsl
+import com.pambrose.common.dsl.blockingGet
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
@@ -53,7 +54,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "proxy ping path should respond with pong" {
       proxyConfigVals.admin.apply {
-        blockingGet("$port/$pingPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$pingPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldStartWith "pong"
         }
@@ -62,7 +63,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "agent ping path should respond with pong" {
       agentConfigVals.admin.apply {
-        blockingGet("$port/$pingPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$pingPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldStartWith "pong"
         }
@@ -71,7 +72,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "proxy version path should return version info" {
       agentConfigVals.admin.apply {
-        blockingGet("$port/$versionPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$versionPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldContain "version"
         }
@@ -80,7 +81,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "agent version path should return version info" {
       agentConfigVals.admin.apply {
-        blockingGet("$port/$versionPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$versionPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldContain "version"
         }
@@ -89,7 +90,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "proxy health check path should return health status" {
       proxyConfigVals.admin.apply {
-        blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText().length shouldBeGreaterThan 10
         }
@@ -98,7 +99,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "agent health check path should return health status" {
       agentConfigVals.admin.apply {
-        blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText().length shouldBeGreaterThan 10
         }
@@ -107,7 +108,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "proxy thread dump path should return thread dump" {
       proxyConfigVals.admin.apply {
-        blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText().length shouldBeGreaterThan 10
         }
@@ -116,7 +117,7 @@ class AdminDefaultPathTest : StringSpec() {
 
     "agent thread dump path should return thread dump" {
       agentConfigVals.admin.apply {
-        blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText().length shouldBeGreaterThan 10
         }

--- a/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
@@ -18,7 +18,8 @@
 
 package io.prometheus.misc
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
+import com.pambrose.common.dsl.KtorDsl
+import com.pambrose.common.dsl.blockingGet
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
@@ -63,7 +64,7 @@ class AdminEmptyPathTest : StringSpec() {
         port shouldBe 8098
         pingPath shouldBe ""
 
-        blockingGet("$port/$pingPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$pingPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.NotFound
         }
       }
@@ -74,7 +75,7 @@ class AdminEmptyPathTest : StringSpec() {
         port shouldBe 8098
         versionPath shouldBe ""
 
-        blockingGet("$port/$versionPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$versionPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.NotFound
         }
       }
@@ -84,7 +85,7 @@ class AdminEmptyPathTest : StringSpec() {
       proxyConfigVals.admin.apply {
         healthCheckPath shouldBe ""
 
-        blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.NotFound
         }
       }
@@ -94,7 +95,7 @@ class AdminEmptyPathTest : StringSpec() {
       proxyConfigVals.admin.apply {
         threadDumpPath shouldBe ""
 
-        blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.NotFound
         }
       }

--- a/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
@@ -18,7 +18,8 @@
 
 package io.prometheus.misc
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
+import com.pambrose.common.dsl.KtorDsl
+import com.pambrose.common.dsl.blockingGet
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
@@ -67,7 +68,7 @@ class AdminNonDefaultPathTest : StringSpec() {
         port shouldBe 8099
         pingPath shouldBe "pingPath2"
 
-        blockingGet("$port/$pingPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$pingPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldStartWith "pong"
         }
@@ -79,7 +80,7 @@ class AdminNonDefaultPathTest : StringSpec() {
         port shouldBe 8099
         versionPath shouldBe "versionPath2"
 
-        blockingGet("$port/$versionPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$versionPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText() shouldContain "version"
         }
@@ -90,7 +91,7 @@ class AdminNonDefaultPathTest : StringSpec() {
       proxyConfigVals.admin.apply {
         healthCheckPath shouldBe "healthCheckPath2"
 
-        blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$healthCheckPath".withPrefix()) { response ->
           response.status shouldBe HttpStatusCode.OK
           response.bodyAsText().length shouldBeGreaterThan 10
         }
@@ -101,7 +102,7 @@ class AdminNonDefaultPathTest : StringSpec() {
       proxyConfigVals.admin.apply {
         threadDumpPath shouldBe "threadDumpPath2"
 
-        blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
+        KtorDsl.blockingGet("$port/$threadDumpPath".withPrefix()) { response ->
           response.bodyAsText().length shouldBeGreaterThan 10
         }
       }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
@@ -32,6 +32,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.Proxy
 import io.prometheus.grpc.RegisterAgentRequest
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.incrementAndFetch
 import io.kotest.matchers.maps.shouldHaveSize as mapShouldHaveSize
 
 @Suppress("LargeClass")
@@ -43,9 +45,14 @@ class ProxyPathManagerTest : StringSpec() {
     return proxy
   }
 
+  // Counter-based like AgentContext.AGENT_ID_GENERATOR; a timestamp+random id can collide
+  // when two mocks are created in the same millisecond, and duplicate agentIds make
+  // removeFromPathManager() drop every agent's registrations instead of one agent's.
+  private val agentIdCounter = AtomicLong(0L)
+
   private fun createMockAgentContext(consolidated: Boolean = false): AgentContext {
     val context = mockk<AgentContext>(relaxed = true)
-    val agentId = "agent-${System.currentTimeMillis()}-${(1..1000).random()}"
+    val agentId = "agent-${agentIdCounter.incrementAndFetch()}"
     every { context.agentId } returns agentId
     every { context.consolidated } returns consolidated
     every { context.isNotValid() } returns false


### PR DESCRIPTION
## Dependency bumps

| Dependency | From | To |
|---|---|---|
| common-utils | 2.9.3 | **3.2.0** (major) |
| Kotlin | 2.4.0 | 2.4.10 |
| gRPC | 1.82.1 | 1.82.2 |
| Shadow | 9.4.3 | 9.5.1 |
| Kotest | 6.2.1 | 6.2.2 |
| logback | 1.5.37 | 1.5.38 |

## Supporting changes

- **Shadow transformer merging fix** (`build.gradle.kts`): under ShadowJar's default `EXCLUDE` duplicates strategy, `mergeServiceFiles()` dropped duplicate `META-INF/services` entries before the merging transformers ran, leaving the fat JAR without grpc-core's DNS resolver (gRPC then defaults to the `unix` scheme on non-IP hostnames). A `filesMatching()` block now sets `DuplicatesStrategy.INCLUDE` on `META-INF/services/**` and `META-INF/*.kotlin_module` only, so the service-file and Kotlin-module transformers merge all copies. CLAUDE.md updated to match.
- **utils 3.x `KtorDsl` migration** (harness + admin tests): `blockingGet` moved from the `KtorDsl` object to a top-level JVM extension, so imports are disambiguated (`KtorDsl.blockingGet`). No behavioral change — the DSL functions are otherwise identical between versions.
- **`ProxyPathManagerTest` agentId-collision fix**: the mock agentId used `timestamp + random`, which can collide when two mocks are created in the same millisecond; duplicate agentIds made `removeFromPathManager()` drop every agent's registrations. Switched to a counter-based id, matching `AgentContext.AGENT_ID_GENERATOR`.

## Verification

- `detekt`, `kotlinter`, `build`, and the **full test suite** pass (unit + in-process/Netty/TLS harness).
- utils `ktor-client-utils` sources are identical 3.1.0 → 3.2.0 — no API changes affecting this project.

_Branch was rebased onto the merged harness-timeout fix (#195), so the harness suite runs against the hardened timeouts._

🤖 Generated with [Claude Code](https://claude.com/claude-code)