### PR TITLE
Convert test atomics to Kotlin atomics API and fix -xtest syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5
 
       - name: Compile (no tests)
-        run: ./gradlew clean build -xtest
+        run: ./gradlew clean build -x test
 
       - name: Lint and detekt
         run: ./gradlew lintKotlinMain lintKotlinTest detekt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Gradle with Kotlin DSL. Java 17+ required. All commands from project root.
 
 ```bash
 ./gradlew build                          # Build with tests
-./gradlew build -xtest                   # Build without tests
+./gradlew build -x test                  # Build without tests
 ./gradlew test                           # Run all tests
 ./gradlew test --tests "TestClassName"   # Run specific test class
 ./gradlew test --tests "io.prometheus.SomeTestClass.someTestMethod"  # Single test method
@@ -29,7 +29,7 @@ Gradle with Kotlin DSL. Java 17+ required. All commands from project root.
 ```
 
 Always run lint and build before completing tasks:
-`./gradlew detekt && ./gradlew lintKotlinMain && ./gradlew build -xtest`
+`./gradlew detekt && ./gradlew lintKotlinMain && ./gradlew build -x test`
 
 ### Useful Make Targets
 

--- a/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentConnectionContextTest.kt
@@ -34,8 +34,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -269,7 +271,7 @@ class AgentConnectionContextTest : StringSpec() {
       // would cancel ALL sibling coroutines. With trySend(), each coroutine completes
       // independently.
       val context = AgentConnectionContext(128)
-      val completedCount = AtomicInteger(0)
+      val completedCount = AtomicInt(0)
       val threwException = AtomicBoolean(false)
 
       coroutineScope {
@@ -282,9 +284,9 @@ class AgentConnectionContextTest : StringSpec() {
               context.sendScrapeResults(
                 ScrapeResults(srAgentId = "agent-1", srScrapeId = i.toLong(), srValidResponse = true),
               )
-              completedCount.incrementAndGet()
+              completedCount.incrementAndFetch()
             } catch (e: Exception) {
-              threwException.set(true)
+              threwException.store(true)
             }
           }
         }
@@ -295,9 +297,9 @@ class AgentConnectionContextTest : StringSpec() {
       }
 
       // All coroutines should complete without throwing
-      threwException.get().shouldBeFalse()
+      threwException.load().shouldBeFalse()
       // All coroutines should have completed (even though some results were dropped)
-      completedCount.get() shouldBe 5
+      completedCount.load() shouldBe 5
     }
 
     "Bug #7: results sent before close should be drainable alongside dropped post-close sends" {
@@ -332,19 +334,19 @@ class AgentConnectionContextTest : StringSpec() {
       // correctly even when sendScrapeResults drops the result on a closed channel.
       // The counter should still decrement in the finally block.
       val context = AgentConnectionContext(128)
-      val backlogSize = AtomicInteger(0)
+      val backlogSize = AtomicInt(0)
 
       coroutineScope {
         (1..10).forEach { i ->
           launch(Dispatchers.IO) {
-            backlogSize.incrementAndGet()
+            backlogSize.incrementAndFetch()
             try {
               delay(20.milliseconds)
               context.sendScrapeResults(
                 ScrapeResults(srAgentId = "agent-1", srScrapeId = i.toLong(), srValidResponse = true),
               )
             } finally {
-              backlogSize.decrementAndGet()
+              backlogSize.decrementAndFetch()
             }
           }
         }
@@ -355,7 +357,7 @@ class AgentConnectionContextTest : StringSpec() {
       }
 
       // After all coroutines complete, backlog should be exactly 0
-      backlogSize.get() shouldBe 0
+      backlogSize.load() shouldBe 0
     }
   }
 }

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -62,8 +62,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.concurrent.atomics.update
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.jvm.isAccessible
@@ -243,7 +246,7 @@ class AgentGrpcServiceTest : StringSpec() {
     // never counted. The increment and decrement are always paired in the same try-finally scope.
     "backlog counter should never go negative with consumer-side increment pattern" {
       val channel = Channel<Int>(UNLIMITED)
-      val backlogSize = AtomicInteger(0)
+      val backlogSize = AtomicInt(0)
       val wentNegative = AtomicBoolean(false)
       val itemCount = 10_000
 
@@ -259,27 +262,27 @@ class AgentGrpcServiceTest : StringSpec() {
         // Consumer: mirrors Agent.kt consumer loop — increment then try/finally decrement
         launch(Dispatchers.IO) {
           for (@Suppress("UnusedPrivateProperty") item in channel) {
-            backlogSize.incrementAndGet()
+            backlogSize.incrementAndFetch()
             try {
               // Simulate processing
             } finally {
-              val current = backlogSize.decrementAndGet()
+              val current = backlogSize.decrementAndFetch()
               if (current < 0) {
-                wentNegative.set(true)
+                wentNegative.store(true)
               }
             }
           }
         }
       }
 
-      wentNegative.get() shouldBe false
-      backlogSize.get() shouldBe 0
+      wentNegative.load() shouldBe false
+      backlogSize.load() shouldBe 0
     }
 
     "backlog counter should remain non-negative throughout processing" {
       val channel = Channel<Int>(UNLIMITED)
-      val backlogSize = AtomicInteger(0)
-      val minObserved = AtomicInteger(Int.MAX_VALUE)
+      val backlogSize = AtomicInt(0)
+      val minObserved = AtomicInt(Int.MAX_VALUE)
       val itemCount = 10_000
 
       coroutineScope {
@@ -294,19 +297,19 @@ class AgentGrpcServiceTest : StringSpec() {
         // Consumer: increment then try/finally decrement, track minimum
         launch(Dispatchers.IO) {
           for (@Suppress("UnusedPrivateProperty") item in channel) {
-            backlogSize.incrementAndGet()
+            backlogSize.incrementAndFetch()
             try {
               // Simulate processing
             } finally {
-              val current = backlogSize.decrementAndGet()
-              minObserved.updateAndGet { min -> minOf(min, current) }
+              val current = backlogSize.decrementAndFetch()
+              minObserved.update { min -> minOf(min, current) }
             }
           }
         }
       }
 
-      minObserved.get() shouldBeGreaterThanOrEqual 0
-      backlogSize.get() shouldBe 0
+      minObserved.load() shouldBeGreaterThanOrEqual 0
+      backlogSize.load() shouldBe 0
     }
 
     // ==================== ShutDown Tests ====================
@@ -545,9 +548,9 @@ class AgentGrpcServiceTest : StringSpec() {
       // Both threads should complete well within 10 seconds.
       // Before the fix, each resetGrpcStubs iteration could block shutDown
       // for up to 5s (awaitTermination) with the redundant nested lock.
-      completedWithinTimeout.set(latch.await(10.seconds))
+      completedWithinTimeout.store(latch.await(10.seconds))
 
-      completedWithinTimeout.get().shouldBeTrue()
+      completedWithinTimeout.load().shouldBeTrue()
 
       // Service should still be in a usable state -- either shut down or with a valid channel
       // Final cleanup
@@ -575,9 +578,9 @@ class AgentGrpcServiceTest : StringSpec() {
       }
 
       thread.start()
-      completedWithinTimeout.set(latch.await(10.seconds))
+      completedWithinTimeout.store(latch.await(10.seconds))
 
-      completedWithinTimeout.get().shouldBeTrue()
+      completedWithinTimeout.load().shouldBeTrue()
       service.channel.isTerminated.shouldBeFalse()
 
       service.shutDown()
@@ -1051,12 +1054,12 @@ class AgentGrpcServiceTest : StringSpec() {
         // Consumer: consumes via flow (mirrors grpcStub.writeResponsesToProxy)
         launch(Dispatchers.IO) {
           channel.consumeAsFlow().collect { consumed.add(it) }
-          consumerCompleted.set(true)
+          consumerCompleted.store(true)
         }
       }
 
       consumed shouldBe listOf(1, 2, 3)
-      consumerCompleted.get().shouldBeTrue()
+      consumerCompleted.load().shouldBeTrue()
     }
 
     "Bug #6 (channel close): producer-side close on error should still terminate consumers" {
@@ -1082,12 +1085,12 @@ class AgentGrpcServiceTest : StringSpec() {
 
         launch(Dispatchers.IO) {
           channel.consumeAsFlow().collect { consumed.add(it) }
-          consumerCompleted.set(true)
+          consumerCompleted.store(true)
         }
       }
 
       consumed shouldBe listOf(10, 20)
-      consumerCompleted.get().shouldBeTrue()
+      consumerCompleted.load().shouldBeTrue()
     }
 
     "Bug #6 (channel close): writeResponsesToProxyUntilDisconnected should complete with closed connectionContext" {
@@ -1159,10 +1162,12 @@ class AgentGrpcServiceTest : StringSpec() {
       delegateField.isAccessible = true
       val delegate = delegateField.get(service)
 
-      // The delegate wraps an AtomicBoolean in a field named "atomicVal"
+      // The delegate wraps a java.util.concurrent.atomic.AtomicBoolean in a field named "atomicVal"
+      // (the AtomicDelegates library uses the Java type), so this interop cast stays on the Java atomic
+      // and keeps .get() even though the rest of the file now uses kotlin.concurrent.atomics.
       val atomicValField = delegate.javaClass.getDeclaredField("atomicVal")
       atomicValField.isAccessible = true
-      val atomicBool = atomicValField.get(delegate) as AtomicBoolean
+      val atomicBool = atomicValField.get(delegate) as java.util.concurrent.atomic.AtomicBoolean
 
       // After successful construction, grpcStarted should be true
       atomicBool.get().shouldBeTrue()

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -39,7 +39,10 @@ import io.prometheus.grpc.unregisterPathResponse
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.concurrent.atomics.update
 import kotlin.time.Duration.Companion.milliseconds
 
 class AgentPathManagerTest : StringSpec() {
@@ -392,14 +395,14 @@ class AgentPathManagerTest : StringSpec() {
     "concurrent registerPath calls are serialized for atomicity (finding 19)" {
       val agent = createMockAgent()
       val manager = AgentPathManager(agent)
-      val concurrentCalls = AtomicInteger(0)
-      val maxConcurrent = AtomicInteger(0)
+      val concurrentCalls = AtomicInt(0)
+      val maxConcurrent = AtomicInt(0)
 
       coEvery { agent.grpcService.registerPathOnProxy(any(), any()) } coAnswers {
-        val current = concurrentCalls.incrementAndGet()
-        maxConcurrent.updateAndGet { max -> maxOf(max, current) }
+        val current = concurrentCalls.incrementAndFetch()
+        maxConcurrent.update { max -> maxOf(max, current) }
         delay(100.milliseconds) // Simulate slow gRPC call
-        concurrentCalls.decrementAndGet()
+        concurrentCalls.decrementAndFetch()
         registerPathResponse {
           valid = true
           pathId = firstArg<String>().hashCode().toLong()
@@ -415,7 +418,7 @@ class AgentPathManagerTest : StringSpec() {
       manager["path2"].shouldNotBeNull()
       // finding 19: the proxy RPC and the local map write are held under pathMutex together so the local
       // map and the proxy's view can't disagree, which serializes concurrent registrations.
-      maxConcurrent.get() shouldBe 1
+      maxConcurrent.load() shouldBe 1
     }
 
     "registerPaths should register all configured paths" {

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextTest.kt
@@ -33,6 +33,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.grpc.RegisterAgentRequest
 import kotlinx.coroutines.async
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 class AgentContextTest : StringSpec() {
@@ -290,7 +291,7 @@ class AgentContextTest : StringSpec() {
     "backlog size should never go negative under concurrent read-write" {
       val context = AgentContext("remote-addr")
       val iterations = 1000
-      val observedNegative = java.util.concurrent.atomic.AtomicBoolean(false)
+      val observedNegative = AtomicBoolean(false)
 
       // Writer: rapidly write items
       val writerThread = Thread {
@@ -307,7 +308,7 @@ class AgentContextTest : StringSpec() {
           repeat(iterations) {
             context.readScrapeRequest()
             if (context.scrapeRequestBacklogSize < 0) {
-              observedNegative.set(true)
+              observedNegative.store(true)
             }
           }
         }
@@ -320,7 +321,7 @@ class AgentContextTest : StringSpec() {
 
       writerThread.isAlive.shouldBeFalse()
       readerThread.isAlive.shouldBeFalse()
-      observedNegative.get().shouldBeFalse()
+      observedNegative.load().shouldBeFalse()
       context.scrapeRequestBacklogSize shouldBe 0
     }
 

--- a/src/test/kotlin/io/prometheus/proxy/RecentReqsSynchronizationTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/RecentReqsSynchronizationTest.kt
@@ -22,7 +22,7 @@ import com.google.common.collect.EvictingQueue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import java.util.concurrent.CyclicBarrier
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.thread
 
 // Bug #6: The debug servlet read recentReqs (an EvictingQueue backed by ArrayDeque)
@@ -64,7 +64,7 @@ class RecentReqsSynchronizationTest : StringSpec() {
               }
             }
           } catch (e: ConcurrentModificationException) {
-            failed.set(true)
+            failed.store(true)
           }
         }
       }
@@ -72,7 +72,7 @@ class RecentReqsSynchronizationTest : StringSpec() {
       writer.join()
       reader.join()
 
-      failed.get().shouldBeFalse()
+      failed.load().shouldBeFalse()
     }
   }
 }


### PR DESCRIPTION
## Summary

Standardizes the **test** sources on the Kotlin experimental atomics API (`kotlin.concurrent.atomics.*`), matching the production idiom already used throughout `src/main`. Five test files were the last holdouts still importing `java.util.concurrent.atomic.*`; this converts them to `AtomicInt` / `AtomicBoolean` with `.load()` / `.store()` / `.incrementAndFetch()` / `.decrementAndFetch()` / `.update { }`.

This is a mechanical, behavior-preserving, **test-only** change — no production code changes.

### Files converted
- `AgentConnectionContextTest.kt`
- `AgentGrpcServiceTest.kt`
- `AgentPathManagerTest.kt`
- `AgentContextTest.kt`
- `RecentReqsSynchronizationTest.kt`

### One intentional exception
`AgentGrpcServiceTest.kt` keeps a single **fully-qualified Java** `AtomicBoolean` cast in the `Bug #6` reflection test. The `AtomicDelegates` delegate wraps a Java `AtomicBoolean` internally and is read via `.get()`, which Kotlin's `AtomicBoolean` does not expose. `grep -rn "java.util.concurrent.atomic" src/test/kotlin` returns only this one cast (plus its explanatory comment).

### Opt-in
Already handled globally in `build.gradle.kts` via `languageSettings.optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")` for all source sets, so no `@OptIn` annotations are needed.

### Drive-by cleanup
Fixes the deprecated `-xtest` Gradle abbreviation to the explicit `-x test` form in `.github/workflows/ci.yml` and `CLAUDE.md`.

## Verification
- ✅ `./gradlew compileTestKotlin`
- ✅ The 5 affected test classes pass (incl. the `Bug #6` reflection test exercising the interop cast)
- ✅ `./gradlew lintKotlinTest detekt` clean
- ✅ Full `./gradlew build` — SUCCESSFUL, 95.8% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)