### PR TITLE
Remove redundant @OptIn in AgentMetricsTest

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentMetricsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentMetricsTest.kt
@@ -27,12 +27,10 @@ import io.mockk.mockk
 import io.prometheus.Agent
 import io.prometheus.client.CollectorRegistry
 import kotlin.concurrent.atomics.AtomicInt
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 // Tests for AgentMetrics which manages Prometheus metrics for the agent component.
 // Metrics include counters for scrape requests and results, connect counts,
 // and gauges for backlog and cache sizes.
-@OptIn(ExperimentalAtomicApi::class)
 class AgentMetricsTest : StringSpec() {
   private fun createMockAgent(): Agent {
     val mockHttpClientCache = mockk<HttpClientCache>(relaxed = true)


### PR DESCRIPTION
## Summary

Removes the redundant file-level `@OptIn(ExperimentalAtomicApi::class)` annotation (and its now-unused `ExperimentalAtomicApi` import) from `AgentMetricsTest.kt`.

The `kotlin.concurrent.atomics.ExperimentalAtomicApi` opt-in is already applied globally to **all** source sets in `build.gradle.kts` via `languageSettings.optIn(...)`, so the per-file annotation was unnecessary. This brings `AgentMetricsTest` in line with the other Kotlin-atomics test files (`AgentTest`, `ProxyPathManagerTest`, `ProxyHttpRoutesTest`, and the five converted in #201), none of which annotate. Follow-up to #201.

## Verification
- ✅ `./gradlew test --tests "io.prometheus.agent.AgentMetricsTest"` passes
- ✅ `./gradlew lintKotlinTest detekt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)