### PR TITLE
Fix medium-severity findings from July 2026 code review

### DIFF
--- a/docs/CODE_REVIEW_JULY_2026.md
+++ b/docs/CODE_REVIEW_JULY_2026.md
@@ -30,14 +30,14 @@ embedded host JVMs.
 | 3 | Reconnect rate limit disabled when log level > INFO (`acquire()` inside log lambda) | high | ✅ |
 | 4 | `fetchContentFromUrl` swallows JVM `Error`s into 503 scrape results | high | ✅ |
 | 5 | `parseArgs` `exitProcess()` kills embedded host JVMs | high | ✅ |
-| 6 | `heartbeatEnabled=false` closes every connection immediately after connect | medium | ⬜ |
-| 7 | `registerPath` races agent removal → permanently dead path in `pathMap` | medium | ⬜ |
-| 8 | Zipkin tracing closed on first reconnect, then reused | medium | ⬜ |
-| 9 | Unguarded `HttpClient.close()` can permanently kill the cache sweeper | medium | ⬜ |
-| 10 | All non-2xx upstream responses mislabeled `path_not_found` | medium | ⬜ |
-| 11 | Config-value validation gaps (`reconnectPauseSecs`, backlog capacity, zipped size, gzip min) | medium | ⬜ |
-| 12 | `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow | medium | ⬜ |
-| 13 | `sendHeartBeat` error handling: ERROR noise, lost stack traces, exception-as-goto | medium | ⬜ |
+| 6 | `heartbeatEnabled=false` closes every connection immediately after connect | medium | ✅ |
+| 7 | `registerPath` races agent removal → permanently dead path in `pathMap` | medium | ✅ |
+| 8 | Zipkin tracing closed on first reconnect, then reused | medium | ✅ |
+| 9 | Unguarded `HttpClient.close()` can permanently kill the cache sweeper | medium | ✅ |
+| 10 | All non-2xx upstream responses mislabeled `path_not_found` | medium | ✅ |
+| 11 | Config-value validation gaps (`reconnectPauseSecs`, backlog capacity, zipped size, gzip min) | medium | ✅ |
+| 12 | `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow | medium | ✅ |
+| 13 | `sendHeartBeat` error handling: ERROR noise, lost stack traces, exception-as-goto | medium | ✅ (via finding 2) |
 | 14 | Polled scrape request lost on stream-only RPC cancellation | low | ⬜ |
 | 15 | Disconnect-vs-submit races mislabel agent-disconnect results as `timed_out` | low | ⬜ |
 | 16 | `scrapeResults` write not atomic with completion CAS — fail can clobber a real result | low | ⬜ |
@@ -178,7 +178,7 @@ document that usage/version remain CLI-only. Keep `exitProcess` behavior for the
 
 ## 🟠 Medium severity
 
-### 6. [ ] `heartbeatEnabled=false` closes every connection immediately after connect
+### 6. [x] `heartbeatEnabled=false` closes every connection immediately after connect
 `Agent.kt:274-276, 349-354, 416-436` — **lifecycle, medium (non-default config, total breakage),
 confirmed**
 
@@ -195,7 +195,7 @@ points at the config flag. Deterministic.
 *successful completion* of the heartbeat task as a disconnect. Add a container/harness test running
 with `heartbeatEnabled=false`.
 
-### 7. [ ] `registerPath` races agent removal → permanently dead path
+### 7. [x] `registerPath` races agent removal → permanently dead path
 `proxy/ProxyServiceImpl.kt:117-127` · `proxy/ProxyPathManager.kt:87-131, 191-200` ·
 `Proxy.kt:339-348` — **concurrency (TOCTOU), medium, confirmed**
 
@@ -215,7 +215,7 @@ re-register the same path. For consolidated paths it is worse — a new agent *a
 `addValidatedPath` and reject registration for an invalidated context; and/or make
 `removeFromPathManager` sweep by agentId even when the context is already absent from the manager.
 
-### 8. [ ] Zipkin tracing closed on first reconnect, then reused
+### 8. [x] Zipkin tracing closed on first reconnect, then reused
 `agent/AgentGrpcService.kt:147-154, 161-201` — **resource lifecycle, medium, confirmed (code
 path); impact plausible**
 
@@ -227,7 +227,7 @@ Tracing silently dies for the remainder of the agent's life in Zipkin-enabled de
 **Fix:** either don't close `tracing` in `resetGrpcStubs()` (close it only in final shutdown), or
 make the tracing objects re-creatable per connection generation.
 
-### 9. [ ] Unguarded `HttpClient.close()` can permanently kill the cache sweeper
+### 9. [x] Unguarded `HttpClient.close()` can permanently kill the cache sweeper
 `agent/HttpClientCache.kt:80-97 (94), 216, 228, 337` — **error path/resource leak, medium,
 plausible**
 
@@ -240,7 +240,7 @@ remaining closes in `close()` and `getOrCreateClient`.
 **Fix:** wrap each `client.close()` in its own `runCatching { }` (log failures), at all three
 sites.
 
-### 10. [ ] All non-2xx upstream responses mislabeled `path_not_found`
+### 10. [x] All non-2xx upstream responses mislabeled `path_not_found`
 `proxy/ProxyHttpRoutes.kt:305-315 (312), 216-219` — **observability, medium, confirmed**
 
 In `submitScrapeRequest`, any non-success status from the agent — target endpoint 500/503, 408
@@ -251,7 +251,7 @@ activity log. Operators cannot distinguish a genuinely unknown path from a down 
 **Fix:** derive the label from the status code (e.g. `upstream_error`, `timed_out`,
 `content_too_large`, with `path_not_found` reserved for the actual 404-unknown-path case).
 
-### 11. [ ] Config-value validation gaps for values used in arithmetic/capacity
+### 11. [x] Config-value validation gaps for values used in arithmetic/capacity
 `Agent.kt:204, 265` · `proxy/ProxyServiceImpl.kt:241` vs `proxy/ProxyOptions.kt:267-271` ·
 `agent/AgentOptions.kt:317-319` — **input validation, medium, confirmed**
 
@@ -267,7 +267,7 @@ activity log. Operators cannot distinguish a genuinely unknown path from a down 
 **Fix:** add `require(... > 0)` checks in the respective options classes, mirroring the existing
 sibling validations (June review finding 27 established the pattern).
 
-### 12. [ ] `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow
+### 12. [x] `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow
 `proxy/ProxyHttpRoutes.kt:238-363 (288)` — **maintainability, medium, confirmed**
 
 One suspend function handles wrapper creation, map registration, channel write + disconnect
@@ -282,7 +282,7 @@ trafficked function in the proxy HTTP path.
 **Fix:** `val statusCode = HttpStatusCode.fromValue(...)` + plain `if/else` expression returns;
 extract the await/timeout leg, the gzip-decode leg, and response assembly into private helpers.
 
-### 13. [ ] `sendHeartBeat` error handling: ERROR noise, lost stack traces, exception-as-goto
+### 13. [x] `sendHeartBeat` error handling: ERROR noise, lost stack traces, exception-as-goto
 `agent/AgentGrpcService.kt:292-324` — **error handling/logging, medium, confirmed**
 
 Three defects in one function: (a) routine transient failures are logged at ERROR; (b) the non-gRPC

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -425,12 +425,22 @@ class Agent(
 
   private suspend fun startHeartBeat(connectionContext: AgentConnectionContext) {
     val cfg = agentConfigVals.internal
+    val heartbeatPauseTime = cfg.heartbeatCheckPauseMillis.milliseconds
+
     if (!cfg.heartbeatEnabled) {
       logger.info { "Heartbeat disabled" }
+      // Stay alive for the connection's lifetime instead of returning: launchConnectionTask treats any
+      // task's completion as a disconnect and closes the shared connectionContext, so returning here would
+      // close the context right after connect -- the first scrape then hits a ClosedSendChannelException
+      // and the agent flaps, dropping its paths (finding 6). Poll connected (rather than awaitCancellation,
+      // which nothing cancels here) so the task still ends promptly once the connection actually closes.
+      while (isRunning && connectionContext.connected) {
+        delay(heartbeatPauseTime)
+      }
+      logger.info { "Heartbeat (disabled) completed" }
       return
     }
 
-    val heartbeatPauseTime = cfg.heartbeatCheckPauseMillis.milliseconds
     val maxInactivityTime = cfg.heartbeatMaxInactivitySecs.seconds
     logger.info { "Heartbeat scheduled to fire after $maxInactivityTime of inactivity" }
 

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -190,8 +190,11 @@ internal class AgentGrpcService(
     grpcLock.withLock {
       logger.info { "Creating gRPC stubs" }
 
+      // Only tear down the channel on reconnect, NOT tracing: tracing/grpcTracing are one-shot lazy
+      // fields, so closing tracing here would leave every channel built after the first reconnect
+      // intercepting over a closed Tracing. tracing is closed once, in the final shutDown() (finding 8).
       if (grpcStarted)
-        shutDownLocked()
+        shutDownChannelLocked()
 
       channel =
         channel(

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -316,6 +316,8 @@ class AgentOptions(
 
     if (minGzipSizeBytes == -1)
       minGzipSizeBytes = MIN_GZIP_SIZE_BYTES.getEnv(agentConfigVals.minGzipSizeBytes)
+    // 0 is valid (gzip every non-empty payload); a negative threshold would gzip everything (finding 11).
+    require(minGzipSizeBytes >= 0) { "minGzipSizeBytes must be >= 0: $minGzipSizeBytes" }
     logger.info { "minGzipSizeBytes: $minGzipSizeBytes" }
 
     if (overrideAuthority.isEmpty())
@@ -360,6 +362,20 @@ class AgentOptions(
 
       val inactivityVal = internal.heartbeatMaxInactivitySecs
       logger.info { "agent.internal.heartbeatMaxInactivitySecs: $inactivityVal" }
+
+      // reconnectPauseSecs feeds RateLimiter.create(1.0 / reconnectPauseSecs) in Agent: 0 yields an
+      // infinite rate (hot reconnect loop) and a negative value an opaque Guava IAE at startup (finding 11).
+      require(internal.reconnectPauseSecs > 0) {
+        "agent.internal.reconnectPauseSecs must be > 0: ${internal.reconnectPauseSecs}"
+      }
+      logger.info { "agent.internal.reconnectPauseSecs: ${internal.reconnectPauseSecs}" }
+
+      // scrapeRequestBacklogUnhealthySize * 2 is the AgentConnectionContext channel capacity: 0 makes it
+      // a rendezvous channel (every send blocks) and a negative value throws at connect time (finding 11).
+      require(internal.scrapeRequestBacklogUnhealthySize > 0) {
+        "agent.internal.scrapeRequestBacklogUnhealthySize must be > 0: ${internal.scrapeRequestBacklogUnhealthySize}"
+      }
+      logger.info { "agent.internal.scrapeRequestBacklogUnhealthySize: ${internal.scrapeRequestBacklogUnhealthySize}" }
     }
 
     assignLogLevel("agent", AGENT_LOG_LEVEL, agentConfigVals.logLevel)

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -91,7 +91,7 @@ internal class HttpClientCache(
             logger.error(e) { "Error during HTTP client cache cleanup" }
             emptyList()
           }
-        clientsToClose.forEach { it.close() }
+        clientsToClose.forEach { closeQuietly(it) }
       }
     }
   }
@@ -213,7 +213,7 @@ internal class HttpClientCache(
         result to drainPendingCloses()
       }
 
-    clientsToClose.forEach { it.close() }
+    clientsToClose.forEach { closeQuietly(it) }
     return entry
   }
 
@@ -225,7 +225,7 @@ internal class HttpClientCache(
       entry.onDoneWithClient()
     }
     if (shouldClose) {
-      entry.client.close()
+      closeQuietly(entry.client)
     }
   }
 
@@ -334,7 +334,7 @@ internal class HttpClientCache(
       closed = true
     }
     // Close clients outside the lock to avoid blocking
-    clientsToClose.forEach { it.close() }
+    clientsToClose.forEach { closeQuietly(it) }
   }
 
   suspend fun getCacheStats(): CacheStats =
@@ -356,5 +356,14 @@ internal class HttpClientCache(
 
   companion object {
     private val logger = logger {}
+
+    // Closes a client, swallowing and logging any failure so it can never propagate. Critical for the
+    // background sweeper loop: a throwing HttpClient.close() there would break out of the while(isActive)
+    // loop and kill the sweeper permanently, leaking every future expired client (finding 9). At the
+    // batch-close sites it also keeps one bad close() from aborting the remaining closes.
+    internal fun closeQuietly(client: HttpClient) {
+      runCatching { client.close() }
+        .onFailure { e -> logger.warn(e) { "Error closing HTTP client: ${e.message}" } }
+    }
   }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -34,6 +34,7 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.prometheus.Proxy
+import io.prometheus.common.ScrapeResults
 import io.prometheus.common.Utils.sanitizeQueryParams
 import io.prometheus.proxy.ProxyConstants.CACHE_CONTROL_VALUE
 import io.prometheus.proxy.ProxyConstants.FAVICON_FILENAME
@@ -235,7 +236,6 @@ internal object ProxyHttpRoutes {
     proxy.logActivity(status)
   }
 
-  @Suppress("ReturnCount")
   internal suspend fun submitScrapeRequest(
     agentContext: AgentContext,
     proxy: Proxy,
@@ -244,11 +244,48 @@ internal object ProxyHttpRoutes {
     request: ApplicationRequest,
   ): ScrapeRequestResponse {
     val scrapeRequest = createScrapeRequest(agentContext, proxy, path, encodedQueryParams, request)
+    val timeoutTime = proxy.proxyConfigVals.internal.scrapeRequestTimeoutSecs.seconds
 
+    // A terminal response here means the agent disconnected or the request timed out.
+    dispatchScrapeRequest(agentContext, proxy, scrapeRequest, timeoutTime)?.let { return it }
+
+    logger.debug { "Results returned from $agentContext for $scrapeRequest" }
+
+    val scrapeResults =
+      scrapeRequest.scrapeResults
+        ?: return ScrapeRequestResponse(
+          statusCode = HttpStatusCode.ServiceUnavailable,
+          updateMsg = "missing_results",
+          fetchDuration = scrapeRequest.ageDuration(),
+        )
+
+    val statusCode = HttpStatusCode.fromValue(scrapeResults.srStatusCode)
+    val contentType = parseContentType(scrapeResults.srContentType, path)
+
+    // Do not return content on error status codes.
+    return if (!statusCode.isSuccess())
+      ScrapeRequestResponse(
+        statusCode = statusCode,
+        contentType = contentType,
+        failureReason = scrapeResults.srFailureReason,
+        url = scrapeResults.srUrl,
+        updateMsg = upstreamErrorLabel(statusCode),
+        fetchDuration = scrapeRequest.ageDuration(),
+      )
+    else
+      buildSuccessResponse(proxy, path, scrapeRequest, scrapeResults, statusCode, contentType)
+  }
+
+  // Registers the request, sends it to the agent, and awaits completion, cleaning up the request map in
+  // a finally. Returns a terminal ScrapeRequestResponse for the agent-disconnected and timed-out cases,
+  // or null when the agent completed and the caller should read scrapeRequest.scrapeResults.
+  private suspend fun dispatchScrapeRequest(
+    agentContext: AgentContext,
+    proxy: Proxy,
+    scrapeRequest: ScrapeRequestWrapper,
+    timeoutTime: Duration,
+  ): ScrapeRequestResponse? {
     try {
-      val proxyConfigVals = proxy.proxyConfigVals
-      val timeoutTime = proxyConfigVals.internal.scrapeRequestTimeoutSecs.seconds
-
       proxy.scrapeRequestManager.addToScrapeRequestMap(scrapeRequest)
       try {
         agentContext.writeScrapeRequest(scrapeRequest)
@@ -261,106 +298,103 @@ internal object ProxyHttpRoutes {
       }
 
       // Suspends until completed, agent disconnects, or timeout expires.
-      // The polling loop (Bug #2) is replaced by a single awaitCompleted() call.
-      if (!scrapeRequest.awaitCompleted(timeoutTime)) {
+      if (!scrapeRequest.awaitCompleted(timeoutTime))
         return ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "timed_out",
           fetchDuration = scrapeRequest.ageDuration(),
         )
-      }
+
+      return null
     } finally {
       scrapeRequest.closeChannel()
       val scrapeId = scrapeRequest.scrapeId
       proxy.scrapeRequestManager.removeFromScrapeRequestMap(scrapeId)
         ?: logger.error { "Scrape request $scrapeId missing in map" }
     }
-
-    logger.debug { "Results returned from $agentContext for $scrapeRequest" }
-
-    val scrapeResults = scrapeRequest.scrapeResults
-      ?: return ScrapeRequestResponse(
-        statusCode = HttpStatusCode.ServiceUnavailable,
-        updateMsg = "missing_results",
-        fetchDuration = scrapeRequest.ageDuration(),
-      )
-
-    HttpStatusCode.fromValue(scrapeResults.srStatusCode).also { statusCode ->
-
-      val contentType =
-        runCatching {
-          ContentType.parse(scrapeResults.srContentType)
-        }.getOrElse {
-          // A malformed Content-Type from the target endpoint is a (minor) misconfiguration worth
-          // surfacing at warn; text/plain is the correct fallback for Prometheus exposition format.
-          logger.warn {
-            "Error parsing content type for /$path: '${scrapeResults.srContentType}' " +
-              "(${it.simpleClassName}); falling back to text/plain"
-          }
-          Text.Plain.withCharset(Charsets.UTF_8)
-        }
-      logger.debug { "Content type: $contentType" }
-
-      // Do not return content on error status codes
-      return if (!statusCode.isSuccess())
-        scrapeResults.run {
-          ScrapeRequestResponse(
-            statusCode = statusCode,
-            contentType = contentType,
-            failureReason = srFailureReason,
-            url = srUrl,
-            updateMsg = "path_not_found",
-            fetchDuration = scrapeRequest.ageDuration(),
-          )
-        }
-      else
-        scrapeResults.run {
-          val maxSize = proxy.proxyConfigVals.internal.maxUnzippedContentSizeMBytes * 1024L * 1024L
-          val decoded =
-            try {
-              if (srZipped)
-                srContentAsZipped.unzip(maxSize)
-              else
-                DecodedContent(srContentAsText, srContentAsText.toByteArray().size.toLong())
-            } catch (e: ProxyUtils.ZipBombException) {
-              return ScrapeRequestResponse(
-                statusCode = HttpStatusCode.PayloadTooLarge,
-                contentType = Text.Plain.withCharset(Charsets.UTF_8),
-                failureReason = e.message ?: "Unzipped content too large",
-                url = srUrl,
-                updateMsg = "payload_too_large",
-                fetchDuration = scrapeRequest.ageDuration(),
-              )
-            } catch (e: IOException) {
-              return ScrapeRequestResponse(
-                statusCode = HttpStatusCode.BadGateway,
-                contentType = Text.Plain.withCharset(Charsets.UTF_8),
-                failureReason = e.message ?: "Invalid gzipped content",
-                url = srUrl,
-                updateMsg = "invalid_gzip",
-                fetchDuration = scrapeRequest.ageDuration(),
-              )
-            }
-
-          proxy.metrics {
-            // Observe the byte count already computed during unzip (gzipped) or the small plain
-            // payload's length, instead of re-encoding the decoded text just to measure it.
-            val encoding = if (srZipped) ProxyMetrics.ENCODING_GZIPPED else ProxyMetrics.ENCODING_PLAIN
-            scrapeResponseBytes.labels(path, encoding).observe(decoded.byteCount.toDouble())
-          }
-
-          ScrapeRequestResponse(
-            statusCode = statusCode,
-            contentType = contentType,
-            contentText = decoded.text,
-            failureReason = srFailureReason,
-            url = srUrl,
-            updateMsg = "success",
-            fetchDuration = scrapeRequest.ageDuration(),
-          )
-        }
-    }
   }
+
+  // Parses the agent-reported Content-Type, falling back to text/plain (the correct default for the
+  // Prometheus exposition format) with a warning when it is malformed.
+  private fun parseContentType(
+    rawContentType: String,
+    path: String,
+  ): ContentType =
+    runCatching { ContentType.parse(rawContentType) }
+      .getOrElse {
+        logger.warn {
+          "Error parsing content type for /$path: '$rawContentType' " +
+            "(${it.simpleClassName}); falling back to text/plain"
+        }
+        Text.Plain.withCharset(Charsets.UTF_8)
+      }
+
+  // Decodes (and size-guards) a successful scrape body and assembles the response, returning a terminal
+  // 413/502 response instead when the gzipped payload is a zip bomb or is corrupt.
+  private fun buildSuccessResponse(
+    proxy: Proxy,
+    path: String,
+    scrapeRequest: ScrapeRequestWrapper,
+    scrapeResults: ScrapeResults,
+    statusCode: HttpStatusCode,
+    contentType: ContentType,
+  ): ScrapeRequestResponse {
+    val maxSize = proxy.proxyConfigVals.internal.maxUnzippedContentSizeMBytes * 1024L * 1024L
+    val decoded =
+      try {
+        if (scrapeResults.srZipped)
+          scrapeResults.srContentAsZipped.unzip(maxSize)
+        else
+          DecodedContent(scrapeResults.srContentAsText, scrapeResults.srContentAsText.toByteArray().size.toLong())
+      } catch (e: ProxyUtils.ZipBombException) {
+        return ScrapeRequestResponse(
+          statusCode = HttpStatusCode.PayloadTooLarge,
+          contentType = Text.Plain.withCharset(Charsets.UTF_8),
+          failureReason = e.message ?: "Unzipped content too large",
+          url = scrapeResults.srUrl,
+          updateMsg = "payload_too_large",
+          fetchDuration = scrapeRequest.ageDuration(),
+        )
+      } catch (e: IOException) {
+        return ScrapeRequestResponse(
+          statusCode = HttpStatusCode.BadGateway,
+          contentType = Text.Plain.withCharset(Charsets.UTF_8),
+          failureReason = e.message ?: "Invalid gzipped content",
+          url = scrapeResults.srUrl,
+          updateMsg = "invalid_gzip",
+          fetchDuration = scrapeRequest.ageDuration(),
+        )
+      }
+
+    proxy.metrics {
+      // Observe the byte count already computed during unzip (gzipped) or the small plain payload's
+      // length, instead of re-encoding the decoded text just to measure it.
+      val encoding = if (scrapeResults.srZipped) ProxyMetrics.ENCODING_GZIPPED else ProxyMetrics.ENCODING_PLAIN
+      scrapeResponseBytes.labels(path, encoding).observe(decoded.byteCount.toDouble())
+    }
+
+    return ScrapeRequestResponse(
+      statusCode = statusCode,
+      contentType = contentType,
+      contentText = decoded.text,
+      failureReason = scrapeResults.srFailureReason,
+      url = scrapeResults.srUrl,
+      updateMsg = "success",
+      fetchDuration = scrapeRequest.ageDuration(),
+    )
+  }
+
+  // Maps a non-success upstream status code (returned by the agent for an already-resolved path) to a
+  // metric/activity label, so operators can tell a down target (5xx), a scrape timeout (408/504), an
+  // oversized payload (413), and a path not registered on the agent (404) apart -- instead of every
+  // failure reading as path_not_found (finding 10).
+  internal fun upstreamErrorLabel(statusCode: HttpStatusCode): String =
+    when (statusCode) {
+      HttpStatusCode.NotFound -> "path_not_found"
+      HttpStatusCode.RequestTimeout, HttpStatusCode.GatewayTimeout -> "timed_out"
+      HttpStatusCode.PayloadTooLarge -> "content_too_large"
+      else -> "upstream_error"
+    }
 
   private fun createScrapeRequest(
     agentContext: AgentContext,

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -269,6 +269,14 @@ class ProxyOptions(
             "internal.maxUnzippedContentSizeMBytes must be >= 0: ${internal.maxUnzippedContentSizeMBytes}"
           }
           logger.info { "internal.maxUnzippedContentSizeMBytes: ${internal.maxUnzippedContentSizeMBytes}" }
+
+          // maxZippedContentSizeMBytes is used in chunked-transfer size math; mirror its sibling above
+          // (0 is a valid reject-all limit, negatives are invalid) so a bad value fails fast at startup
+          // instead of surfacing as a confusing ChunkValidationException per transfer (finding 11).
+          require(internal.maxZippedContentSizeMBytes >= 0) {
+            "internal.maxZippedContentSizeMBytes must be >= 0: ${internal.maxZippedContentSizeMBytes}"
+          }
+          logger.info { "internal.maxZippedContentSizeMBytes: ${internal.maxZippedContentSizeMBytes}" }
         }
 
         // Resolved after assignCommonOptions so trustCertCollectionFilePath reflects the CLI/env/config value.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -79,12 +79,23 @@ internal class ProxyPathManager(
     return multiSegmentPathError(path) ?: addValidatedPath(path, labels, agentContext)
   }
 
+  @Suppress("ReturnCount")
   private fun addValidatedPath(
     path: String,
     labels: String,
     agentContext: AgentContext,
   ): String? {
     synchronized(pathMap) {
+      // Re-check validity inside the lock: agent removal (transportTerminated / cleanup eviction) can
+      // interleave between the caller's out-of-lock getAgentContext() check and here, invalidating the
+      // context. Inserting a path for an invalidated context creates a permanently-dead path that no
+      // cleanup sweeps, so reject it and let the agent re-register on reconnect (finding 7).
+      if (agentContext.isNotValid()) {
+        val reason = "Agent context ${agentContext.agentId} was invalidated during registration of /$path"
+        logger.warn { reason }
+        return reason
+      }
+
       val agentInfo = pathMap[path]
       if (agentContext.consolidated) {
         if (agentInfo == null) {
@@ -194,41 +205,42 @@ internal class ProxyPathManager(
   ) {
     require(agentId.isNotEmpty()) { EMPTY_AGENT_ID_MSG }
 
-    val agentContext = proxy.agentContextManager.getAgentContext(agentId)
-    if (agentContext == null) {
+    if (proxy.agentContextManager.getAgentContext(agentId) == null)
       logger.debug { "Agent context already removed for agentId: $agentId ($reason)" }
-    } else {
+    else
       logger.info { "Removing paths for agentId: $agentId ($reason)" }
 
-      synchronized(pathMap) {
-        // Collect map mutations in a first pass to avoid modifying the map during iteration.
-        val keysToRemove = mutableListOf<String>()
-        val keysToUpdate = mutableMapOf<String, AgentContextInfo>()
-        pathMap.forEach { (k, v) ->
-          if (v.agentContexts.size == 1) {
-            if (v.agentContexts[0].agentId == agentId)
+    // Always sweep the pathMap by agentId, even when the context is already gone from the manager: a
+    // registerPath that raced this removal can strand a path pointing at an invalidated context, and
+    // skipping the sweep would leave that path 404ing forever (finding 7).
+    synchronized(pathMap) {
+      // Collect map mutations in a first pass to avoid modifying the map during iteration.
+      val keysToRemove = mutableListOf<String>()
+      val keysToUpdate = mutableMapOf<String, AgentContextInfo>()
+      pathMap.forEach { (k, v) ->
+        if (v.agentContexts.size == 1) {
+          if (v.agentContexts[0].agentId == agentId)
+            keysToRemove += k
+        } else {
+          val filtered = v.agentContexts.filterNot { it.agentId == agentId }
+          if (filtered.size != v.agentContexts.size) {
+            logger.info { "Removed agentId $agentId from consolidated path /$k" }
+            if (filtered.isEmpty())
               keysToRemove += k
-          } else {
-            val filtered = v.agentContexts.filterNot { it.agentId == agentId }
-            if (filtered.size != v.agentContexts.size) {
-              logger.info { "Removed agentId $agentId from consolidated path /$k" }
-              if (filtered.isEmpty())
-                keysToRemove += k
-              else
-                keysToUpdate[k] = v.copy(agentContexts = filtered)
-            }
+            else
+              keysToUpdate[k] = v.copy(agentContexts = filtered)
           }
         }
+      }
 
-        keysToUpdate.forEach { (k, v) -> pathMap[k] = v }
+      keysToUpdate.forEach { (k, v) -> pathMap[k] = v }
 
-        keysToRemove.forEach { k ->
-          pathMap.remove(k)
-            ?.also {
-              if (!isTestMode)
-                logger.info { "Removed path /$k for $it" }
-            } ?: logger.warn { "Missing ${agentContext.desc}path /$k for agentId: $agentId" }
-        }
+      keysToRemove.forEach { k ->
+        pathMap.remove(k)
+          ?.also {
+            if (!isTestMode)
+              logger.info { "Removed path /$k for $it" }
+          } ?: logger.warn { "Missing path /$k for agentId: $agentId" }
       }
     }
   }

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -18,7 +18,9 @@
 
 package io.prometheus.agent
 
+import brave.Tracing
 import com.pambrose.common.concurrent.await
+import com.pambrose.common.service.ZipkinReporterService
 import com.pambrose.common.util.zip
 import io.grpc.Metadata
 import io.kotest.assertions.throwables.shouldNotThrow
@@ -33,6 +35,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import io.prometheus.Agent
 import io.prometheus.common.DefaultObjects.EMPTY_INSTANCE
@@ -475,6 +478,32 @@ class AgentGrpcServiceTest : StringSpec() {
       newChannel.isTerminated.shouldBeFalse()
 
       service.shutDown()
+    }
+
+    // ==================== Finding 8: Zipkin tracing lifecycle across reconnects ====================
+
+    // tracing/grpcTracing are one-shot lazy fields. resetGrpcStubs() runs on every reconnect and must
+    // NOT close tracing, or every channel built after the first reconnect installs an interceptor over
+    // a closed Tracing and tracing silently dies for the rest of the agent's life. tracing must be
+    // closed only by the final shutDown().
+    "Finding 8: tracing survives reconnects and is closed only on final shutDown" {
+      val agent = createMockAgent("localhost:$PROXY_AGENT_PORT")
+      every { agent.isZipkinEnabled } returns true
+      val tracing = spyk(Tracing.newBuilder().build())
+      val zipkinService = mockk<ZipkinReporterService>(relaxed = true)
+      every { agent.zipkinReporterService } returns zipkinService
+      every { zipkinService.newTracing(any()) } returns tracing
+
+      // Construction builds the first channel, installing the tracing interceptor (creating `tracing`).
+      val service = AgentGrpcService(agent, agent.options, "test-server")
+
+      // Each reconnect swaps the channel but must NOT close the one-shot tracing.
+      repeat(3) { service.resetGrpcStubs() }
+      verify(exactly = 0) { tracing.close() }
+
+      // Only the final shutDown closes tracing.
+      service.shutDown()
+      verify(exactly = 1) { tracing.close() }
     }
 
     // ==================== Concurrent shutDown / resetGrpcStubs Tests ====================

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -271,6 +271,36 @@ class AgentOptionsTest : StringSpec() {
 
     // ==================== Validation Tests ====================
 
+    // Finding 11: config values used in arithmetic/capacity must be validated. reconnectPauseSecs feeds
+    // RateLimiter.create(1.0 / reconnectPauseSecs) (0 -> infinite rate), scrapeRequestBacklogUnhealthySize
+    // * 2 is the connection channel capacity (0 -> rendezvous channel), and a negative minGzipSizeBytes
+    // would gzip everything.
+    "Finding 11: reconnectPauseSecs of 0 should throw IllegalArgumentException" {
+      shouldThrow<IllegalArgumentException> {
+        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.internal.reconnectPauseSecs=0"), false)
+      }
+    }
+
+    "Finding 11: scrapeRequestBacklogUnhealthySize of 0 should throw IllegalArgumentException" {
+      shouldThrow<IllegalArgumentException> {
+        AgentOptions(
+          listOf("--name", "test", "--proxy", "host", "-Dagent.internal.scrapeRequestBacklogUnhealthySize=0"),
+          false,
+        )
+      }
+    }
+
+    "Finding 11: minGzipSizeBytes of -1 should throw IllegalArgumentException" {
+      shouldThrow<IllegalArgumentException> {
+        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=-5"), false)
+      }
+    }
+
+    "Finding 11: minGzipSizeBytes of 0 should be accepted (gzip every non-empty payload)" {
+      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=0"), false)
+      options.minGzipSizeBytes shouldBe 0
+    }
+
     "maxConcurrentHttpClients of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
         AgentOptions(

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -19,6 +19,7 @@
 package io.prometheus.agent
 
 import com.pambrose.common.concurrent.await
+import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
@@ -74,6 +75,18 @@ class HttpClientCacheTest : StringSpec() {
 
     afterEach {
       cache.close()
+    }
+
+    // Finding 9: a throwing HttpClient.close() must never propagate. In the background sweeper loop it
+    // would break out of the while(isActive) loop and kill the sweeper permanently (leaking every
+    // future expired client); at the batch-close sites it would abort the remaining closes. closeQuietly
+    // wraps close() so the failure is logged and swallowed.
+    "Finding 9: closeQuietly swallows a throwing HttpClient.close()" {
+      val throwing = mockk<HttpClient>(relaxed = true)
+      every { throwing.close() } throws RuntimeException("close boom")
+
+      shouldNotThrow<Throwable> { HttpClientCache.closeQuietly(throwing) }
+      verify { throwing.close() }
     }
 
     // Item 4: once closed, the cache must reject new requests. Otherwise an in-flight scrape

--- a/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.prometheus.harness
+
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.prometheus.Agent
+import io.prometheus.Proxy
+import io.prometheus.agent.AgentOptions
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.common.startAndAwaitReady
+import io.prometheus.harness.HarnessConstants.CONFIG_ARG
+import io.prometheus.proxy.ProxyOptions
+import kotlin.time.Duration.Companion.seconds
+import io.ktor.server.cio.CIO as ServerCIO
+
+// Finding 6: launchConnectionTask closes the shared connectionContext whenever any connection-lifetime
+// task completes. With heartbeatEnabled=false the heartbeat task returns immediately, closing the context
+// right after connect. The read stream stays suspended (so the agent looks connected), but the first
+// scrape request hits the closed channel with a ClosedSendChannelException -- the scrape fails and the
+// agent flaps, losing its registered path. The fix keeps the heartbeat task alive for the connection's
+// lifetime (polling connectionContext.connected) without sending heartbeats, so scrapes succeed.
+class InProcessHeartbeatDisabledTest : StringSpec() {
+  init {
+    "Finding 6: with heartbeat disabled a scrape through the proxy still succeeds" {
+      CollectorRegistry.defaultRegistry.clear()
+
+      val serverName = "hb-disabled-${System.nanoTime()}"
+      val httpPort = 9526
+
+      // The metrics endpoint the agent will scrape.
+      val stub =
+        embeddedServer(ServerCIO, port = 0) {
+          routing {
+            get("/metrics") { call.respondText("test_metric 42\n") }
+          }
+        }
+      val stubPort = stub.startAndAwaitReady()
+
+      val proxy =
+        Proxy(
+          options =
+            ProxyOptions(
+              CONFIG_ARG +
+                listOf(
+                  "-Dproxy.admin.enabled=false",
+                  "-Dproxy.metrics.enabled=false",
+                  // Fail a lost scrape fast so the buggy path doesn't block the whole scrape timeout.
+                  "-Dproxy.internal.scrapeRequestTimeoutSecs=5",
+                ),
+            ),
+          proxyPort = httpPort,
+          inProcessServerName = serverName,
+          testMode = true,
+        ) { startSync() }
+
+      val client = HttpClient(CIO)
+      try {
+        val agent =
+          Agent(
+            options =
+              AgentOptions(
+                CONFIG_ARG +
+                  listOf(
+                    "-Dagent.admin.enabled=false",
+                    "-Dagent.metrics.enabled=false",
+                    "-Dagent.internal.heartbeatEnabled=false",
+                  ),
+                exitOnMissingConfig = false,
+              ),
+            inProcessServerName = serverName,
+            testMode = true,
+          ) { startSync() }
+
+        try {
+          agent.awaitInitialConnection(10.seconds).shouldBeTrue()
+          agent.pathManager.registerPath("hbpath", "http://localhost:$stubPort/metrics")
+
+          // With the bug the first scrape closes the connection and drops the path, so scrapes never
+          // succeed; with the fix the connection stays healthy and the scrape returns the metric.
+          eventually(10.seconds) {
+            val response = client.get("http://localhost:$httpPort/hbpath")
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldContain "test_metric"
+          }
+        } finally {
+          if (agent.isRunning) runCatching { agent.stopSync(5.seconds) }
+        }
+      } finally {
+        client.close()
+        runCatching { proxy.stopSync(10.seconds) }
+        stub.stop(0, 0)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -539,7 +539,8 @@ class ProxyHttpRoutesTest : StringSpec() {
 
       // It should return 502 Bad Gateway because failScrapeRequest uses that code
       response.statusCode shouldBe HttpStatusCode.BadGateway
-      response.updateMsg shouldBe "path_not_found" // assigned by failScrapeRequest
+      // 502 maps to upstream_error (finding 10): a disconnect/bad-gateway is not a path-not-found.
+      response.updateMsg shouldBe "upstream_error"
     }
 
     "submitScrapeRequest should unblock immediately when proxy is shut down" {
@@ -563,7 +564,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       )
 
       response.statusCode shouldBe HttpStatusCode.BadGateway
-      response.updateMsg shouldBe "path_not_found"
+      response.updateMsg shouldBe "upstream_error"
     }
 
     "submitScrapeRequest should return success for valid non-zipped response" {
@@ -732,7 +733,52 @@ class ProxyHttpRoutesTest : StringSpec() {
       response.contentType shouldBe ContentType.Text.Plain.withCharset(Charsets.UTF_8)
     }
 
-    "submitScrapeRequest should return path_not_found for non-success status" {
+    // Finding 10: a non-2xx upstream status must map to a label that reflects the cause, so operators
+    // can tell a down target, a timeout, an oversized payload, and a truly unknown path apart -- instead
+    // of every failure being labeled path_not_found.
+    "Finding 10: upstreamErrorLabel maps status codes to distinct labels" {
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.NotFound) shouldBe "path_not_found"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.RequestTimeout) shouldBe "timed_out"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.GatewayTimeout) shouldBe "timed_out"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.PayloadTooLarge) shouldBe "content_too_large"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.InternalServerError) shouldBe "upstream_error"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.BadGateway) shouldBe "upstream_error"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.ServiceUnavailable) shouldBe "upstream_error"
+    }
+
+    "Finding 10: submitScrapeRequest labels a 500 upstream response upstream_error" {
+      val proxy = createSpyProxyForSubmit(timeoutSecs = 30)
+      val agentContext = AgentContext("test-remote")
+
+      launch {
+        val wrapper = agentContext.readScrapeRequest()!!
+        val results = ScrapeResults(
+          srAgentId = agentContext.agentId,
+          srScrapeId = wrapper.scrapeId,
+          srValidResponse = false,
+          srStatusCode = 500,
+          srContentType = "text/plain; charset=utf-8",
+          srFailureReason = "Internal Server Error",
+          srUrl = "http://localhost:$PROXY_HTTP_PORT/metrics",
+        )
+        proxy.scrapeRequestManager.assignScrapeResults(results)
+      }
+
+      val response = ProxyHttpRoutes.submitScrapeRequest(
+        agentContext,
+        proxy,
+        "metrics",
+        "",
+        mockk<ApplicationRequest>(relaxed = true),
+      )
+
+      response.statusCode shouldBe HttpStatusCode.InternalServerError
+      response.updateMsg shouldBe "upstream_error"
+      response.failureReason shouldBe "Internal Server Error"
+      response.contentText shouldBe ""
+    }
+
+    "submitScrapeRequest should return path_not_found for a 404 (unregistered path) status" {
       val proxy = createSpyProxyForSubmit(timeoutSecs = 30)
       val agentContext = AgentContext("test-remote")
 

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -264,6 +264,22 @@ class ProxyOptionsTest : StringSpec() {
       options.configVals.proxy.internal.maxUnzippedContentSizeMBytes shouldBe 0
     }
 
+    // Finding 11: maxZippedContentSizeMBytes is used in chunked-transfer size math but its sibling
+    // maxUnzippedContentSizeMBytes was the only one validated. Mirror the sibling: reject negatives,
+    // allow 0 as a degenerate reject-all limit.
+    "Finding 11: a negative maxZippedContentSizeMBytes should be rejected" {
+      val exception =
+        shouldThrow<IllegalArgumentException> {
+          ProxyOptions(listOf("-Dproxy.internal.maxZippedContentSizeMBytes=-1"))
+        }
+      exception.message shouldContain "maxZippedContentSizeMBytes"
+    }
+
+    "Finding 11: a zero maxZippedContentSizeMBytes should be accepted (reject-all limit)" {
+      val options = ProxyOptions(listOf("-Dproxy.internal.maxZippedContentSizeMBytes=0"))
+      options.configVals.proxy.internal.maxZippedContentSizeMBytes shouldBe 0
+    }
+
     // ==================== Constructor Variants Tests ====================
 
     "list constructor should work" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyPathManagerTest.kt
@@ -418,9 +418,11 @@ class ProxyPathManagerTest : StringSpec() {
       val proxy = createMockProxy()
       val manager = ProxyPathManager(proxy, isTestMode = true)
       val context = createMockAgentContext()
-      every { context.isNotValid() } returns true
 
+      // Register while valid, then the agent becomes invalid (disconnect/eviction) while the path is
+      // still mapped -- addValidatedPath now rejects an already-invalid context (finding 7, Fix 1).
       manager.addPath("/metrics", """{"job":"test"}""", context)
+      every { context.isNotValid() } returns true
 
       val info = manager.getAgentContextInfo("/metrics")
       info.shouldNotBeNull()
@@ -449,11 +451,13 @@ class ProxyPathManagerTest : StringSpec() {
       val manager = ProxyPathManager(proxy, isTestMode = true)
       val context1 = createMockAgentContext(consolidated = true)
       val context2 = createMockAgentContext(consolidated = true)
-      every { context1.isNotValid() } returns true
-      every { context2.isNotValid() } returns true
 
+      // Register both while valid, then both agents become invalid (finding 7, Fix 1 rejects adding an
+      // already-invalid context, so invalidate after registration).
       manager.addPath("/metrics", """{"job":"test"}""", context1)
       manager.addPath("/metrics", """{"job":"test"}""", context2)
+      every { context1.isNotValid() } returns true
+      every { context2.isNotValid() } returns true
 
       val info = manager.getAgentContextInfo("/metrics")
       info.shouldNotBeNull()
@@ -467,11 +471,12 @@ class ProxyPathManagerTest : StringSpec() {
       val manager = ProxyPathManager(proxy, isTestMode = true)
       val context1 = createMockAgentContext(consolidated = true)
       val context2 = createMockAgentContext(consolidated = true)
-      every { context1.isNotValid() } returns true
-      every { context2.isNotValid() } returns false
 
+      // Register both while valid, then only context1 becomes invalid (finding 7, Fix 1).
       manager.addPath("/metrics", """{"job":"test"}""", context1)
       manager.addPath("/metrics", """{"job":"test"}""", context2)
+      every { context1.isNotValid() } returns true
+      every { context2.isNotValid() } returns false
 
       val info = manager.getAgentContextInfo("/metrics")
       info.shouldNotBeNull()
@@ -605,6 +610,45 @@ class ProxyPathManagerTest : StringSpec() {
 
       // Should not throw
       manager.removeFromPathManager("missing-agent", "disconnect")
+    }
+
+    // Finding 7: registerPath checks the agent context validity outside the pathMap lock, so agent
+    // removal can interleave and leave a path pointing at an invalidated context that no cleanup sweeps.
+    // Fix 1: addValidatedPath re-checks validity inside the lock and rejects an invalidated context.
+    "Finding 7: addPath should reject an already-invalidated agent context" {
+      val proxy = createMockProxy()
+      val manager = ProxyPathManager(proxy, isTestMode = true)
+      val context = createMockAgentContext()
+      // Simulate the context being invalidated by a racing removal between the caller's check and here.
+      every { context.isNotValid() } returns true
+
+      val reason = manager.addPath("/metrics", """{"job":"test"}""", context)
+
+      reason.shouldNotBeNull()
+      reason shouldContain "invalidated"
+      manager.pathMapSize shouldBe 0
+      manager.getAgentContextInfo("/metrics").shouldBeNull()
+    }
+
+    // Fix 2: removeFromPathManager sweeps the pathMap by agentId even when the context is already gone
+    // from the manager, so a path stranded by the race above is still cleaned up.
+    "Finding 7: removeFromPathManager sweeps a stranded path even when the context is gone" {
+      val proxy = createMockProxy()
+      val manager = ProxyPathManager(proxy, isTestMode = true)
+      val context = createMockAgentContext()
+      val agentId = context.agentId
+
+      manager.addPath("/metrics", """{"job":"test"}""", context)
+      manager.pathMapSize shouldBe 1
+
+      // The context has already been removed from the manager (raced disconnect).
+      every { proxy.agentContextManager.getAgentContext(agentId) } returns null
+      proxy.agentContextManager.getAgentContext(agentId).shouldBeNull()
+
+      manager.removeFromPathManager(agentId, "disconnect")
+
+      manager.pathMapSize shouldBe 0
+      manager.getAgentContextInfo("/metrics").shouldBeNull()
     }
 
     // ==================== getAgentContextInfo Defensive Copy ====================


### PR DESCRIPTION
Fixes the medium-severity findings (6–12) from `docs/CODE_REVIEW_JULY_2026.md`. Finding 13 was already addressed by finding 2's `sendHeartBeat` rewrite (marked ✅ in the doc). Each change was written test-first.

## Fixes

| # | Problem | Fix |
|---|---------|-----|
| **6** | `heartbeatEnabled=false` closes the connection right after connect → the first scrape flaps the agent and drops its paths | Heartbeat-disabled task polls `connectionContext.connected` for the connection's lifetime instead of returning. (The review's `awaitCancellation()` idea would hang the scope — nothing cancels it.) |
| **7** | `registerPath` checks context validity outside the pathMap lock → a race with agent removal strands a permanently-dead path | `addValidatedPath` re-checks `isValid()` inside the lock and rejects an invalidated context; `removeFromPathManager` always sweeps by agentId even when the context is already gone from the manager |
| **8** | Zipkin `tracing` (a one-shot `lazy`) is closed on every reconnect, so tracing dies after the first reconnect | `resetGrpcStubs()` shuts down only the channel; `tracing` is closed once, in final `shutDown()` |
| **9** | An unguarded throwing `HttpClient.close()` in the sweeper loop kills the background cache sweeper permanently | `closeQuietly()` wraps every `close()` (all 4 sites) in `runCatching` |
| **10** | Every non-2xx upstream response is mislabeled `path_not_found` | `upstreamErrorLabel(statusCode)` → `path_not_found` / `timed_out` / `content_too_large` / `upstream_error` |
| **11** | Config values used in arithmetic/capacity weren't validated | `require(> 0 / >= 0)` for `reconnectPauseSecs`, `scrapeRequestBacklogUnhealthySize`, `minGzipSizeBytes`, `maxZippedContentSizeMBytes` |
| **12** | `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow | Extracted `dispatchScrapeRequest` / `parseContentType` / `buildSuccessResponse`; replaced `.also { return }` with `val statusCode` + if/else; dropped `@Suppress("ReturnCount")` |

## Notes

- Two review suggestions were wrong as stated and I diverged: finding 6's `awaitCancellation()` (would hang the scope) and — a testing gotcha — a MockK `every {}` block matching `context.agentId` gave a false-green finding-7 test until the id was captured in a local.
- Intentional test-behavior changes: two 502 label tests (finding 10) now expect `upstream_error`; three `isNotValid()`-aggregation tests (finding 7) register a valid context then invalidate it (registering an already-invalid context is now rejected).

## Test plan

- New `InProcessHeartbeatDisabledTest` reproduces finding 6 (RED: 178 scrape attempts, never `OK`) and confirms scrapes succeed after the fix.
- New/updated unit tests for findings 7–11 (`ProxyPathManagerTest`, `AgentGrpcServiceTest`, `ProxyHttpRoutesTest`, `AgentOptionsTest`, `ProxyOptionsTest`, `HttpClientCacheTest`); finding 12 is behavior-preserving and covered by the existing `ProxyHttpRoutesTest` suite. Each RED was observed before GREEN.
- `./gradlew build` green: detekt + kotlinter clean, all non-container tests pass, coverage 95.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)