### PR TITLE
Harden embedded-server test readiness against CPU contention

### DIFF
--- a/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
+++ b/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
@@ -46,9 +46,12 @@ import kotlin.time.TimeSource.Monotonic
 // The deadline is generous because it is only a ceiling, not a wait: a healthy server satisfies
 // the streak in tens of milliseconds. The extra headroom absorbs CPU contention during a full
 // test-suite run, where many embedded servers and the gRPC harness compete for cores and a fresh
-// CIO server can take several seconds to start answering.
+// CIO server can take several seconds to start answering. Raised to 60s because on heavily loaded /
+// fewer-core machines the 30s ceiling could still be exceeded before the server answered stably;
+// since this only ever delays the return on a struggling server, the extra headroom is free for
+// healthy runs.
 suspend fun EmbeddedServer<*, *>.startAndAwaitReady(
-  timeout: Duration = 30.seconds,
+  timeout: Duration = 60.seconds,
   stableProbes: Int = 3,
 ): Int {
   start(wait = false)

--- a/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
@@ -35,6 +35,7 @@ import io.ktor.server.routing.routing
 import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.Proxy
+import io.prometheus.common.startAndAwaitReady
 import io.prometheus.proxy.ProxyUtils.respondWith
 import io.prometheus.proxy.ProxyUtils.unzip
 import io.ktor.server.cio.CIO as ServerCIO
@@ -158,10 +159,10 @@ class ProxyUtilsTest : StringSpec() {
             call.respondWith("test content")
           }
         }
-      }.start(wait = false)
+      }
 
       try {
-        val port = server.engine.resolvedConnectors().first().port
+        val port = server.startAndAwaitReady()
         val client = newHttpClient()
 
         val response = client.get("http://localhost:$port/test-respond")
@@ -184,10 +185,10 @@ class ProxyUtilsTest : StringSpec() {
             )
           }
         }
-      }.start(wait = false)
+      }
 
       try {
-        val port = server.engine.resolvedConnectors().first().port
+        val port = server.startAndAwaitReady()
         val client = newHttpClient()
 
         val response = client.get("http://localhost:$port/test-json")
@@ -207,10 +208,10 @@ class ProxyUtilsTest : StringSpec() {
             call.respondWith("error", status = HttpStatusCode.ServiceUnavailable)
           }
         }
-      }.start(wait = false)
+      }
 
       try {
-        val port = server.engine.resolvedConnectors().first().port
+        val port = server.startAndAwaitReady()
         val client = newHttpClient()
 
         val response = client.get("http://localhost:$port/test-error")
@@ -230,10 +231,10 @@ class ProxyUtilsTest : StringSpec() {
             call.respondWith("content", status = HttpStatusCode.NotFound)
           }
         }
-      }.start(wait = false)
+      }
 
       try {
-        val port = server.engine.resolvedConnectors().first().port
+        val port = server.startAndAwaitReady()
         val client = newHttpClient()
 
         val response = client.get("http://localhost:$port/test-bug14")


### PR DESCRIPTION
Two flaky full-suite test failures (both pass in isolation) traced to embedded-server readiness under CPU contention — the same class the maintainer hardened in b63f494. Neither is a regression: the failing tests pass on their own, and their server setups were untouched by recent work.

## Fixes (test-only)

- **`ProxyUtilsTest`** — 4 tests started their embedded server with the raw `start(wait = false)` + `resolvedConnectors()` pattern and fired a request immediately, racing the Ktor request pipeline. A lost race lands on CIO's default 404 page (`expected:<content> but was:<404 Not Found html>`). Switched all 4 to the existing `startAndAwaitReady()` helper, which polls for consecutive stable HTTP replies before returning the port.
- **`EmbeddedTestServer.startAndAwaitReady`** — raised the readiness ceiling 30s → 60s. On a heavily loaded / fewer-core machine the 30s ceiling could be exceeded before a fresh CIO server answered stably (`IllegalStateException: … did not stably serve HTTP within 30s`). The ceiling only ever *delays the return on a struggling server*, so the extra headroom is free for healthy runs.

## Notes

- The ceiling bump is a mitigation, not a guarantee — under severe contention the more reliable path is to run the split Make targets (`make nh-tests` / `ip-tests` / `netty-tests` / `tls-tests`) rather than the whole suite in one JVM.

## Test plan

- `ProxyUtilsTest` and `AgentHttpServiceTest` pass on rerun; kotlinter clean. Changes are test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)