### PR TITLE
Fix low-severity and idiom findings from July 2026 code review

### DIFF
--- a/docs/CODE_REVIEW_JULY_2026.md
+++ b/docs/CODE_REVIEW_JULY_2026.md
@@ -38,35 +38,35 @@ embedded host JVMs.
 | 11 | Config-value validation gaps (`reconnectPauseSecs`, backlog capacity, zipped size, gzip min) | medium | ✅ |
 | 12 | `submitScrapeRequest` is a ~125-line god method with `.also { return }` control flow | medium | ✅ |
 | 13 | `sendHeartBeat` error handling: ERROR noise, lost stack traces, exception-as-goto | medium | ✅ (via finding 2) |
-| 14 | Polled scrape request lost on stream-only RPC cancellation | low | ⬜ |
-| 15 | Disconnect-vs-submit races mislabel agent-disconnect results as `timed_out` | low | ⬜ |
-| 16 | `scrapeResults` write not atomic with completion CAS — fail can clobber a real result | low | ⬜ |
-| 17 | Chunked HEADER check-then-act buffers a transfer nobody awaits | low | ⬜ |
-| 18 | `closeAll()` discards drained count → inflated backlog gauge until reconnect | low | ⬜ |
-| 19 | `AgentPathManager` RPC+map updates not atomic; `clear()` bypasses the mutex | low | ⬜ |
-| 20 | Ignored `awaitTermination` → stale agentId can poison the next connection | low | ⬜ |
-| 21 | Routine client errors and normal shutdown logged at ERROR | low | ⬜ |
-| 22 | `handleConnectionFailure` discards the gRPC status | low | ⬜ |
-| 23 | Stream-failure logging block duplicated four times (already drifted) | low | ⬜ |
-| 24 | `http_client_cache_size_check` health check is unreachable | low | ⬜ |
-| 25 | Hand-rolled LRU: `ConcurrentHashMap` under a mutex + parallel recency map | low | ⬜ |
-| 26 | Public API leaks beyond the documented surface | low | ⬜ |
-| 27 | Commented-out code remnants (one comment contradicts the line below it) | low | ⬜ |
-| 28 | Magic numbers (idle timeout, backlog multiplier, retry delays, grace periods) | low | ⬜ |
-| 29 | Duplicate `Cache-Control` header on every scrape response | low | ⬜ |
-| 30 | Doubled exception rendering in scrape-failure warn logging | low | ⬜ |
-| 31 | Dead parameter flexibility (`parseArgs(Array<String>?)`, unused `backlogCapacity` default) | low | ⬜ |
-| 32 | Cleanup-service gating predicate duplicated between `startUp`/`shutDown` | low | ⬜ |
-| 33 | `HttpClientCache` uses epoch millis instead of monotonic `TimeMark`s | idiom | ⬜ |
-| 34 | Two hand-rolled cause-chain walks with different exception sets (drifted) | idiom | ⬜ |
-| 35 | The `-1`-sentinel resolve/validate/log stanza copy-pasted ~25× | idiom | ⬜ |
-| 36 | Scope-function misuse cluster (`apply` receiver smuggling, consumer `apply`, shadowing) | idiom | ⬜ |
-| 37 | `readConfig` control flow: nullable `Throwable` + non-local returns from `runCatching` | idiom | ⬜ |
-| 38 | Manual CAS loop in `decrementBacklog` — stdlib `update` now exists | idiom | ⬜ |
-| 39 | `mergeContentTexts`: `var` flag mutated inside `map` + repeated `"# EOF"` literal | idiom | ⬜ |
-| 40 | `reconnectLimiter` split declaration/`init`-assignment | idiom | ⬜ |
-| 41 | Manual `while(true)/poll/break` drain loops | idiom | ⬜ |
-| 42 | Scheme-stripping `when` reducible to `removePrefix` chain (+ case-sensitivity gap) | idiom | ⬜ |
+| 14 | Polled scrape request lost on stream-only RPC cancellation | low | ✅ |
+| 15 | Disconnect-vs-submit races mislabel agent-disconnect results as `timed_out` | low | ✅ |
+| 16 | `scrapeResults` write not atomic with completion CAS — fail can clobber a real result | low | ✅ |
+| 17 | Chunked HEADER check-then-act buffers a transfer nobody awaits | low | ⬜ (deferred — optional, self-healing/size-capped) |
+| 18 | `closeAll()` discards drained count → inflated backlog gauge until reconnect | low | ✅ |
+| 19 | `AgentPathManager` RPC+map updates not atomic; `clear()` bypasses the mutex | low | ✅ |
+| 20 | Ignored `awaitTermination` → stale agentId can poison the next connection | low | ✅ (awaitTermination logged; interceptor-generation token deferred) |
+| 21 | Routine client errors and normal shutdown logged at ERROR | low | ✅ |
+| 22 | `handleConnectionFailure` discards the gRPC status | low | ✅ |
+| 23 | Stream-failure logging block duplicated four times (already drifted) | low | ✅ |
+| 24 | `http_client_cache_size_check` health check is unreachable | low | ✅ |
+| 25 | Hand-rolled LRU: `ConcurrentHashMap` under a mutex + parallel recency map | low | ✅ |
+| 26 | Public API leaks beyond the documented surface | low | ✅ |
+| 27 | Commented-out code remnants (one comment contradicts the line below it) | low | ✅ |
+| 28 | Magic numbers (idle timeout, backlog multiplier, retry delays, grace periods) | low | ✅ |
+| 29 | Duplicate `Cache-Control` header on every scrape response | low | ✅ |
+| 30 | Doubled exception rendering in scrape-failure warn logging | low | ✅ |
+| 31 | Dead parameter flexibility (`parseArgs(Array<String>?)`, unused `backlogCapacity` default) | low | ✅ |
+| 32 | Cleanup-service gating predicate duplicated between `startUp`/`shutDown` | low | ✅ |
+| 33 | `HttpClientCache` uses epoch millis instead of monotonic `TimeMark`s | idiom | ✅ |
+| 34 | Two hand-rolled cause-chain walks with different exception sets (drifted) | idiom | ✅ |
+| 35 | The `-1`-sentinel resolve/validate/log stanza copy-pasted ~25× | idiom | ⬜ (deferred — large precedence-sensitive refactor) |
+| 36 | Scope-function misuse cluster (`apply` receiver smuggling, consumer `apply`, shadowing) | idiom | ✅ (apply-misuse sites; 65–120-line options `apply` blocks deferred) |
+| 37 | `readConfig` control flow: nullable `Throwable` + non-local returns from `runCatching` | idiom | ✅ |
+| 38 | Manual CAS loop in `decrementBacklog` — stdlib `update` now exists | idiom | ✅ |
+| 39 | `mergeContentTexts`: `var` flag mutated inside `map` + repeated `"# EOF"` literal | idiom | ✅ |
+| 40 | `reconnectLimiter` split declaration/`init`-assignment | idiom | ✅ |
+| 41 | Manual `while(true)/poll/break` drain loops | idiom | ✅ |
+| 42 | Scheme-stripping `when` reducible to `removePrefix` chain (+ case-sensitivity gap) | idiom | ✅ |
 
 ---
 
@@ -304,7 +304,7 @@ finding 2 — fix together.)
 All traced; all bounded (no hangs or leaks) — these cost accuracy or a timeout window, not
 availability.
 
-### 14. [ ] Polled scrape request lost on stream-only RPC cancellation
+### 14. [x] Polled scrape request lost on stream-only RPC cancellation
 `proxy/AgentContext.kt:100-103` · `proxy/ProxyServiceImpl.kt:183-185` — **low, confirmed**
 
 `readScrapeRequest` receives the notifier token then `poll()`s the wrapper; if the
@@ -317,7 +317,7 @@ cancellation.
 
 **Fix:** re-queue or fail the polled wrapper from a `finally`/cancellation handler around the emit.
 
-### 15. [ ] Disconnect-vs-submit races mislabel agent-disconnect results as `timed_out`
+### 15. [x] Disconnect-vs-submit races mislabel agent-disconnect results as `timed_out`
 `proxy/ScrapeRequestManager.kt:80-87` · `proxy/AgentContext.kt:109-119` ·
 `proxy/ProxyHttpRoutes.kt:252-271` · `proxy/ProxyPathManager.kt:117-125` — **low, confirmed**
 
@@ -332,7 +332,7 @@ disconnect/displacement. Metrics labels are skewed accordingly.
 wrapper with an agent-disconnected result instead of bare-closing the channel; distinguish
 "completed with null results" from "await timed out" in `submitScrapeRequest`.
 
-### 16. [ ] `scrapeResults` write not atomic with completion CAS
+### 16. [x] `scrapeResults` write not atomic with completion CAS
 `proxy/ScrapeRequestManager.kt:53-78` · `proxy/ScrapeRequestWrapper.kt:58-71` — **low, confirmed**
 
 `markComplete()`'s CAS makes completion idempotent, but both `assignScrapeResults` and
@@ -355,7 +355,7 @@ end-of-stream orphan sweep — transient memory waste only, self-healing and siz
 **Fix (optional):** re-check `containsScrapeRequest` at SUMMARY time or on each CHUNK and abandon
 early; low priority given the cap.
 
-### 18. [ ] `closeAll()` discards the drained-request count
+### 18. [x] `closeAll()` discards the drained-request count
 `agent/AgentGrpcService.kt:450-454` vs `Agent.kt:350-353` — **low, confirmed**
 
 On write-stream failure, `closeAll()` wins the close race and drains N buffered scrape actions but
@@ -366,7 +366,7 @@ can falsely report unhealthy during the disconnect window.
 **Fix:** `val drained = connectionContext.close(); if (drained > 0) agent.decrementBacklog(drained)`
 inside `closeAll()`, mirroring the `invokeOnCompletion` handler.
 
-### 19. [ ] `AgentPathManager` RPC+map updates not atomic; `clear()` bypasses the mutex
+### 19. [x] `AgentPathManager` RPC+map updates not atomic; `clear()` bypasses the mutex
 `agent/AgentPathManager.kt:47, 60-91` · `Agent.kt:250` — **low, confirmed lock-scope tracing;
 interleavings plausible**
 
@@ -379,7 +379,7 @@ because `clear()` doesn't take the mutex. Requires concurrent dynamic path manag
 **Fix:** hold `pathMutex` across RPC+map (or serialize path mutations onto a single actor/channel),
 and route `clear()` through the mutex.
 
-### 20. [ ] Ignored `awaitTermination` → stale agentId can poison the next connection
+### 20. [x] Ignored `awaitTermination` → stale agentId can poison the next connection
 `agent/AgentGrpcService.kt:151-152` · `Agent.kt:243-247` · `agent/AgentClientInterceptor.kt:52-74`
 — **low, plausible**
 
@@ -397,7 +397,7 @@ generation (e.g. pass a generation token) or synchronize all `agentId` writers c
 
 ## 🟡 Low severity — quality & observability
 
-### 21. [ ] Routine client errors and normal shutdown logged at ERROR
+### 21. [x] Routine client errors and normal shutdown logged at ERROR
 `proxy/ProxyUtils.kt:79, 91, 109` — **logging, low, confirmed**
 
 Every request for an unknown path logs at ERROR — a misconfigured Prometheus or a port scanner
@@ -405,14 +405,14 @@ floods the error log on every scrape interval — and `proxyNotRunningResponse` 
 at ERROR once per in-flight request during normal shutdown. **Fix:** warn (or info) for these
 expected conditions.
 
-### 22. [ ] `handleConnectionFailure` discards the gRPC status
+### 22. [x] `handleConnectionFailure` discards the gRPC status
 `Agent.kt:362-364` — **logging, low, confirmed**
 
 The `StatusRuntimeException` branch logs only "Disconnected from proxy at $proxyHost", dropping
 `e.status` entirely — UNAVAILABLE vs UNAUTHENTICATED vs RESOURCE_EXHAUSTED reconnect loops are
 indistinguishable in logs. **Fix:** include `e.status` (and message) in the log line.
 
-### 23. [ ] Stream-failure logging block duplicated four times (already drifted)
+### 23. [x] Stream-failure logging block duplicated four times (already drifted)
 `Agent.kt:344-348` · `agent/AgentGrpcService.kt:464-470` · `proxy/ProxyServiceImpl.kt:215-222,
 306-313` — **duplication, low, confirmed**
 
@@ -420,7 +420,7 @@ The `runCatchingCancellable { ... }.onFailure { if (isRunning) Status.fromThrowa
 pattern recurs with variations that have already diverged (some suppress CANCELLED, some don't;
 some close channels). **Fix:** extract one shared helper with explicit knobs.
 
-### 24. [ ] `http_client_cache_size_check` health check is unreachable
+### 24. [x] `http_client_cache_size_check` health check is unreachable
 `Agent.kt:403-413` · `agent/HttpClientCache.kt:239-241` — **dead code/boundary, low, plausible**
 
 Threshold is `maxCacheSize + 1` with `>=` (i.e. `size > maxCacheSize`), but `createAndCacheClient`
@@ -428,7 +428,7 @@ evicts before insert and `removeEntry` removes from the map immediately even for
 `cache.size` never exceeds `maxCacheSize` — the unhealthy branch can never fire. **Fix:** either
 track (and alert on) in-use-but-evicted clients pending close, or remove the check.
 
-### 25. [ ] Hand-rolled LRU: `ConcurrentHashMap` under a mutex + parallel recency map
+### 25. [x] Hand-rolled LRU: `ConcurrentHashMap` under a mutex + parallel recency map
 `agent/HttpClientCache.kt:63-66` — **design, low, confirmed**
 
 `cache` is a `ConcurrentHashMap` yet every mutation is serialized under `accessMutex` alongside a
@@ -437,7 +437,7 @@ contract that isn't the real one, and `evictLeastRecentlyUsed` is O(n) per inser
 **Fix:** a single `LinkedHashMap(accessOrder = true)` under the mutex (or Caffeine) replaces both
 structures. (Interacts with finding 33 — do together.)
 
-### 26. [ ] Public API leaks beyond the documented surface
+### 26. [x] Public API leaks beyond the documented surface
 `Proxy.kt:391, 427` · `common/BaseOptions.kt:201` — **API surface, low, confirmed (policy
 documented in CLAUDE.md)**
 
@@ -447,7 +447,7 @@ signature. `BaseOptions.configVals` / `Proxy.proxyConfigVals` / `Agent.agentConf
 expose the generated `ConfigVals` type, which is not in the enumerated public-API list. **Fix:**
 demote to `internal` (checking `docs/packages.md` per the promotion/demotion policy).
 
-### 27. [ ] Commented-out code remnants
+### 27. [x] Commented-out code remnants
 `Proxy.kt:364` · `proxy/ProxyHttpService.kt:77-81, 95` · `proxy/AgentContext.kt:139` ·
 `common/BaseOptions.kt:50, 422` — **dead code, low, confirmed**
 
@@ -455,7 +455,7 @@ Includes one actively misleading case: `common/BaseOptions.kt:422` has the comme
 `// .resolve() Unnecessary` directly above/beside a line that *does* call `.resolve(...)`.
 **Fix:** delete the remnants; correct or remove the contradictory comment.
 
-### 28. [ ] Magic numbers
+### 28. [x] Magic numbers
 `proxy/ProxyHttpService.kt:56` (`45` idle-timeout fallback) · `Agent.kt:265` (`* 2` backlog
 multiplier) · `agent/AgentGrpcService.kt:152` (`awaitTermination(5, SECONDS)`) ·
 `agent/AgentHttpService.kt:287` (`exponentialDelay(maxDelayMs = 5000L)`) · `Proxy.kt:273`
@@ -464,14 +464,14 @@ confirmed**
 
 **Fix:** name them as constants with a one-line rationale where non-obvious (especially the `* 2`).
 
-### 29. [ ] Duplicate `Cache-Control` header on every scrape response
+### 29. [x] Duplicate `Cache-Control` header on every scrape response
 `proxy/ProxyHttpRoutes.kt:93` + `proxy/ProxyUtils.kt:128` — **duplication, low, duplication
 confirmed / append semantics plausible**
 
 `handleClientRequests` sets `Cache-Control` on entry, then `respondWith` appends the same header
 again (Ktor's `response.header` appends rather than replaces). **Fix:** one site owns the header.
 
-### 30. [ ] Doubled exception rendering in scrape-failure warn logging
+### 30. [x] Doubled exception rendering in scrape-failure warn logging
 `common/ScrapeResults.kt:104, 115` — **logging, low, confirmed**
 
 `logger.warn(e) { "fetchScrapeUrl() $e - $url" }` interpolates the exception's `toString()` into
@@ -479,7 +479,7 @@ the message *and* passes it for a full stack trace — every scrape of a down en
 common failure) prints the exception twice plus a stack at WARN. **Fix:** message without `$e`
 (keep the throwable argument), matching the deliberately compact IOException branch at line 110.
 
-### 31. [ ] Dead parameter flexibility
+### 31. [x] Dead parameter flexibility
 `common/BaseOptions.kt:242-249` · `agent/AgentConnectionContext.kt:39` — **dead code, low,
 confirmed**
 
@@ -489,7 +489,7 @@ shadows the constructor's non-null `args` and is called exactly once with the no
 silently diverges from config if a new call site forgets to pass it. **Fix:** drop the nullability
 and the default.
 
-### 32. [ ] Cleanup-service gating predicate duplicated between `startUp`/`shutDown`
+### 32. [x] Cleanup-service gating predicate duplicated between `startUp`/`shutDown`
 `Proxy.kt:247-254` vs `265-266` — **duplication, low, confirmed**
 
 The predicate deciding whether `agentCleanupService` runs is written twice in different shapes; an
@@ -501,7 +501,7 @@ both.
 
 ## 🔵 Kotlin idioms
 
-### 33. [ ] `HttpClientCache` uses epoch millis instead of monotonic `TimeMark`s
+### 33. [x] `HttpClientCache` uses epoch millis instead of monotonic `TimeMark`s
 `agent/HttpClientCache.kt:99-103, 189, 258-265, 301, 342` — **consistency + minor correctness**
 
 `CacheEntry(createdAt/lastAccessedAt: Long = System.currentTimeMillis())` with manual `now - then`
@@ -510,7 +510,7 @@ vs `maxAge.inWholeMilliseconds` arithmetic, while the rest of the project uses
 an NTP wall-clock step means mass eviction or immortal entries. **Fix:**
 `val createdAt: TimeMark = markNow()` + `createdAt.elapsedNow() < maxAge`.
 
-### 34. [ ] Two hand-rolled cause-chain walks with different exception sets
+### 34. [x] Two hand-rolled cause-chain walks with different exception sets
 `agent/AgentHttpService.kt:124-137` · `common/ScrapeResults.kt:121-134` — **duplication with
 behavioral drift**
 
@@ -533,7 +533,7 @@ but resolution can collapse to a helper:
 `scrapeTimeoutSecs = resolvePositiveInt(scrapeTimeoutSecs, SCRAPE_TIMEOUT_SECS, default, "scrapeTimeoutSecs")`
 — mirroring the existing `resolveBooleanOption`, which proves the pattern works here.
 
-### 36. [ ] Scope-function misuse cluster
+### 36. [x] Scope-function misuse cluster
 Multiple sites — **readability**
 
 - `Agent.kt:347` / `agent/AgentGrpcService.kt:467`: `Status.fromThrowable(e).apply { logger.error(e)
@@ -549,7 +549,7 @@ Multiple sites — **readability**
   times — the classic sign the scope function is fighting you. → `val http = agentConfigVals.http`
   and plain member access.
 
-### 37. [ ] `readConfig` control flow: nullable `Throwable` + non-local returns
+### 37. [x] `readConfig` control flow: nullable `Throwable` + non-local returns
 `common/BaseOptions.kt:447-500` — **readability**
 
 Success paths `return` non-locally from inside `runCatchingCancellable { }`, while
@@ -559,7 +559,7 @@ local `fun fail(configName: String, e: Throwable?): Nothing` + per-branch
 throwable, no non-local returns. (Restructure together with finding 5, which touches the same
 function family.)
 
-### 38. [ ] Manual CAS loop in `decrementBacklog`
+### 38. [x] Manual CAS loop in `decrementBacklog`
 `Agent.kt:187-193` — **readability**
 
 The hand-written `while (true) { load; compareAndSet }` loop predates the API; Kotlin 2.4's
@@ -567,7 +567,7 @@ The hand-written `while (true) { load; compareAndSet }` loop predates the API; K
 `scrapeRequestBacklogSize.update { maxOf(it - delta, 0) }` — 7 lines become 1; keep the KDoc
 rationale.
 
-### 39. [ ] `mergeContentTexts`: `var` flag mutated inside `map` + repeated literal
+### 39. [x] `mergeContentTexts`: `var` flag mutated inside `map` + repeated literal
 `proxy/ProxyHttpRoutes.kt:183-193` — **readability**
 
 `var hasEof = false` is set as a side effect of the `nonEmpty.map { }` transformation, and
@@ -575,19 +575,19 @@ rationale.
 trimmed.any { it.endsWith(EOF) }`, `val stripped = trimmed.map { it.removeSuffix(EOF).trimEnd() }`;
 hoist an `EOF` constant.
 
-### 40. [ ] `reconnectLimiter` split declaration/`init`-assignment
+### 40. [x] `reconnectLimiter` split declaration/`init`-assignment
 `Agent.kt:174, 204` — **readability**
 
 `private val reconnectLimiter: RateLimiter` declared, assigned 30 lines later in `init` — nothing
 forces the split. Initialize at the declaration (with the finding-11 validation added first).
 
-### 41. [ ] Manual `while(true)/poll/break` drain loops
+### 41. [x] Manual `while(true)/poll/break` drain loops
 `proxy/AgentContext.kt:115-118` · `agent/AgentConnectionContext.kt:81-84` — **readability**
 
 → `generateSequence { scrapeRequestQueue.poll() }.forEach { it.closeChannel() }` and
 `generateSequence { tryReceive().getOrNull() }.count()` respectively.
 
-### 42. [ ] Scheme-stripping `when` reducible to `removePrefix` chain
+### 42. [x] Scheme-stripping `when` reducible to `removePrefix` chain
 `agent/AgentGrpcService.kt:117-125` — **readability + tiny consistency gap**
 
 The `when { startsWith... }` reduces to

--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -32,7 +32,6 @@ import com.pambrose.common.util.randomId
 import com.pambrose.common.util.runCatchingCancellable
 import com.pambrose.common.util.simpleClassName
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import io.prometheus.agent.AgentConnectionContext
@@ -50,8 +49,8 @@ import io.prometheus.common.ConfigVals
 import io.prometheus.common.ConfigWrappers.newAdminConfig
 import io.prometheus.common.ConfigWrappers.newMetricsConfig
 import io.prometheus.common.ConfigWrappers.newZipkinConfig
-import io.prometheus.common.Utils.exceptionDetails
 import io.prometheus.common.Utils.getVersionDesc
+import io.prometheus.common.Utils.logStreamFailure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -62,6 +61,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Semaphore
 import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.update
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -171,8 +171,10 @@ class Agent(
   private val initialConnectionLatch = CountDownLatch(1)
   private val initialPathsRegisteredLatch = CountDownLatch(1)
 
-  // Prime the limiter. internal + var so tests can substitute a mock to verify reconnect pacing (finding 3).
-  internal var reconnectLimiter: RateLimiter
+  // Primed (one acquire) at construction. internal + var so tests can substitute a mock to verify
+  // reconnect pacing (finding 3). reconnectPauseSecs is validated > 0 in AgentOptions (finding 11).
+  internal var reconnectLimiter: RateLimiter =
+    RateLimiter.create(1.0 / agentConfigVals.internal.reconnectPauseSecs).apply { acquire() }
   private var lastMsgSentMark: TimeMark by nonNullableReference(clock.markNow())
 
   internal val agentName = options.agentName.ifBlank { "Unnamed-${hostInfo.hostName}" }
@@ -186,11 +188,7 @@ class Agent(
    * overlapping items. This CAS loop prevents the counter from going negative.
    */
   internal fun decrementBacklog(delta: Int) {
-    while (true) {
-      val current = scrapeRequestBacklogSize.load()
-      val next = maxOf(current - delta, 0)
-      if (scrapeRequestBacklogSize.compareAndSet(current, next)) return
-    }
+    scrapeRequestBacklogSize.update { maxOf(it - delta, 0) }
   }
 
   internal val pathManager = AgentPathManager(this)
@@ -199,11 +197,9 @@ class Agent(
   internal val launchId = randomId(15)
   internal val metrics by lazy { AgentMetrics(this) }
 
-  val agentConfigVals: ConfigVals.Agent get() = configVals.agent
+  internal val agentConfigVals: ConfigVals.Agent get() = configVals.agent
 
   init {
-    reconnectLimiter = RateLimiter.create(1.0 / agentConfigVals.internal.reconnectPauseSecs).apply { acquire() }
-
     fun toPlainText() =
       """
         Prometheus Agent Info [${getVersionDesc(false)}]
@@ -263,7 +259,10 @@ class Agent(
         initialPathsRegisteredLatch.countDown()
 
         // Close connectionContext when disconnected from the server or the service is shutdown and isRunning is false
-        val connectionContext = AgentConnectionContext(agentConfigVals.internal.scrapeRequestBacklogUnhealthySize * 2)
+        val connectionContext =
+          AgentConnectionContext(
+            agentConfigVals.internal.scrapeRequestBacklogUnhealthySize * BACKLOG_CAPACITY_MULTIPLIER,
+          )
 
         coroutineScope {
           // Each task runs for the connection's lifetime; on completion launchConnectionTask closes
@@ -354,7 +353,7 @@ class Agent(
       runCatchingCancellable { block() }
         .onFailure { e ->
           if (isRunning)
-            Status.fromThrowable(e).apply { logger.error(e) { "$name(): ${exceptionDetails(e)}" } }
+            logger.logStreamFailure(name, e)
         }
     }.apply {
       invokeOnCompletion {
@@ -370,7 +369,9 @@ class Agent(
       }
 
       is StatusRuntimeException -> {
-        logger.info { "Disconnected from proxy at $proxyHost" }
+        // Include the gRPC status so UNAVAILABLE / UNAUTHENTICATED / RESOURCE_EXHAUSTED reconnect loops
+        // are distinguishable in the logs (finding 22).
+        logger.info { "Disconnected from proxy at $proxyHost - ${e.status}" }
       }
 
       is StatusException -> {
@@ -410,17 +411,10 @@ class Agent(
           HealthCheck.Result.healthy()
       },
     )
-    healthCheckRegistry.register(
-      "http_client_cache_size_check",
-      healthCheck {
-        val currentSize = agentHttpService.httpClientCache.currentCacheSize()
-        val threshold = options.maxCacheSize + 1
-        if (currentSize >= threshold)
-          HealthCheck.Result.unhealthy("HTTP client cache size $currentSize >= threshold $threshold")
-        else
-          HealthCheck.Result.healthy()
-      },
-    )
+    // The http_client_cache_size_check health check was removed (finding 24): its threshold
+    // (maxCacheSize + 1) was unreachable because the cache evicts before insert, so cache.size never
+    // exceeds maxCacheSize and the unhealthy branch could never fire. The cache size is still exported
+    // as a metric (AgentMetrics).
   }
 
   private suspend fun startHeartBeat(connectionContext: AgentConnectionContext) {
@@ -579,6 +573,10 @@ class Agent(
     // every heartbeat fails; a small threshold keeps a transient blip from reconnecting while still
     // detecting a truly dead connection within a few heartbeat cycles (finding 2).
     private const val MAX_HEARTBEAT_FAILURES = 3
+
+    // The connection's scrape-request channel is sized at 2x the backlog-unhealthy threshold so the
+    // health check can fire (backlog >= threshold) before the channel actually blocks senders (finding 28).
+    private const val BACKLOG_CAPACITY_MULTIPLIER = 2
 
     /**
      * JVM entry point for the standalone Agent process.

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -186,7 +186,14 @@ class Proxy(
   // unlabeled since PromQL rate()/increase() already tolerate counter resets across restarts.
   internal val launchId = randomId(15)
 
-  val proxyConfigVals: ConfigVals.Proxy2 get() = configVals.proxy
+  // internal: the generated ConfigVals type is not part of the documented public API (finding 26).
+  internal val proxyConfigVals: ConfigVals.Proxy2 get() = configVals.proxy
+
+  // The stale-agent cleanup service runs when explicitly enabled, or is forced on when the transport
+  // filter is disabled (there's then no per-connection disconnect detection, so it's the only cleanup
+  // mechanism). Computed once so startUp() and shutDown() can't drift (finding 32).
+  private val agentCleanupServiceEnabled: Boolean
+    get() = proxyConfigVals.internal.staleAgentCheckEnabled || options.transportFilterDisabled
 
   init {
     fun toPlainText() =
@@ -244,10 +251,9 @@ class Proxy(
     // agent disconnects. The stale agent cleanup service is the only mechanism to clean up
     // leaked AgentContexts (e.g., agents that called connectAgentWithTransportFilterDisabled
     // but crashed before opening a readRequestsFromProxy stream). Force-enable it.
-    if (proxyConfigVals.internal.staleAgentCheckEnabled) {
-      agentCleanupService.startSync()
-    } else if (options.transportFilterDisabled) {
-      logger.warn { "Forcing agent eviction thread on: transportFilterDisabled requires stale agent cleanup" }
+    if (agentCleanupServiceEnabled) {
+      if (!proxyConfigVals.internal.staleAgentCheckEnabled)
+        logger.warn { "Forcing agent eviction thread on: transportFilterDisabled requires stale agent cleanup" }
       agentCleanupService.startSync()
     } else {
       logger.info { "Agent eviction thread not started" }
@@ -262,7 +268,7 @@ class Proxy(
     agentContextManager.invalidateAllAgentContexts()
     grpcService.stopSync()
     httpService.stopSync()
-    if (proxyConfigVals.internal.staleAgentCheckEnabled || options.transportFilterDisabled)
+    if (agentCleanupServiceEnabled)
       agentCleanupService.stopSync()
     super.shutDown()
   }
@@ -270,7 +276,7 @@ class Proxy(
   override fun run() {
     runBlocking {
       while (isRunning) {
-        delay(500.milliseconds)
+        delay(RUN_LOOP_PAUSE)
       }
     }
   }
@@ -361,7 +367,6 @@ class Proxy(
       args.invoke(metrics)
   }
 
-  // val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
   private val formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
 
   /**
@@ -388,7 +393,7 @@ class Proxy(
    * @param path The request path to check
    * @return true if this is a Blitz verification request, false otherwise
    */
-  fun isBlitzRequest(path: String) = with(proxyConfigVals.internal) { blitz.enabled && path == blitz.path }
+  internal fun isBlitzRequest(path: String) = with(proxyConfigVals.internal) { blitz.enabled && path == blitz.path }
 
   /**
    * Builds a Prometheus-compatible service discovery JSON response.
@@ -424,7 +429,7 @@ class Proxy(
    * @return JsonArray containing service discovery information for all registered paths
    * @see <a href="https://prometheus.io/docs/prometheus/latest/http_sd/">Prometheus HTTP Service Discovery</a>
    */
-  fun buildServiceDiscoveryJson(): JsonArray =
+  internal fun buildServiceDiscoveryJson(): JsonArray =
     buildJsonArray {
       pathManager.allPathContextInfos().forEach { (path, agentContextInfo) ->
         addJsonObject {
@@ -467,6 +472,9 @@ class Proxy(
 
   companion object {
     private val logger = logger {}
+
+    // Idle pause of the proxy's run loop, which just parks the service thread until shutdown (finding 28).
+    private val RUN_LOOP_PAUSE = 500.milliseconds
 
     // Service-discovery label keys computed by the proxy; agent-supplied labels must not overwrite them.
     private val RESERVED_SD_LABEL_KEYS = setOf("__metrics_path__", "agentName", "hostName")

--- a/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentConnectionContext.kt
@@ -36,7 +36,9 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
  * @see io.prometheus.Agent
  */
 internal class AgentConnectionContext(
-  val backlogCapacity: Int = 128,
+  // No default: the sole production caller derives this from config, and a default would silently
+  // diverge if a future call site forgot to pass it (finding 31).
+  val backlogCapacity: Int,
 ) {
   private var disconnected by atomicBoolean(false)
   private val scrapeRequestActionsChannel = Channel<ScrapeRequestAction>(backlogCapacity)
@@ -78,10 +80,7 @@ internal class AgentConnectionContext(
         // Close (not cancel) and drain the scrape request actions channel so that
         // callers can adjust scrapeRequestBacklogSize by the drained count.
         scrapeRequestActionsChannel.close()
-        var drained = 0
-        while (scrapeRequestActionsChannel.tryReceive().isSuccess) {
-          drained++
-        }
+        val drained = generateSequence { scrapeRequestActionsChannel.tryReceive().getOrNull() }.count()
         // Use close() instead of cancel() so buffered results can still be drained
         // by the consumer. cancel() discards all buffered items, causing the proxy
         // to time out waiting for results that were already computed.

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -31,7 +31,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.grpc.ClientInterceptor
 import io.grpc.ClientInterceptors
 import io.grpc.ManagedChannel
-import io.grpc.Status
 import io.prometheus.Agent
 import io.prometheus.common.BaseOptions.Companion.HTTPS_PREFIX
 import io.prometheus.common.BaseOptions.Companion.HTTP_PREFIX
@@ -39,7 +38,7 @@ import io.prometheus.common.DefaultObjects.EMPTY_INSTANCE
 import io.prometheus.common.Messages.EMPTY_AGENT_ID_MSG
 import io.prometheus.common.Messages.EMPTY_PATH_MSG
 import io.prometheus.common.ScrapeResults
-import io.prometheus.common.Utils.exceptionDetails
+import io.prometheus.common.Utils.logStreamFailure
 import io.prometheus.common.Utils.parseHostPort
 import io.prometheus.grpc.ChunkedScrapeResponse
 import io.prometheus.grpc.ProxyServiceGrpcKt
@@ -128,15 +127,12 @@ internal class AgentGrpcService(
   private val tlsContext: TlsContext
 
   init {
+    // Strip either scheme prefix (case-insensitively, matching BaseOptions.isUrlPrefix); the prefixes
+    // are mutually exclusive so a chain works, and removePrefixIgnoreCase no-ops when absent (finding 42).
     val schemeStripped =
       options.proxyHostname
-        .run {
-          when {
-            startsWith(HTTP_PREFIX) -> removePrefix(HTTP_PREFIX)
-            startsWith(HTTPS_PREFIX) -> removePrefix(HTTPS_PREFIX)
-            else -> this
-          }
-        }
+        .removePrefixIgnoreCase(HTTPS_PREFIX)
+        .removePrefixIgnoreCase(HTTP_PREFIX)
 
     val parsed = parseHostPort(schemeStripped, DEFAULT_GRPC_PORT)
     agentHostName = parsed.host
@@ -161,7 +157,11 @@ internal class AgentGrpcService(
   private fun shutDownChannelLocked() {
     if (grpcStarted) {
       channel.shutdownNow()
-      channel.awaitTermination(5, SECONDS)
+      // A false return means the channel did not terminate in time; a leftover call's late onHeaders can
+      // then re-assign a stale agentId to the next connection (finding 20), so surface it instead of
+      // ignoring the boolean.
+      if (!channel.awaitTermination(CHANNEL_TERMINATION_TIMEOUT_SECS, SECONDS))
+        logger.warn { "gRPC channel did not terminate within ${CHANNEL_TERMINATION_TIMEOUT_SECS}s" }
     }
   }
 
@@ -473,7 +473,11 @@ internal class AgentGrpcService(
     val chunkedChannel = Channel<ChunkedScrapeResponse>(UNLIMITED)
 
     fun closeAll() {
-      connectionContext.close()
+      // close() drains N buffered scrape actions; decrement the backlog by that count here too (mirroring
+      // Agent.launchConnectionTask's invokeOnCompletion) so the gauge isn't left inflated by N until the
+      // next connect resets it (finding 18).
+      val drained = connectionContext.close()
+      if (drained > 0) agent.decrementBacklog(drained)
       nonChunkedChannel.close()
       chunkedChannel.close()
     }
@@ -489,7 +493,7 @@ internal class AgentGrpcService(
       runCatchingCancellable { block() }
         .onFailure { e ->
           if (agent.isRunning)
-            Status.fromThrowable(e).apply { logger.error(e) { "$name(): ${exceptionDetails(e)}" } }
+            logger.logStreamFailure(name, e)
           if (e !is CancellationException) closeAll()
         }
     }
@@ -527,5 +531,13 @@ internal class AgentGrpcService(
   companion object {
     private val logger = logger {}
     private const val DEFAULT_GRPC_PORT = 50051
+
+    // Max time to wait for the gRPC channel to terminate after shutdownNow() (finding 28).
+    private const val CHANNEL_TERMINATION_TIMEOUT_SECS = 5L
+
+    // Case-insensitive counterpart to String.removePrefix, so the proxy-hostname scheme strip matches
+    // BaseOptions.isUrlPrefix's case-insensitivity (finding 42). No-ops when the prefix is absent.
+    private fun String.removePrefixIgnoreCase(prefix: String): String =
+      if (startsWith(prefix, ignoreCase = true)) substring(prefix.length) else this
   }
 }

--- a/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentHttpService.kt
@@ -31,7 +31,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpRequestRetry
-import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
@@ -52,8 +51,9 @@ import io.prometheus.common.ScrapeResults
 import io.prometheus.common.ScrapeResults.Companion.errorCode
 import io.prometheus.common.Utils.appendQueryParams
 import io.prometheus.common.Utils.sanitizeUrl
+import io.prometheus.common.hasTimeoutCause
 import io.prometheus.grpc.ScrapeRequest
-import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.readByteArray
 import javax.net.ssl.X509TrustManager
@@ -123,18 +123,10 @@ internal class AgentHttpService(
         }
       } catch (e: Throwable) {
         // Catch regular exceptions and HttpRequestTimeoutException (which is a CancellationException)
-        // but let other CancellationExceptions propagate (like system shutdown).
-        // Ktor often wraps the timeout exception, so we walk the cause chain as well.
-        var isTimeout = e is HttpRequestTimeoutException || e is TimeoutCancellationException
-        var curr: Throwable? = e
-        while (!isTimeout && curr != null) {
-          isTimeout = isTimeoutException(curr)
-          curr = curr.cause
-        }
-
-        if (e is kotlinx.coroutines.CancellationException && !isTimeout) {
+        // but let other CancellationExceptions propagate (like system shutdown). Uses the shared
+        // cause-walk predicate so the catch branch and the status-code mapping agree (finding 34).
+        if (e is CancellationException && !e.hasTimeoutCause())
           throw e
-        }
 
         // Re-throw JVM Errors (OutOfMemoryError, StackOverflowError, etc.) so the agent terminates
         // instead of swallowing them into a routine 503 result and running in a corrupted state.
@@ -289,7 +281,7 @@ internal class AgentHttpService(
               response.status.value in 500..599
             }
             modifyRequest { it.headers.append("x-retry-count", retryCount.toString()) }
-            exponentialDelay(maxDelayMs = 5000L)
+            exponentialDelay(maxDelayMs = MAX_RETRY_DELAY_MS)
           }
         }
       }
@@ -356,8 +348,8 @@ internal class AgentHttpService(
     private const val SUCCESS_MSG = "success"
     private const val UNSUCCESSFUL_MSG = "unsuccessful"
 
-    private fun isTimeoutException(e: Throwable): Boolean =
-      e is HttpRequestTimeoutException || e is TimeoutCancellationException
+    // Cap on the retry backoff so total retry time stays bounded within the scrape timeout (finding 28).
+    private const val MAX_RETRY_DELAY_MS = 5000L
 
     private fun handleInvalidPath(scrapeRequest: ScrapeRequest): ScrapeResults {
       logger.warn { "Invalid path in fetchScrapeUrl(): ${scrapeRequest.path}" }

--- a/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentPathManager.kt
@@ -44,7 +44,9 @@ internal class AgentPathManager(
 
   operator fun get(path: String): PathContext? = pathContextMap[path]
 
-  fun clear() = pathContextMap.clear()
+  // Routed through pathMutex so a dynamic registerPath racing a reconnect can't insert a stale
+  // PathContext into the freshly-cleared map (finding 19).
+  suspend fun clear() = pathMutex.withLock { pathContextMap.clear() }
 
   suspend fun pathMapSize(): Int = agent.grpcService.pathMapSize()
 
@@ -67,8 +69,10 @@ internal class AgentPathManager(
 
     val path = pathVal.removePrefix("/")
     val labelsJson = labels.defaultEmptyJsonObject()
-    val pathId = agent.grpcService.registerPathOnProxy(path, labelsJson).pathId
+    // Hold pathMutex across the proxy RPC AND the local map write so concurrent register/unregister of
+    // the same path can't leave the local map and the proxy's view disagreeing (finding 19).
     pathMutex.withLock {
+      val pathId = agent.grpcService.registerPathOnProxy(path, labelsJson).pathId
       if (!agent.isTestMode)
         logger.info { "Registered $url as /$path with labels $labelsJson" }
       pathContextMap[path] = PathContext(pathId, path, url, labelsJson)
@@ -79,8 +83,9 @@ internal class AgentPathManager(
     require(pathVal.isNotEmpty()) { EMPTY_PATH_MSG }
 
     val path = pathVal.removePrefix("/")
-    agent.grpcService.unregisterPathOnProxy(path)
+    // Hold pathMutex across the proxy RPC AND the local map write (finding 19).
     pathMutex.withLock {
+      agent.grpcService.unregisterPathOnProxy(path)
       val pathContext = pathContextMap.remove(path)
       if (pathContext == null) {
         logger.info { "No path value /$path found in pathContextMap when unregistering" }

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.security.SecureRandom
-import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.concurrent.atomics.AtomicBoolean
@@ -38,6 +37,8 @@ import kotlin.concurrent.atomics.decrementAndFetch
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource.Monotonic
 
 /**
  * LRU cache for Ktor [HttpClient] instances keyed by authentication credentials.
@@ -60,9 +61,14 @@ internal class HttpClientCache(
   private val maxIdleTime: Duration = 10.minutes,
   private val cleanupInterval: Duration = 5.minutes,
 ) {
-  private val cache = ConcurrentHashMap<String, CacheEntry>()
+  // A single access-ordered LinkedHashMap (accessOrder = true) is both the cache and the recency
+  // tracker: get() moves an entry to the most-recently-used end, so the least-recently-used entry is
+  // always the iteration head -- O(1) eviction, no parallel recency map (finding 25). Every access is
+  // under accessMutex, so the plain map is safe; cacheSize mirrors the size for a lock-free
+  // currentCacheSize() read from the metrics/health-check threads (Bug #12).
+  private val cache = LinkedHashMap<String, CacheEntry>(INITIAL_CAPACITY, LOAD_FACTOR, true)
+  private val cacheSize = AtomicInt(0)
 
-  private val accessOrder = HashMap<String, Long>()
   private val accessMutex = Mutex()
   private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -98,8 +104,10 @@ internal class HttpClientCache(
 
   class CacheEntry(
     val client: HttpClient,
-    val createdAt: Long = System.currentTimeMillis(),
-    var lastAccessedAt: Long = System.currentTimeMillis(),
+    // Monotonic TimeMarks rather than epoch millis so an NTP wall-clock step can't mass-evict or
+    // immortalize entries, matching the rest of the project (finding 33).
+    val createdAt: TimeMark = Monotonic.markNow(),
+    var lastAccessedAt: TimeMark = Monotonic.markNow(),
   ) {
     private val markedForClose = AtomicBoolean(false)
     private val inUseCount = AtomicInt(0)
@@ -177,7 +185,7 @@ internal class HttpClientCache(
     }
   }
 
-  fun currentCacheSize() = cache.size
+  fun currentCacheSize() = cacheSize.load()
 
   // When an entry is returned from the cache, it is marked as in use.
   suspend fun getOrCreateClient(
@@ -186,15 +194,14 @@ internal class HttpClientCache(
   ): CacheEntry {
     val cacheKey = key.cacheKey()
     val maskedString = key.maskedKey()
-    val now = System.currentTimeMillis()
 
     val (entry, clientsToClose) =
       accessMutex.withLock {
         check(!closed) { "HttpClientCache is closed" }
+        // cache[cacheKey] is a get(): on an accessOrder LinkedHashMap it also marks the entry MRU.
         val result = cache[cacheKey]?.let { existing ->
-          if (isEntryValid(existing, now)) {
-            existing.lastAccessedAt = now
-            updateAccessOrder(cacheKey, now)
+          if (isEntryValid(existing)) {
+            existing.lastAccessedAt = Monotonic.markNow()
             logger.debug { "Using cached HTTP client for key: $maskedString" }
             existing.onStartWithClient()
             existing
@@ -203,12 +210,7 @@ internal class HttpClientCache(
             removeEntry(cacheKey)
             null
           }
-        } ?: createAndCacheClient(
-          cacheKey,
-          maskedString,
-          clientFactory = clientFactory,
-          now = now,
-        ).apply { onStartWithClient() }
+        } ?: createAndCacheClient(cacheKey, maskedString, clientFactory).apply { onStartWithClient() }
 
         result to drainPendingCloses()
       }
@@ -234,39 +236,24 @@ internal class HttpClientCache(
     keyString: String,
     maskedKey: String,
     clientFactory: () -> HttpClient,
-    now: Long,
   ): CacheEntry {
-    if (cache.size >= maxCacheSize) {
+    if (cache.size >= maxCacheSize)
       evictLeastRecentlyUsed()
-    }
 
-    val client = clientFactory()
-    val entry = CacheEntry(client, now, now)
+    val entry = CacheEntry(clientFactory())
     cache[keyString] = entry
-    updateAccessOrder(keyString, now)
+    cacheSize.store(cache.size)
     logger.info { "Created and cached HTTP client for key: $maskedKey" }
     return entry
   }
 
-  private fun updateAccessOrder(
-    keyString: String,
-    timestamp: Long,
-  ) {
-    accessOrder[keyString] = timestamp
-  }
-
-  private fun isEntryValid(
-    entry: CacheEntry,
-    now: Long,
-  ): Boolean {
-    val age = now - entry.createdAt
-    val idleTime = now - entry.lastAccessedAt
-    return age < maxAge.inWholeMilliseconds && idleTime < maxIdleTime.inWholeMilliseconds
-  }
+  private fun isEntryValid(entry: CacheEntry): Boolean =
+    entry.createdAt.elapsedNow() < maxAge && entry.lastAccessedAt.elapsedNow() < maxIdleTime
 
   // Called with mutex
   private fun evictLeastRecentlyUsed() {
-    val lruKey = accessOrder.entries.minByOrNull { it.value }?.key
+    // accessOrder = true keeps the least-recently-used entry at the iteration head.
+    val lruKey = cache.keys.firstOrNull()
     if (lruKey != null) {
       // The cache key for authenticated clients is a salted digest (non-sensitive), but mask it
       // anyway so eviction logs never expose a per-credential identifier; NO_AUTH is left as-is.
@@ -281,13 +268,13 @@ internal class HttpClientCache(
   private fun removeEntry(keyString: String) {
     val entry = cache.remove(keyString)
     if (entry != null) {
+      cacheSize.store(cache.size)
       entry.markForClose()
       if (!entry.isInUse()) {
         pendingCloses += entry.client
       }
       // In-use entries will be closed when the last user calls onFinishedWithClient()
     }
-    accessOrder.remove(keyString)
   }
 
   // Called with mutex. Returns and clears the pending-close list.
@@ -298,9 +285,8 @@ internal class HttpClientCache(
 
   // Called with mutex
   private fun cleanupExpiredEntries() {
-    val now = System.currentTimeMillis()
     val expiredKeys = cache.entries
-      .filter { !isEntryValid(it.value, now) }
+      .filter { !isEntryValid(it.value) }
       .map { it.key }
 
     if (expiredKeys.isNotEmpty()) {
@@ -328,7 +314,7 @@ internal class HttpClientCache(
       // Drain any pending closes from prior removeEntry() calls
       clientsToClose += drainPendingCloses()
       cache.clear()
-      accessOrder.clear()
+      cacheSize.store(0)
       // Set the terminal flag in the same critical section that clears the map, so there is no
       // window where getOrCreateClient() could repopulate the cache after this point.
       closed = true
@@ -339,8 +325,7 @@ internal class HttpClientCache(
 
   suspend fun getCacheStats(): CacheStats =
     accessMutex.withLock {
-      val now = System.currentTimeMillis()
-      val validEntries = cache.values.count { isEntryValid(it, now) }
+      val validEntries = cache.values.count { isEntryValid(it) }
       CacheStats(
         totalEntries = cache.size,
         validEntries = validEntries,
@@ -356,6 +341,9 @@ internal class HttpClientCache(
 
   companion object {
     private val logger = logger {}
+
+    private const val INITIAL_CAPACITY = 16
+    private const val LOAD_FACTOR = 0.75f
 
     // Closes a client, swallowing and logging any failure so it can never propagate. Critical for the
     // background sweeper loop: a throwing HttpClient.close() there would break out of the while(isActive)

--- a/src/main/kotlin/io/prometheus/common/BaseOptions.kt
+++ b/src/main/kotlin/io/prometheus/common/BaseOptions.kt
@@ -47,7 +47,6 @@ import java.io.FileNotFoundException
 import java.net.URI
 import kotlin.system.exitProcess
 
-// @Parameters(separators = "=")
 abstract class BaseOptions protected constructor(
   private val progName: String,
   private val args: Array<String>,
@@ -198,7 +197,8 @@ abstract class BaseOptions protected constructor(
 
   private lateinit var config: Config
 
-  lateinit var configVals: ConfigVals
+  // internal: the generated ConfigVals type is not part of the documented public API (finding 26).
+  internal lateinit var configVals: ConfigVals
     private set
 
   val isTlsEnabled: Boolean
@@ -253,14 +253,14 @@ abstract class BaseOptions protected constructor(
       else
         throw ConfigLoadException(message, cause)
 
-    fun parseArgs(args: Array<String>?) {
+    fun parseArgs() {
       try {
         val jcom =
           JCommander(this)
             .apply {
               programName = progName
               setCaseSensitiveOptions(false)
-              parse(*(args.orEmpty()))
+              parse(*args)
             }
 
         if (usage) {
@@ -278,7 +278,7 @@ abstract class BaseOptions protected constructor(
       }
     }
 
-    parseArgs(args)
+    parseArgs()
     readConfig(envConfig, exitOnMissingConfig)
     configVals = ConfigVals(config)
     assignConfigVals()
@@ -433,7 +433,6 @@ abstract class BaseOptions protected constructor(
         exitOnMissingConfig,
       )
         .resolve(ConfigResolveOptions.defaults())
-    // .resolve() Unnecessary
 
     dynamicParams
       .forEach { (k, v) ->
@@ -465,52 +464,51 @@ abstract class BaseOptions protected constructor(
     fallback: Config,
     exitOnMissingConfig: Boolean,
   ): Config {
-    // Captures the parse failure (if any) so the post-when handling can honor exitOnMissingConfig.
-    // The success paths return early from inside runCatchingCancellable.
-    val failureCause: Throwable? =
-      when {
-        configName.isBlank() -> {
-          if (exitOnMissingConfig) {
-            logger.error { $$"A configuration file or url must be specified with --config or $$$envConfig" }
-            exitProcess(1)
-          }
-          return fallback
-        }
+    // A parse failure ends startup: in standalone mode terminate the process; in embedded mode
+    // (exitOnMissingConfig == false) throw so the host application can recover. Local helper so each
+    // branch fails inline (no nullable Throwable threaded past the when, no non-local returns -- finding 37).
+    fun fail(e: Throwable): Nothing =
+      if (exitOnMissingConfig)
+        exitProcess(1)
+      else
+        throw ConfigLoadException("Unable to load configuration from '$configName'", e)
 
-        configName.isUrlPrefix() -> {
-          runCatchingCancellable {
-            val configSyntax = getConfigSyntax(configName)
-            return ConfigFactory
-              .parseURL(URI(configName).toURL(), configParseOptions.setSyntax(configSyntax))
-              .withFallback(fallback)
-          }.exceptionOrNull()
-            ?.also { e ->
-              if (e.cause is FileNotFoundException)
-                logger.error { "Invalid config url: $configName" }
-              else
-                logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
-            }
+    return when {
+      configName.isBlank() -> {
+        if (exitOnMissingConfig) {
+          logger.error { $$"A configuration file or url must be specified with --config or $$$envConfig" }
+          exitProcess(1)
         }
+        fallback
+      }
 
-        else -> {
-          runCatchingCancellable {
-            return ConfigFactory.parseFileAnySyntax(File(configName), configParseOptions).withFallback(fallback)
-          }.exceptionOrNull()
-            ?.also { e ->
-              if (e.cause is FileNotFoundException)
-                logger.error { "Invalid config filename: $configName" }
-              else
-                logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
-            }
+      configName.isUrlPrefix() -> {
+        runCatchingCancellable {
+          val configSyntax = getConfigSyntax(configName)
+          ConfigFactory
+            .parseURL(URI(configName).toURL(), configParseOptions.setSyntax(configSyntax))
+            .withFallback(fallback)
+        }.getOrElse { e ->
+          if (e.cause is FileNotFoundException)
+            logger.error { "Invalid config url: $configName" }
+          else
+            logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
+          fail(e)
         }
       }
 
-    // A parse failure reached here. In standalone mode terminate the process; in embedded mode
-    // (exitOnMissingConfig == false) throw so the host application can recover instead of dying.
-    if (exitOnMissingConfig)
-      exitProcess(1)
-    else
-      throw ConfigLoadException("Unable to load configuration from '$configName'", failureCause)
+      else -> {
+        runCatchingCancellable {
+          ConfigFactory.parseFileAnySyntax(File(configName), configParseOptions).withFallback(fallback)
+        }.getOrElse { e ->
+          if (e.cause is FileNotFoundException)
+            logger.error { "Invalid config filename: $configName" }
+          else
+            logger.error(e) { "Exception: ${e.simpleClassName} - ${e.message}" }
+          fail(e)
+        }
+      }
+    }
   }
 
   internal companion object {

--- a/src/main/kotlin/io/prometheus/common/ScrapeResults.kt
+++ b/src/main/kotlin/io/prometheus/common/ScrapeResults.kt
@@ -20,6 +20,7 @@ package io.prometheus.common
 
 import com.pambrose.common.util.EMPTY_BYTE_ARRAY
 import com.pambrose.common.util.simpleClassName
+import io.prometheus.common.Utils.causeChain
 import com.google.protobuf.ByteString
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -98,10 +99,11 @@ internal class ScrapeResults(
       e: Throwable,
       url: String,
     ): Int {
-      // Walk the cause chain to detect wrapped timeout exceptions.
-      // Ktor sometimes wraps HttpRequestTimeoutException in other exceptions.
-      if (hasTimeoutCause(e)) {
-        logger.warn(e) { "fetchScrapeUrl() $e - $url" }
+      // Detect wrapped timeout exceptions (Ktor sometimes wraps them) via the shared cause-walk.
+      if (e.hasTimeoutCause()) {
+        // Message without $e -- the throwable is already passed for the stack trace, so interpolating
+        // its toString() too would render it twice (finding 30).
+        logger.warn(e) { "fetchScrapeUrl() timed out - $url" }
         return RequestTimeout.value
       }
 
@@ -112,25 +114,20 @@ internal class ScrapeResults(
         }
 
         else -> {
-          logger.warn(e) { "fetchScrapeUrl() $e - $url" }
+          logger.warn(e) { "fetchScrapeUrl() - $url" }
           ServiceUnavailable.value
         }
       }
     }
-
-    private fun hasTimeoutCause(e: Throwable): Boolean {
-      var current: Throwable? = e
-      while (current != null) {
-        when (current) {
-          is TimeoutCancellationException,
-          is HttpConnectTimeoutException,
-          is SocketTimeoutException,
-          is HttpRequestTimeoutException,
-            -> return true
-        }
-        current = current.cause
-      }
-      return false
-    }
   }
 }
+
+// Shared timeout-cause predicate used by both the status-code mapping here and the agent's scrape-fetch
+// catch branch, so they can no longer disagree about the same throwable (finding 34).
+internal fun Throwable.hasTimeoutCause(): Boolean =
+  causeChain().any {
+    it is TimeoutCancellationException ||
+      it is HttpConnectTimeoutException ||
+      it is SocketTimeoutException ||
+      it is HttpRequestTimeoutException
+  }

--- a/src/main/kotlin/io/prometheus/common/Utils.kt
+++ b/src/main/kotlin/io/prometheus/common/Utils.kt
@@ -22,6 +22,7 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import com.pambrose.common.util.Version.Companion.versionDesc
 import com.pambrose.common.util.simpleClassName
+import io.github.oshai.kotlinlogging.KLogger
 import io.grpc.Status
 import io.prometheus.Proxy
 import kotlinx.serialization.json.Json
@@ -125,6 +126,21 @@ internal object Utils {
   }
 
   fun Status.exceptionDetails(e: Throwable) = "$code $description ${e.simpleClassName} - ${e.message}"
+
+  // The throwable's cause chain (itself first), for detecting a wrapped cause without a hand-rolled
+  // while/cause loop. Shared so the different cause-walks no longer drift (finding 34).
+  fun Throwable.causeChain(): Sequence<Throwable> = generateSequence(this) { it.cause }
+
+  // Logs a connection/stream-task failure at ERROR with the gRPC status details. Shared by the agent's
+  // connection-task and stream-task failure handlers, which were byte-for-byte identical (finding 23) and
+  // used apply {} only to smuggle the Status receiver for exceptionDetails() (finding 36).
+  fun KLogger.logStreamFailure(
+    name: String,
+    e: Throwable,
+  ) {
+    val status = Status.fromThrowable(e)
+    error(e) { "$name(): ${status.exceptionDetails(e)}" }
+  }
 
   data class HostPort(
     val host: String,

--- a/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContext.kt
@@ -21,6 +21,8 @@ package io.prometheus.proxy
 import com.pambrose.common.delegate.AtomicDelegates.atomicBoolean
 import com.pambrose.common.delegate.AtomicDelegates.nonNullableReference
 import com.pambrose.common.dsl.GuavaDsl.toStringElements
+import io.ktor.http.HttpStatusCode
+import io.prometheus.common.ScrapeResults
 import io.prometheus.grpc.RegisterAgentRequest
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
@@ -109,12 +111,18 @@ internal class AgentContext(
   fun invalidate() {
     valid = false
     scrapeRequestNotifier.close()
-    // Drain any buffered scrape requests and close their completion channels
-    // so HTTP handlers waiting on awaitCompleted() are notified immediately
-    // instead of waiting for the full scrape timeout to expire.
-    while (true) {
-      val wrapper = scrapeRequestQueue.poll() ?: break
-      wrapper.closeChannel()
+    // Drain any buffered scrape requests and FAIL them with an agent-disconnected result (not a bare
+    // channel close) so a waiting HTTP handler's awaitCompleted() sees a truthful 502 instead of a null
+    // result that submitScrapeRequest would mislabel as timed_out (finding 15).
+    generateSequence { scrapeRequestQueue.poll() }.forEach { wrapper ->
+      wrapper.complete(
+        ScrapeResults(
+          srAgentId = agentId,
+          srScrapeId = wrapper.scrapeId,
+          srStatusCode = HttpStatusCode.BadGateway.value,
+          srFailureReason = "Agent disconnected",
+        ),
+      )
     }
   }
 
@@ -136,7 +144,6 @@ internal class AgentContext(
       add("hostName", hostName)
       add("remoteAddr", remoteAddr)
       add("lastRequestDuration", lastRequestDuration)
-      // add("inactivityDuration", inactivityDuration)
     }
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/io/prometheus/proxy/ProxyGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyGrpcService.kt
@@ -74,7 +74,7 @@ internal class ProxyGrpcService(
         PLAINTEXT_CONTEXT
 
     grpcServer = createGrpcServer(tlsContext, options)
-    grpcServer.shutdownWithJvm(2.seconds)
+    grpcServer.shutdownWithJvm(SHUTDOWN_GRACE)
     addListener(genericServiceListener(logger), MoreExecutors.directExecutor())
 
     healthCheck = healthCheck {
@@ -149,7 +149,7 @@ internal class ProxyGrpcService(
   override fun shutDown() {
     if (proxy.isZipkinEnabled)
       tracing.close()
-    grpcServer.shutdownGracefully(2.seconds)
+    grpcServer.shutdownGracefully(SHUTDOWN_GRACE)
   }
 
   override fun toString() =
@@ -165,5 +165,8 @@ internal class ProxyGrpcService(
 
   companion object {
     private val logger = logger {}
+
+    // Grace period for gRPC server shutdown before forcing termination (finding 28).
+    private val SHUTDOWN_GRACE = 2.seconds
   }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -36,7 +36,6 @@ import io.ktor.server.routing.get
 import io.prometheus.Proxy
 import io.prometheus.common.ScrapeResults
 import io.prometheus.common.Utils.sanitizeQueryParams
-import io.prometheus.proxy.ProxyConstants.CACHE_CONTROL_VALUE
 import io.prometheus.proxy.ProxyConstants.FAVICON_FILENAME
 import io.prometheus.proxy.ProxyUtils.DecodedContent
 import io.prometheus.proxy.ProxyUtils.incrementScrapeRequestCount
@@ -70,6 +69,9 @@ internal object ProxyHttpRoutes {
   private val format = Json { prettyPrint = true }
   private val authHeaderWithoutTlsWarned = AtomicBoolean(false)
 
+  // OpenMetrics end-of-stream marker, stripped from each consolidated agent's body and re-appended once.
+  private const val EOF_MARKER = "# EOF"
+
   fun Routing.handleRequests(proxy: Proxy) {
     handleServiceDiscoveryEndpoint(proxy)
     handleClientRequests(proxy)
@@ -91,8 +93,8 @@ internal object ProxyHttpRoutes {
 
   private fun Routing.handleClientRequests(proxy: Proxy) {
     get("/*") {
-      call.response.header(HttpHeaders.CacheControl, CACHE_CONTROL_VALUE)
-
+      // Cache-Control is set once, by respondWith() (the single response site); setting it here too
+      // would make Ktor append a second identical header (finding 29).
       val path = call.request.path().drop(1)
       val queryParams = call.request.queryParameters.formUrlEncode()
 
@@ -181,20 +183,11 @@ internal object ProxyHttpRoutes {
     if (nonEmpty.isEmpty()) return ""
     if (nonEmpty.size == 1) return nonEmpty[0].contentText
 
-    var hasEof = false
-    val stripped = nonEmpty.map { result ->
-      val text = result.contentText
-      val trimmed = text.trimEnd()
-      if (trimmed.endsWith("# EOF")) {
-        hasEof = true
-        trimmed.removeSuffix("# EOF").trimEnd()
-      } else {
-        trimmed
-      }
-    }
-
+    val trimmed = nonEmpty.map { it.contentText.trimEnd() }
+    val hasEof = trimmed.any { it.endsWith(EOF_MARKER) }
+    val stripped = trimmed.map { it.removeSuffix(EOF_MARKER).trimEnd() }
     val joined = stripped.joinToString("\n")
-    return if (hasEof) "$joined\n# EOF" else joined
+    return if (hasEof) "$joined\n$EOF_MARKER" else joined
   }
 
   private suspend fun RoutingContext.executeScrapeRequests(

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpService.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpService.kt
@@ -53,7 +53,9 @@ internal class ProxyHttpService(
   isTestMode: Boolean,
 ) : GenericIdleService() {
   private val idleTimeout =
-    with(proxy.proxyConfigVals.http) { (if (idleTimeoutSecs == -1) 45 else idleTimeoutSecs).seconds }
+    with(proxy.proxyConfigVals.http) {
+      (if (idleTimeoutSecs == -1) DEFAULT_IDLE_TIMEOUT_SECS else idleTimeoutSecs).seconds
+    }
 
   private val tracing by lazy { proxy.zipkinReporterService.newTracing("proxy-http") }
 
@@ -73,11 +75,6 @@ internal class ProxyHttpService(
       routing {
         handleRequests(proxy)
       }
-
-//      EmbeddedServer.monitor.subscribe(ApplicationStarted) {
-//        // This runs when Ktor signals the application has started
-//        println("Ktor application started")
-//      }
     }
 
   init {
@@ -92,12 +89,14 @@ internal class ProxyHttpService(
     if (proxy.isZipkinEnabled)
       tracing.close()
     httpServer.stop(5.seconds.inWholeMilliseconds, 5.seconds.inWholeMilliseconds)
-    // sleep(2.seconds)
   }
 
   override fun toString() = toStringElements { add("port", httpPort) }
 
   companion object {
     private val logger = logger {}
+
+    // Fallback Ktor server idle timeout (seconds) used when http.idleTimeoutSecs is the -1 sentinel (finding 28).
+    private const val DEFAULT_IDLE_TIMEOUT_SECS = 45
   }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -148,7 +148,8 @@ internal class ProxyServiceImpl(
         reason = "Invalid agentId: $agentId (unregisterPath)"
       }
     } else {
-      proxy.pathManager.removePath(request.path, agentId).apply { agentContext.markActivityTime(false) }
+      // The activity-time bump is unrelated to the response receiver, so .also (not .apply) -- finding 36.
+      proxy.pathManager.removePath(request.path, agentId).also { agentContext.markActivityTime(false) }
     }
   }
 
@@ -181,7 +182,16 @@ internal class ProxyServiceImpl(
             ),
           )
         while (proxy.isRunning && agentContext.isValid()) {
-          agentContext.readScrapeRequest()?.apply { emit(scrapeRequest) }
+          val wrapper = agentContext.readScrapeRequest() ?: continue
+          try {
+            emit(wrapper.scrapeRequest)
+          } catch (e: CancellationException) {
+            // Cancelled after polling the wrapper out of the queue but before delivering it: fail the
+            // wrapper so the waiting HTTP handler gets a prompt error instead of blocking the full
+            // scrape-timeout window (finding 14).
+            proxy.scrapeRequestManager.failScrapeRequest(wrapper.scrapeId, "readRequestsFromProxy cancelled")
+            throw e
+          }
         }
       } finally {
         // When transportFilterDisabled is true, there is no ProxyServerTransportFilter to
@@ -247,9 +257,9 @@ internal class ProxyServiceImpl(
           }
 
           ChunkOneOfCase.CHUNK -> {
-            response.chunk
-              .apply {
-                logger.debug { "Reading chunk $chunkCount for scrapeId: $chunkScrapeId" }
+            // with(...) rather than apply { }: this block consumes the chunk, it doesn't configure it (finding 36).
+            with(response.chunk) {
+              logger.debug { "Reading chunk $chunkCount for scrapeId: $chunkScrapeId" }
                 val context = contextManager.getChunkedContext(chunkScrapeId)
                 if (context == null) {
                   logger.warn { "Missing chunked context for chunk with scrapeId: $chunkScrapeId, skipping" }
@@ -271,9 +281,9 @@ internal class ProxyServiceImpl(
           }
 
           ChunkOneOfCase.SUMMARY -> {
-            response.summary
-              .apply {
-                val context = contextManager.removeChunkedContext(summaryScrapeId)
+            // with(...) rather than apply { }: this block consumes the summary (finding 36).
+            with(response.summary) {
+              val context = contextManager.removeChunkedContext(summaryScrapeId)
                 activeScrapeIds -= summaryScrapeId
                 if (context == null) {
                   logger.warn { "Missing chunked context for summary with scrapeId: $summaryScrapeId, skipping" }
@@ -319,8 +329,8 @@ internal class ProxyServiceImpl(
     // thread) for the same scrapeId. Double-handling is prevented by two invariants that future edits
     // must preserve: (a) contextManager.removeChunkedContext() is a ConcurrentHashMap.remove(), so only
     // one caller gets the non-null context and the ?.also block (warn + failScrapeRequest + metric)
-    // runs at most once; and (b) failScrapeRequest() -> markComplete() is idempotent via an
-    // AtomicBoolean compareAndSet, so even a double-fail has no observable effect.
+    // runs at most once; and (b) failScrapeRequest() -> ScrapeRequestWrapper.complete() is idempotent
+    // via an AtomicBoolean compareAndSet, so even a double-fail has no observable effect.
     if (activeScrapeIds.isNotEmpty()) {
       val contextManager = proxy.agentContextManager
       activeScrapeIds.forEach { scrapeId ->

--- a/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyUtils.kt
@@ -76,7 +76,7 @@ internal object ProxyUtils {
   ): ResponseResults {
     val message = "Invalid AgentContext for /$path"
     proxy.logActivity(message)
-    logger.error { message }
+    logger.warn { message }
     return ResponseResults(
       statusCode = HttpStatusCode.NotFound,
       updateMsgs = listOf("invalid_agent_context"),
@@ -89,7 +89,7 @@ internal object ProxyUtils {
   ): ResponseResults {
     val message = "Invalid path request /$path"
     proxy.logActivity(message)
-    logger.error { message }
+    logger.warn { message }
     return ResponseResults(
       statusCode = HttpStatusCode.NotFound,
       updateMsgs = listOf("invalid_path"),
@@ -106,7 +106,7 @@ internal object ProxyUtils {
   }
 
   fun proxyNotRunningResponse(): ResponseResults {
-    logger.error { "Proxy stopped" }
+    logger.info { "Proxy stopped" }
     return ResponseResults(
       statusCode = HttpStatusCode.ServiceUnavailable,
       updateMsgs = listOf("proxy_stopped"),

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
@@ -54,8 +54,7 @@ internal class ScrapeRequestManager {
     val scrapeId = scrapeResults.srScrapeId
     scrapeRequestMap[scrapeId]
       ?.also { wrapper ->
-        wrapper.scrapeResults = scrapeResults
-        wrapper.markComplete()
+        wrapper.complete(scrapeResults)
         wrapper.agentContext.markActivityTime(true)
       } ?: logger.warn { "Missing ScrapeRequestWrapper for scrape_id: $scrapeId (likely timed out)" }
   }
@@ -66,13 +65,14 @@ internal class ScrapeRequestManager {
   ) {
     scrapeRequestMap[scrapeId]
       ?.also { wrapper ->
-        wrapper.scrapeResults = ScrapeResults(
-          srAgentId = wrapper.agentContext.agentId,
-          srScrapeId = scrapeId,
-          srStatusCode = HttpStatusCode.BadGateway.value,
-          srFailureReason = failureReason,
+        wrapper.complete(
+          ScrapeResults(
+            srAgentId = wrapper.agentContext.agentId,
+            srScrapeId = scrapeId,
+            srStatusCode = HttpStatusCode.BadGateway.value,
+            srFailureReason = failureReason,
+          ),
         )
-        wrapper.markComplete()
         wrapper.agentContext.markActivityTime(true)
       } ?: logger.warn { "failScrapeRequest() missing ScrapeRequestWrapper for scrape_id: $scrapeId" }
   }

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestWrapper.kt
@@ -63,12 +63,19 @@ internal class ScrapeRequestWrapper(
 
   fun ageDuration() = createTimeMark.elapsedNow()
 
-  fun markComplete() {
+  // Publishes [results] and completes the request, but ONLY if this call wins the completion CAS. Folding
+  // the result write and the completion flag together means a losing racer (e.g. failScrapeRequest racing
+  // a real assignScrapeResults) can't clobber the winning result before the HTTP handler reads it
+  // (finding 16). The volatile scrapeResults write happens-before closeChannel(), which unblocks
+  // awaitCompleted(). Returns true if this call completed the request.
+  fun complete(results: ScrapeResults): Boolean =
     if (completed.compareAndSet(expectedValue = false, newValue = true)) {
-      // Required
+      scrapeResults = results
       closeChannel()
+      true
+    } else {
+      false
     }
-  }
 
   fun closeChannel() {
     completeChannel.close()

--- a/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.seconds
 class AgentConnectionContextTest : StringSpec() {
   init {
     "close should disconnect context and return 0 when empty" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       context.connected.shouldBeTrue()
 
       val drained = context.close()
@@ -52,7 +52,7 @@ class AgentConnectionContextTest : StringSpec() {
     }
 
     "close should be idempotent and return 0 on second call" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       val drained1 = context.close()
       context.connected.shouldBeFalse()
@@ -71,7 +71,7 @@ class AgentConnectionContextTest : StringSpec() {
     // The fix replaces the coroutine Mutex + runBlocking with a plain synchronized block.
     // This test verifies close() completes promptly when called from invokeOnCompletion.
     "close should not deadlock when called from invokeOnCompletion" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val completedLatch = CountDownLatch(1)
 
       coroutineScope {
@@ -94,7 +94,7 @@ class AgentConnectionContextTest : StringSpec() {
     // Verifies that concurrent close() calls from multiple threads don't cause issues.
     // This exercises the synchronized block under contention.
     "concurrent close calls should not throw or deadlock" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val threadCount = 10
       val startLatch = CountDownLatch(1)
       val doneLatch = CountDownLatch(threadCount)
@@ -119,7 +119,7 @@ class AgentConnectionContextTest : StringSpec() {
     // M8: scrapeResultsChannel uses close() instead of cancel(), so buffered results
     // can still be drained by the consumer after the context is closed.
     "buffered scrape results should be drainable after close" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       // Buffer some results before closing
       val result1 = ScrapeResults(srAgentId = "agent-1", srScrapeId = 1L, srValidResponse = true)
@@ -154,7 +154,7 @@ class AgentConnectionContextTest : StringSpec() {
     }
 
     "empty scrape results channel should close cleanly" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       // Close with no buffered results
       context.close()
@@ -168,7 +168,7 @@ class AgentConnectionContextTest : StringSpec() {
     // Item 8: sendScrapeResults reports delivery (true) vs. drop-on-closed (false) so the caller
     // can increment a "dropped" metric instead of silently losing a computed result.
     "sendScrapeResults should return true when open and false after close" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val result = ScrapeResults(srAgentId = "agent-1", srScrapeId = 1L, srValidResponse = true)
 
       // While the connection is open, the result is accepted into the unbounded channel.
@@ -188,7 +188,7 @@ class AgentConnectionContextTest : StringSpec() {
     // ==================== Bug #5: close() drains scrapeRequestActionsChannel ====================
 
     "Bug #5: close should drain buffered scrape request actions and return count" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       // Buffer some scrape request actions
       context.sendScrapeRequestAction {
@@ -208,7 +208,7 @@ class AgentConnectionContextTest : StringSpec() {
     }
 
     "Bug #5: second close should return 0 after items already drained" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       context.sendScrapeRequestAction {
         ScrapeResults(srAgentId = "agent-1", srScrapeId = 1L, srValidResponse = true)
@@ -234,7 +234,7 @@ class AgentConnectionContextTest : StringSpec() {
     // and logs a warning instead of throwing.
 
     "Bug #7: sendScrapeResults on open channel should deliver result" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val result = ScrapeResults(srAgentId = "agent-1", srScrapeId = 42L, srValidResponse = true)
 
       context.sendScrapeResults(result)
@@ -248,7 +248,7 @@ class AgentConnectionContextTest : StringSpec() {
     }
 
     "Bug #7: sendScrapeResults on closed channel should not throw" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       // Close the context first
       context.close()
@@ -268,7 +268,7 @@ class AgentConnectionContextTest : StringSpec() {
       // then close() is called. With the old send(), one ClosedSendChannelException
       // would cancel ALL sibling coroutines. With trySend(), each coroutine completes
       // independently.
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val completedCount = AtomicInteger(0)
       val threwException = AtomicBoolean(false)
 
@@ -301,7 +301,7 @@ class AgentConnectionContextTest : StringSpec() {
     }
 
     "Bug #7: results sent before close should be drainable alongside dropped post-close sends" {
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
 
       // Send a result before close
       context.sendScrapeResults(
@@ -331,7 +331,7 @@ class AgentConnectionContextTest : StringSpec() {
       // Verifies that the try/finally pattern for scrapeRequestBacklogSize works
       // correctly even when sendScrapeResults drops the result on a closed channel.
       // The counter should still decrement in the finally block.
-      val context = AgentConnectionContext()
+      val context = AgentConnectionContext(128)
       val backlogSize = AtomicInteger(0)
 
       coroutineScope {

--- a/src/test/kotlin/io/prometheus/agent/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentContextTest.kt
@@ -217,8 +217,8 @@ class AgentContextTest : StringSpec() {
       // isValid should be false
       context.isValid().shouldBeFalse()
 
-      // closeChannel was called on the drained wrapper
-      verify(exactly = 1) { mockRequest.closeChannel() }
+      // The drained wrapper is failed with an agent-disconnected result via complete() (finding 15).
+      verify(exactly = 1) { mockRequest.complete(any()) }
     }
 
     "markActivityTime should reset inactivity duration" {

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -667,7 +667,7 @@ class AgentGrpcServiceTest : StringSpec() {
       every { mockStub.readRequestsFromProxy(any(), any()) } returns flowOf(request1, request2)
       service.grpcStub = mockStub
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val mockHttpService = mockk<AgentHttpService>(relaxed = true)
 
       service.readRequestsFromProxy(mockHttpService, connectionContext)
@@ -690,7 +690,7 @@ class AgentGrpcServiceTest : StringSpec() {
       every { mockStub.readRequestsFromProxy(any(), any()) } returns flowOf()
       service.grpcStub = mockStub
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val mockHttpService = mockk<AgentHttpService>(relaxed = true)
 
       // Should complete without error
@@ -711,7 +711,7 @@ class AgentGrpcServiceTest : StringSpec() {
       val agent = createMockAgent("localhost:$PROXY_AGENT_PORT")
       val service = AgentGrpcService(agent, agent.options, "test-server")
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val nonChunkedChannel = Channel<ScrapeResponse>(UNLIMITED)
       val chunkedChannel = Channel<ChunkedScrapeResponse>(UNLIMITED)
 
@@ -747,7 +747,7 @@ class AgentGrpcServiceTest : StringSpec() {
       // chunkContentSizeBytes defaults to 32768 in mock
       val service = AgentGrpcService(agent, agent.options, "test-server")
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val nonChunkedChannel = Channel<ScrapeResponse>(UNLIMITED)
       val chunkedChannel = Channel<ChunkedScrapeResponse>(UNLIMITED)
 
@@ -788,7 +788,7 @@ class AgentGrpcServiceTest : StringSpec() {
       every { mockOptions.chunkContentSizeBytes } returns 10
       val service = AgentGrpcService(agent, mockOptions, "test-server")
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val nonChunkedChannel = Channel<ScrapeResponse>(UNLIMITED)
       val chunkedChannel = Channel<ChunkedScrapeResponse>(UNLIMITED)
 
@@ -857,7 +857,7 @@ class AgentGrpcServiceTest : StringSpec() {
       val agent = createMockAgent("localhost:$PROXY_AGENT_PORT")
       val service = AgentGrpcService(agent, agent.options, "test-server")
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       val nonChunkedChannel = Channel<ScrapeResponse>(UNLIMITED)
       val chunkedChannel = Channel<ChunkedScrapeResponse>(UNLIMITED)
 
@@ -1100,7 +1100,7 @@ class AgentGrpcServiceTest : StringSpec() {
       coEvery { mockStub.writeChunkedResponsesToProxy(any()) } returns EMPTY_INSTANCE
       service.grpcStub = mockStub
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
       // Close the connectionContext immediately so processScrapeResults exits,
       // triggering the inner finally to close both channels.
       connectionContext.close()
@@ -1129,7 +1129,7 @@ class AgentGrpcServiceTest : StringSpec() {
       }
       service.grpcStub = mockStub
 
-      val connectionContext = AgentConnectionContext()
+      val connectionContext = AgentConnectionContext(128)
 
       shouldNotThrow<Throwable> {
         coroutineScope {

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -389,7 +389,7 @@ class AgentPathManagerTest : StringSpec() {
     // operations for the full RPC duration. The fix moves the gRPC call outside
     // the mutex so concurrent registrations for different paths can proceed in
     // parallel. The mutex now only protects the local pathContextMap update.
-    "concurrent registerPath calls for different paths should not block each other" {
+    "concurrent registerPath calls are serialized for atomicity (finding 19)" {
       val agent = createMockAgent()
       val manager = AgentPathManager(agent)
       val concurrentCalls = AtomicInteger(0)
@@ -413,9 +413,9 @@ class AgentPathManagerTest : StringSpec() {
 
       manager["path1"].shouldNotBeNull()
       manager["path2"].shouldNotBeNull()
-      // With the fix, both gRPC calls run concurrently outside the mutex.
-      // With the old code, the global mutex serialized them (maxConcurrent=1).
-      maxConcurrent.get() shouldBe 2
+      // finding 19: the proxy RPC and the local map write are held under pathMutex together so the local
+      // map and the proxy's view can't disagree, which serializes concurrent registrations.
+      maxConcurrent.get() shouldBe 1
     }
 
     "registerPaths should register all configured paths" {

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -680,9 +680,8 @@ class HttpClientCacheTest : StringSpec() {
     // is identity-based. Mutable lastAccessedAt no longer affects equals/hashCode.
     "CacheEntry equality should be identity-based" {
       val client = createMockHttpClient()
-      val now = System.currentTimeMillis()
-      val entry1 = CacheEntry(client, now, now)
-      val entry2 = CacheEntry(client, now, now)
+      val entry1 = CacheEntry(client)
+      val entry2 = CacheEntry(client)
 
       // Same instance should be equal
       (entry1 == entry1).shouldBeTrue()

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode
 import io.mockk.mockk
 import io.prometheus.grpc.chunkedScrapeResponse
 import io.prometheus.grpc.headerData
@@ -320,7 +321,7 @@ class AgentContextManagerTest : StringSpec() {
       manager.totalAgentScrapeRequestBacklogSize shouldBe 0
     }
 
-    "invalidateAllAgentContexts should unblock awaitCompleted on buffered wrappers" {
+    "invalidateAllAgentContexts should fail buffered wrappers with an agent-disconnected result (finding 15)" {
       val manager = AgentContextManager(isTestMode = true)
       val context = AgentContext("remote-addr")
       manager.addAgentContext(context)
@@ -334,13 +335,15 @@ class AgentContextManagerTest : StringSpec() {
         wrapper.awaitCompleted(30.seconds)
       }
 
-      // invalidateAllAgentContexts should drain and close the wrapper's channel
+      // invalidateAllAgentContexts drains each context, failing buffered wrappers with a 502 result.
       manager.invalidateAllAgentContexts()
 
       val completed = deferred.await()
       val elapsed = System.currentTimeMillis() - startTime
 
-      completed.shouldBeFalse()
+      // awaitCompleted returns true with a 502 result rather than a null that would read as timed_out.
+      completed.shouldBeTrue()
+      wrapper.scrapeResults?.srStatusCode shouldBe HttpStatusCode.BadGateway.value
       // Should unblock well under the 30-second timeout
       elapsed shouldBeLessThan 5000L
     }

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.ktor.http.HttpStatusCode
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -97,7 +98,7 @@ class AgentContextTest : StringSpec() {
     // M3: invalidate() now drains buffered scrape requests and calls closeChannel() on each
     // so HTTP handlers waiting on awaitCompleted() are notified immediately instead of
     // waiting for the full scrape timeout to expire.
-    "invalidate should close pending scrape request wrappers" {
+    "invalidate should complete pending scrape request wrappers" {
       val context = AgentContext("remote-addr")
       val wrapper1 = mockk<ScrapeRequestWrapper>(relaxed = true)
       val wrapper2 = mockk<ScrapeRequestWrapper>(relaxed = true)
@@ -111,13 +112,13 @@ class AgentContextTest : StringSpec() {
       context.invalidate()
 
       context.isValid().shouldBeFalse()
-      // All buffered wrappers should have had closeChannel() called
-      verify(exactly = 1) { wrapper1.closeChannel() }
-      verify(exactly = 1) { wrapper2.closeChannel() }
-      verify(exactly = 1) { wrapper3.closeChannel() }
+      // All buffered wrappers should be failed with an agent-disconnected result (finding 15).
+      verify(exactly = 1) { wrapper1.complete(any()) }
+      verify(exactly = 1) { wrapper2.complete(any()) }
+      verify(exactly = 1) { wrapper3.complete(any()) }
     }
 
-    "invalidate should unblock awaitCompleted on buffered wrappers" {
+    "invalidate should fail buffered wrappers with an agent-disconnected result (finding 15)" {
       val context = AgentContext("remote-addr")
 
       // Create a real ScrapeRequestWrapper so awaitCompleted() works end-to-end
@@ -131,15 +132,15 @@ class AgentContextTest : StringSpec() {
         wrapper.awaitCompleted(30.seconds)
       }
 
-      // Invalidate should drain the channel and close the wrapper's completion channel
       context.invalidate()
 
-      // awaitCompleted should unblock almost immediately.
-      // It returns false because scrapeResults was never assigned (agent disconnected).
+      // awaitCompleted unblocks almost immediately, now returning TRUE with a 502 result so
+      // submitScrapeRequest reports the truthful agent-disconnect instead of mislabeling it timed_out.
       val completed = deferred.await()
       val elapsed = System.currentTimeMillis() - startTime
 
-      completed.shouldBeFalse()
+      completed.shouldBeTrue()
+      wrapper.scrapeResults?.srStatusCode shouldBe HttpStatusCode.BadGateway.value
       // Should unblock in well under the 30-second timeout
       elapsed shouldBeLessThan 5000L
     }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -473,7 +473,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       response.updateMsg shouldBe "timed_out"
     }
 
-    "submitScrapeRequest should return timed_out when agent disconnects during scrape" {
+    "submitScrapeRequest should report agent-disconnect (not timed_out) when the agent disconnects mid-scrape" {
       val proxy = createSpyProxyForSubmit(timeoutSecs = 30)
       val agentContext = AgentContext("test-remote")
 
@@ -490,8 +490,10 @@ class ProxyHttpRoutesTest : StringSpec() {
         mockk<ApplicationRequest>(relaxed = true),
       )
 
-      response.statusCode shouldBe HttpStatusCode.ServiceUnavailable
-      response.updateMsg shouldBe "timed_out"
+      // finding 15: invalidate() now fails the buffered wrapper with a 502 agent-disconnected result,
+      // so this is reported truthfully as an upstream error instead of being mislabeled timed_out.
+      response.statusCode shouldBe HttpStatusCode.BadGateway
+      response.updateMsg shouldBe "upstream_error"
     }
 
     "submitScrapeRequest should return timed_out when proxy stops during scrape" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -327,9 +327,8 @@ class ProxyTest : StringSpec() {
 
       // Old (broken) order: invalidate agents THEN fail requests
       proxy.agentContextManager.invalidateAllAgentContexts()
-      // The wrapper's completeChannel was already closed by invalidate(),
-      // so markComplete in failAllInFlightScrapeRequests won't call observeDuration again.
-      // But the results ARE still set because scrapeResults is assigned before markComplete.
+      // This wrapper is only in the scrapeRequestMap (not an agent queue), so failAllInFlightScrapeRequests
+      // completes it: ScrapeRequestWrapper.complete() publishes the result behind its CAS (finding 16).
       proxy.scrapeRequestManager.failAllInFlightScrapeRequests("Proxy is shutting down")
 
       // Results are set, but awaitCompleted() would have already returned false

--- a/src/test/kotlin/io/prometheus/proxy/ScrapeRequestManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ScrapeRequestManagerTest.kt
@@ -173,7 +173,7 @@ class ScrapeRequestManagerTest : StringSpec() {
     // assignScrapeResults matches the response to the original request and calls
     // markComplete() to signal the waiting HTTP handler. This test verifies that
     // multiple concurrent scrapes are correctly tracked and completed independently.
-    "multiple assignScrapeResults should call markComplete for each" {
+    "multiple assignScrapeResults should complete each wrapper" {
       val manager = ScrapeRequestManager()
       val wrapper1 = createMockWrapper(123L)
       val wrapper2 = createMockWrapper(456L)
@@ -189,13 +189,13 @@ class ScrapeRequestManagerTest : StringSpec() {
       manager.assignScrapeResults(results1)
       manager.assignScrapeResults(results2)
 
-      verify { wrapper1.markComplete() }
-      verify { wrapper2.markComplete() }
+      verify { wrapper1.complete(results1) }
+      verify { wrapper2.complete(results2) }
     }
 
     // ==================== assignScrapeResults Verification Tests ====================
 
-    "assignScrapeResults should set scrapeResults on wrapper" {
+    "assignScrapeResults should complete the wrapper with the results" {
       val manager = ScrapeRequestManager()
       val wrapper = createMockWrapper(100L)
       val results = mockk<ScrapeResults>(relaxed = true)
@@ -205,7 +205,8 @@ class ScrapeRequestManagerTest : StringSpec() {
       manager.addToScrapeRequestMap(wrapper)
       manager.assignScrapeResults(results)
 
-      verify { wrapper.scrapeResults = results }
+      // Result publication is now folded behind the completion CAS (finding 16).
+      verify { wrapper.complete(results) }
     }
 
     "assignScrapeResults should call markActivityTime on agent context" {
@@ -227,17 +228,17 @@ class ScrapeRequestManagerTest : StringSpec() {
     // Bug #2: Chunk/summary validation failures left the HTTP handler waiting until timeout.
     // failScrapeRequest() notifies the waiting handler immediately with an error result.
 
-    "failScrapeRequest should set error results and call markComplete" {
+    "failScrapeRequest should complete the wrapper with error results" {
       val manager = ScrapeRequestManager()
       val resultsSlot = slot<ScrapeResults>()
       val wrapper = createMockWrapper(300L)
       every { wrapper.agentContext.agentId } returns "agent-99"
-      every { wrapper.scrapeResults = capture(resultsSlot) } answers { nothing }
+      every { wrapper.complete(capture(resultsSlot)) } returns true
 
       manager.addToScrapeRequestMap(wrapper)
       manager.failScrapeRequest(300L, "Chunk checksum mismatch")
 
-      verify { wrapper.markComplete() }
+      verify { wrapper.complete(any()) }
       verify { wrapper.agentContext.markActivityTime(true) }
 
       val captured = resultsSlot.captured
@@ -265,14 +266,15 @@ class ScrapeRequestManagerTest : StringSpec() {
     // recording a duplicate latency observation and skewing metrics. The fix uses an
     // AtomicBoolean in markComplete() so observeDuration() is only called once.
 
-    "Bug #15: assignScrapeResults should call markComplete each time wrapper is in map" {
+    "Bug #15: assignScrapeResults should complete each time wrapper is in map" {
       val manager = ScrapeRequestManager()
       val wrapper = createMockWrapper(400L)
-      var markCompleteCallCount = 0
+      var completeCallCount = 0
 
-      // Track markComplete invocations
-      every { wrapper.markComplete() } answers {
-        markCompleteCallCount++
+      // Track complete() invocations
+      every { wrapper.complete(any()) } answers {
+        completeCallCount++
+        true
       }
 
       manager.addToScrapeRequestMap(wrapper)
@@ -286,10 +288,10 @@ class ScrapeRequestManagerTest : StringSpec() {
       manager.assignScrapeResults(results1)
       manager.assignScrapeResults(results2)
 
-      // Both calls go through the manager (since wrapper is still in the map).
-      // The real ScrapeRequestWrapper.markComplete() uses AtomicBoolean to guard
-      // observeDuration, but the manager itself calls markComplete on every assignment.
-      markCompleteCallCount shouldBe 2
+      // Both calls go through the manager (since wrapper is still in the map). The real
+      // ScrapeRequestWrapper.complete() CAS makes only the first publish, but the manager itself
+      // calls complete() on every assignment.
+      completeCallCount shouldBe 2
     }
 
     "Bug #15: double assignScrapeResults should not throw" {
@@ -308,9 +310,9 @@ class ScrapeRequestManagerTest : StringSpec() {
       manager.assignScrapeResults(results1)
       manager.assignScrapeResults(results2)
 
-      // The manager calls markComplete() each time, but the real ScrapeRequestWrapper's
-      // AtomicBoolean guard ensures observeDuration is only called once.
-      verify(atLeast = 1) { wrapper.markComplete() }
+      // The manager calls complete() each time, but the real ScrapeRequestWrapper's CAS
+      // ensures only the first call publishes.
+      verify(atLeast = 1) { wrapper.complete(any()) }
     }
 
     "Bug #15: double failScrapeRequest should not throw" {
@@ -324,9 +326,9 @@ class ScrapeRequestManagerTest : StringSpec() {
       manager.failScrapeRequest(600L, "first failure")
       manager.failScrapeRequest(600L, "second failure")
 
-      // Both calls should succeed without exceptions; the real markComplete()
-      // uses AtomicBoolean to guard observeDuration
-      verify(exactly = 2) { wrapper.markComplete() }
+      // Both calls should succeed without exceptions; the real complete()
+      // CAS ensures only the first publishes.
+      verify(exactly = 2) { wrapper.complete(any()) }
     }
 
     // ==================== Bug #5: Log level for missing scrape request ====================

--- a/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ScrapeRequestWrapperTest.kt
@@ -128,13 +128,12 @@ class ScrapeRequestWrapperTest : StringSpec() {
 
     // ==================== Completion Tests ====================
 
-    "awaitCompleted should return true when markComplete is called with results" {
+    "awaitCompleted should return true when complete() is called with results" {
       val wrapper = createWrapper()
 
       launch {
         Thread.sleep(50)
-        wrapper.scrapeResults = ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)
-        wrapper.markComplete()
+        wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId))
       }
 
       val result = wrapper.awaitCompleted(5.seconds)
@@ -172,13 +171,13 @@ class ScrapeRequestWrapperTest : StringSpec() {
       str shouldContain "/test/path"
     }
 
-    // ==================== markComplete Tests ====================
+    // ==================== complete() Tests ====================
 
-    "markComplete without metrics should not throw" {
+    "complete without metrics should not throw" {
       val wrapper = createWrapper()
 
       // Should not throw
-      wrapper.markComplete()
+      wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId))
     }
 
     // ==================== awaitCompleted Edge Cases ====================
@@ -186,10 +185,9 @@ class ScrapeRequestWrapperTest : StringSpec() {
     "awaitCompleted should return true immediately when already completed with results" {
       val wrapper = createWrapper()
 
-      wrapper.scrapeResults = ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)
-      wrapper.markComplete()
+      wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId))
 
-      // After markComplete with results, awaitCompleted should return true quickly
+      // After complete() with results, awaitCompleted should return true quickly
       val result = wrapper.awaitCompleted(5.seconds)
       result.shouldBeTrue()
     }
@@ -203,8 +201,7 @@ class ScrapeRequestWrapperTest : StringSpec() {
 
       launch {
         Thread.sleep(50)
-        wrapper.scrapeResults = ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)
-        wrapper.markComplete()
+        wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId))
       }
 
       // Using named parameter `timeout`
@@ -238,31 +235,27 @@ class ScrapeRequestWrapperTest : StringSpec() {
       }
     }
 
-    // ==================== markComplete Idempotency Tests ====================
+    // ==================== complete() Idempotency Tests ====================
 
-    "markComplete should not throw when called multiple times" {
+    "complete should not throw when called multiple times" {
       val wrapper = createWrapper()
-      wrapper.scrapeResults = ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)
+      val results = ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)
 
-      wrapper.markComplete()
-      // Second call should not throw — channel is already closed
-      wrapper.markComplete()
+      wrapper.complete(results).shouldBeTrue()
+      // Second call should be a no-op (returns false) — channel already closed
+      wrapper.complete(results).shouldBeFalse()
     }
 
-    // ==================== Bug #15: markComplete double-call protection ====================
-
-    // Bug #15: markComplete() uses an AtomicBoolean so the channel is closed exactly once even when
-    // called multiple times. (Latency is now observed once per response in the routing layer rather
-    // than inside markComplete, so repeated markComplete calls can no longer skew the metric.)
-
-    "Bug #15: markComplete should close channel only once" {
+    // Bug #15 / finding 16: complete() uses an AtomicBoolean so the channel is closed exactly once and
+    // only the first (winning) call publishes its result, so a losing racer can't clobber it.
+    "complete should close channel and publish only once" {
       val wrapper = createWrapper()
 
-      wrapper.markComplete()
+      wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)).shouldBeTrue()
 
-      // Second and third calls should be no-ops (no exceptions)
-      wrapper.markComplete()
-      wrapper.markComplete()
+      // Second and third calls should be no-ops (return false, no exceptions)
+      wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)).shouldBeFalse()
+      wrapper.complete(ScrapeResults(srAgentId = "agent-1", srScrapeId = wrapper.scrapeId)).shouldBeFalse()
     }
   }
 }


### PR DESCRIPTION
Addresses the low-severity and Kotlin-idiom findings (14–42) from `docs/CODE_REVIEW_JULY_2026.md` — 25 fully, 2 partial, 2 deferred (all marked in the doc). Behavior-preserving refactors are covered by the existing suite; every behavior change has a new or updated test.

## Highlights

**Low-severity concurrency (14–20)**
- **16**: `ScrapeRequestWrapper.complete()` publishes the result *behind* the completion CAS, so a losing racer (fail vs. real result) can't clobber a real result — Prometheus no longer gets a 502 for a scrape that succeeded.
- **15**: `invalidate()` fails buffered wrappers with a 502 agent-disconnected result instead of a bare channel close, so a mid-scrape disconnect is reported truthfully instead of mislabeled `timed_out`.
- **14**: fail the polled wrapper on RPC cancellation (prompt error instead of the full scrape-timeout window).
- **18** backlog decremented by the drained count; **19** `pathMutex` held across the RPC+map write (and `clear()`); **20** false `awaitTermination` logged.

**Low-severity quality/observability (21–32)**
- ERROR→warn/info for routine paths (**21**), gRPC status in disconnect logs (**22**), shared `logStreamFailure` helper (**23**), removed the unreachable cache health check (**24**), demoted public-API leaks (`isBlitzRequest`/`buildServiceDiscoveryJson`/`configVals`) to `internal` (**26**), comment remnants deleted (**27**), magic numbers named (**28**), single Cache-Control owner (**29**), de-doubled exception logging (**30**), dead `backlogCapacity` default dropped (**31**), cleanup predicate computed once (**32**).

**Idioms (33–42)**
- **25+33**: `HttpClientCache` rewritten to a single `LinkedHashMap(accessOrder=true)` + monotonic `TimeMark`s, with an `AtomicInt` size mirror so `currentCacheSize()` stays lock-free (preserving the Bug #12 non-blocking read).
- Shared `causeChain()`/`hasTimeoutCause()` (**34**), `readConfig` restructured with a local `fail()` (**37**), `decrementBacklog` → `update{}` (**38**), `mergeContentTexts` cleanup (**39**), `reconnectLimiter` init at declaration (**40**), drain loops → `generateSequence` (**41**), case-insensitive `removePrefix` chain (**42**), `apply`-misuse sites (**36**).

## Deferred / partial (noted in the doc)

- **17** (chunked-buffer re-check) — the review marks it *optional* (self-healing, size-capped).
- **35** (`-1`-sentinel `resolvePositiveInt` helper, ~25 sites) — a large refactor of precedence-sensitive config resolution where the sites have genuinely drifted; regression risk outweighs the readability gain in a batch PR.
- **20** interceptor generation-token and **36** the 65–120-line options `apply` blocks (same precedence-sensitive code as 35) — deferred; their simpler halves are done.

## Test plan

- New/updated unit tests for the behavior changes: `invalidate()` now yields a 502 (finding 15) across `AgentContextTest`/`AgentContextManagerTest`/`ProxyHttpRoutesTest`; `markComplete()` → `complete(results)` rippled through `ScrapeRequestManagerTest`/`ScrapeRequestWrapperTest` (finding 16); `AgentPathManager` concurrency test now asserts serialized-for-atomicity (finding 19). `HttpClientCache` rewrite validated by its existing suite.
- `./gradlew build` green: detekt + kotlinter clean, all non-container tests pass, coverage 95.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)