### PR TITLE
Use Kotlin collection literals across the test suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,14 @@ fun Project.configureKotlin() {
     }
   }
 
+  // Collection literals are a language-wide opt-in, so enable them for every
+  // Kotlin source set (main + test) rather than per-task.
+  tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+      freeCompilerArgs.add("-Xcollection-literals")
+    }
+  }
+
   // Run the unused-return-value checker over production code only. Kotest's
   // assertion DSL (e.g. shouldBe) returns its receiver, and tests intentionally
   // discard that result, so applying the checker to the test source set would
@@ -160,15 +168,6 @@ fun Project.configureKotlin() {
   tasks.named<KotlinCompile>("compileKotlin") {
     compilerOptions {
       freeCompilerArgs.add("-Xreturn-value-checker=check")
-      freeCompilerArgs.add("-Xcollection-literals")
-    }
-  }
-
-  // Collection literals are also enabled for tests, but the unused-return-value
-  // checker is not (see above) — Kotest's assertion DSL would trip it.
-  tasks.named<KotlinCompile>("compileTestKotlin") {
-    compilerOptions {
-      freeCompilerArgs.add("-Xcollection-literals")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,6 +163,14 @@ fun Project.configureKotlin() {
       freeCompilerArgs.add("-Xcollection-literals")
     }
   }
+
+  // Collection literals are also enabled for tests, but the unused-return-value
+  // checker is not (see above) — Kotest's assertion DSL would trip it.
+  tasks.named<KotlinCompile>("compileTestKotlin") {
+    compilerOptions {
+      freeCompilerArgs.add("-Xcollection-literals")
+    }
+  }
 }
 
 fun Project.configureTesting() {

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -463,10 +463,5 @@ class AgentOptions(
 
   internal companion object {
     private val logger = logger {}
-
-    fun agentOptions(
-      args: List<String>,
-      exitOnMissingConfig: Boolean,
-    ) = AgentOptions(args, exitOnMissingConfig)
   }
 }

--- a/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentOptions.kt
@@ -463,5 +463,10 @@ class AgentOptions(
 
   internal companion object {
     private val logger = logger {}
+
+    fun agentOptions(
+      args: List<String>,
+      exitOnMissingConfig: Boolean,
+    ) = AgentOptions(args, exitOnMissingConfig)
   }
 }

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -81,7 +81,7 @@ internal class HttpClientCache(
   // Clients removed via removeEntry() that are not in use and need to be closed.
   // Only accessed while holding accessMutex. Drained after releasing the mutex
   // so that potentially slow HttpClient.close() calls don't block other cache operations.
-  private val pendingCloses = mutableListOf<HttpClient>()
+  private val pendingCloses: MutableList<HttpClient> = []
 
   init {
     scope.launch {
@@ -301,7 +301,7 @@ internal class HttpClientCache(
     // if the cleanup coroutine held the mutex when close() tried to acquire it via runBlocking.
     scope.cancel()
 
-    val clientsToClose = mutableListOf<HttpClient>()
+    val clientsToClose: MutableList<HttpClient> = []
     accessMutex.withLock {
       cache.values.forEach { entry ->
         entry.markForClose()

--- a/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
+++ b/src/main/kotlin/io/prometheus/agent/HttpClientCache.kt
@@ -95,7 +95,7 @@ internal class HttpClientCache(
             }
           }.getOrElse { e ->
             logger.error(e) { "Error during HTTP client cache cleanup" }
-            []
+            emptyList()
           }
         clientsToClose.forEach { closeQuietly(it) }
       }
@@ -279,7 +279,7 @@ internal class HttpClientCache(
 
   // Called with mutex. Returns and clears the pending-close list.
   private fun drainPendingCloses(): List<HttpClient> {
-    if (pendingCloses.isEmpty()) return []
+    if (pendingCloses.isEmpty()) return emptyList()
     return pendingCloses.toList().also { pendingCloses.clear() }
   }
 

--- a/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
+++ b/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
@@ -42,7 +42,7 @@ internal class FileDiscoverySource(
     // setAllowMissing(false): a missing file throws instead of yielding an empty config, so it is
     // never mistaken for a valid-but-empty file (which would tear down every discovered path).
     val config = ConfigFactory.parseFile(File(filePath), PARSE_OPTIONS)
-    val elements = if (config.hasPath(PATHS_KEY)) config.getConfigList(PATHS_KEY) else []
+    val elements = if (config.hasPath(PATHS_KEY)) config.getConfigList(PATHS_KEY) else emptyList()
     return elements.map { element ->
       val path = element.getString("path") // required; a missing field throws (malformed)
       DiscoveredPath(

--- a/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
+++ b/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
@@ -42,7 +42,7 @@ internal class FileDiscoverySource(
     // setAllowMissing(false): a missing file throws instead of yielding an empty config, so it is
     // never mistaken for a valid-but-empty file (which would tear down every discovered path).
     val config = ConfigFactory.parseFile(File(filePath), PARSE_OPTIONS)
-    val elements = if (config.hasPath(PATHS_KEY)) config.getConfigList(PATHS_KEY) else emptyList()
+    val elements = if (config.hasPath(PATHS_KEY)) config.getConfigList(PATHS_KEY) else []
     return elements.map { element ->
       val path = element.getString("path") // required; a missing field throws (malformed)
       DiscoveredPath(

--- a/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
@@ -120,7 +120,7 @@ internal class AgentAuthManager private constructor(
               "Legacy proxy.agentToken is active as an allow-all identity alongside " +
                 "${configured.size} per-agent ${if (configured.size == 1) "identity" else "identities"}"
             }
-          AgentIdentity(LEGACY_IDENTITY_NAME, sha256(legacyToken), [])
+          AgentIdentity(LEGACY_IDENTITY_NAME, sha256(legacyToken), emptyList())
         }
 
       val allIdentities = configured + listOfNotNull(legacyIdentity)

--- a/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
@@ -120,7 +120,7 @@ internal class AgentAuthManager private constructor(
               "Legacy proxy.agentToken is active as an allow-all identity alongside " +
                 "${configured.size} per-agent ${if (configured.size == 1) "identity" else "identities"}"
             }
-          AgentIdentity(LEGACY_IDENTITY_NAME, sha256(legacyToken), emptyList())
+          AgentIdentity(LEGACY_IDENTITY_NAME, sha256(legacyToken), [])
         }
 
       val allIdentities = configured + listOfNotNull(legacyIdentity)

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -431,5 +431,5 @@ internal data class ResponseResults(
   val statusCode: HttpStatusCode = HttpStatusCode.OK,
   val contentType: ContentType = Text.Plain.withCharset(Charsets.UTF_8),
   val contentText: String = "",
-  val updateMsgs: List<String> = [],
+  val updateMsgs: List<String> = emptyList(),
 )

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -299,8 +299,6 @@ class ProxyOptions(
   internal companion object {
     private val logger = logger {}
 
-    fun proxyOptions(args: List<String>) = ProxyOptions(args)
-
     // gRPC timeout fields use -1L as the "leave the gRPC default in place" sentinel (the
     // `> -1L` guards in ProxyGrpcService rely on it). Any other non-positive value is invalid
     // and would otherwise surface as an opaque gRPC builder exception at startup.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -299,6 +299,8 @@ class ProxyOptions(
   internal companion object {
     private val logger = logger {}
 
+    fun proxyOptions(args: List<String>) = ProxyOptions(args)
+
     // gRPC timeout fields use -1L as the "leave the gRPC default in place" sentinel (the
     // `> -1L` guards in ProxyGrpcService rely on it). Any other non-positive value is invalid
     // and would otherwise surface as an opaque gRPC builder exception at startup.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -114,7 +114,7 @@ internal class ProxyPathManager(
           logger.error { reason }
           return reason
         }
-        val displacedContexts = agentInfo?.agentContexts ?: []
+        val displacedContexts = agentInfo?.agentContexts ?: emptyList()
         if (agentInfo != null) {
           logger.info { "Overwriting path /$path for ${agentInfo.agentContexts.firstOrNull()}" }
           proxy.metrics { agentDisplacementCount.inc() }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -215,8 +215,8 @@ internal class ProxyPathManager(
     // skipping the sweep would leave that path 404ing forever (finding 7).
     synchronized(pathMap) {
       // Collect map mutations in a first pass to avoid modifying the map during iteration.
-      val keysToRemove = mutableListOf<String>()
-      val keysToUpdate = mutableMapOf<String, AgentContextInfo>()
+      val keysToRemove: MutableList<String> = []
+      val keysToUpdate: MutableMap<String, AgentContextInfo> = mutableMapOf()
       pathMap.forEach { (k, v) ->
         if (v.agentContexts.size == 1) {
           if (v.agentContexts[0].agentId == agentId)

--- a/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
@@ -24,7 +24,7 @@ import io.prometheus.Agent
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import kotlin.concurrent.atomics.minusAssign
 import kotlin.concurrent.atomics.plusAssign
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 
 class AgentBacklogDriftTest : StringSpec() {
   private fun createTestAgent(): Agent =

--- a/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentBacklogDriftTest.kt
@@ -24,11 +24,12 @@ import io.prometheus.Agent
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import kotlin.concurrent.atomics.minusAssign
 import kotlin.concurrent.atomics.plusAssign
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 
 class AgentBacklogDriftTest : StringSpec() {
   private fun createTestAgent(): Agent =
     Agent(
-      options = AgentOptions(listOf("--proxy", "localhost:$PROXY_AGENT_PORT"), exitOnMissingConfig = false),
+      options = agentOptions(["--proxy", "localhost:$PROXY_AGENT_PORT"], exitOnMissingConfig = false),
       inProcessServerName = "backlog-drift-test",
       testMode = true,
     )

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -818,7 +818,7 @@ class AgentGrpcServiceTest : StringSpec() {
       nonChunkedChannel.tryReceive().isSuccess.shouldBeFalse()
 
       // Drain chunked channel
-      val capturedChunked = mutableListOf<ChunkedScrapeResponse>()
+      val capturedChunked: MutableList<ChunkedScrapeResponse> = []
       while (true) {
         val item = chunkedChannel.tryReceive()
         if (item.isSuccess) capturedChunked.add(item.getOrThrow()) else break
@@ -1036,7 +1036,7 @@ class AgentGrpcServiceTest : StringSpec() {
       // Mirrors the writeResponsesToProxyUntilDisconnected pattern: a producer closes channels
       // in its finally block, and consumers using consumeAsFlow() should complete normally.
       val channel = Channel<Int>(UNLIMITED)
-      val consumed = mutableListOf<Int>()
+      val consumed: MutableList<Int> = []
       val consumerCompleted = AtomicBoolean(false)
 
       coroutineScope {
@@ -1058,7 +1058,7 @@ class AgentGrpcServiceTest : StringSpec() {
         }
       }
 
-      consumed shouldBe listOf(1, 2, 3)
+      consumed shouldBe [1, 2, 3]
       consumerCompleted.load().shouldBeTrue()
     }
 
@@ -1066,7 +1066,7 @@ class AgentGrpcServiceTest : StringSpec() {
       // When the producer throws, the finally block still closes the channel,
       // allowing consumers to drain remaining items and complete.
       val channel = Channel<Int>(UNLIMITED)
-      val consumed = mutableListOf<Int>()
+      val consumed: MutableList<Int> = []
       val consumerCompleted = AtomicBoolean(false)
 
       coroutineScope {
@@ -1089,7 +1089,7 @@ class AgentGrpcServiceTest : StringSpec() {
         }
       }
 
-      consumed shouldBe listOf(10, 20)
+      consumed shouldBe [10, 20]
       consumerCompleted.load().shouldBeTrue()
     }
 

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
@@ -46,7 +46,7 @@ import io.ktor.server.cio.CIO as ServerCIO
 class AgentHttpServiceHeaderTest : StringSpec() {
   init {
     "per-request Accept header should vary independently of cached client" {
-      val capturedHeaders = Collections.synchronizedList(mutableListOf<String?>())
+      val capturedHeaders: MutableList<String?> = Collections.synchronizedList([])
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
@@ -85,7 +85,7 @@ class AgentHttpServiceHeaderTest : StringSpec() {
     }
 
     "defaultRequest Accept header should persist across requests demonstrating old bug" {
-      val capturedHeaders = Collections.synchronizedList(mutableListOf<String?>())
+      val capturedHeaders: MutableList<String?> = Collections.synchronizedList([])
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -26,7 +26,7 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 
 class AgentOptionsTest : StringSpec() {
   init {
@@ -128,7 +128,7 @@ class AgentOptionsTest : StringSpec() {
           "--https_truststore_password",
           "s3cr3t",
         ]
-      val options = AgentOptions(args, false)
+      val options = agentOptions(args, false)
       options.httpsTrustStorePath shouldBe "/etc/agent/truststore.jks"
       options.httpsTrustStorePassword shouldBe "s3cr3t"
     }

--- a/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentOptionsTest.kt
@@ -26,35 +26,36 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 
 class AgentOptionsTest : StringSpec() {
   init {
     // ==================== Default Value Tests ====================
 
     "default proxyHostname should be set from config" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "myhost:1234"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "myhost:1234"], false)
       options.proxyHostname shouldBe "myhost:1234"
     }
 
     "default agentName should be overridable via command line" {
-      val options = AgentOptions(listOf("--name", "custom-agent", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "custom-agent", "--proxy", "host"], false)
       options.agentName shouldBe "custom-agent"
     }
 
     "consolidated should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.consolidated.shouldBeFalse()
     }
 
     "consolidated should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "-o"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "-o"], false)
       options.consolidated.shouldBeTrue()
     }
 
     // ==================== Scrape Configuration Tests ====================
 
     "scrapeTimeoutSecs should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--timeout", "45"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--timeout", "45"], false)
       options.scrapeTimeoutSecs shouldBe 45
     }
 
@@ -62,62 +63,62 @@ class AgentOptionsTest : StringSpec() {
     // fail fast at startup like the other numeric options (chunk, retries, client_timeout, etc.).
     "scrapeTimeoutSecs of 0 should be rejected" {
       val exception = shouldThrow<IllegalArgumentException> {
-        AgentOptions(listOf("--name", "test", "--proxy", "host", "--timeout", "0"), false)
+        agentOptions(["--name", "test", "--proxy", "host", "--timeout", "0"], false)
       }
       exception.message shouldContain "scrapeTimeoutSecs"
     }
 
     "negative scrapeTimeoutSecs from config should be rejected" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.scrapeTimeoutSecs=-5"), false)
+        agentOptions(["--name", "test", "--proxy", "host", "-Dagent.scrapeTimeoutSecs=-5"], false)
       }
     }
 
     "scrapeMaxRetries should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--max_retries", "3"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--max_retries", "3"], false)
       options.scrapeMaxRetries shouldBe 3
     }
 
     // ==================== Chunk and Gzip Tests ====================
 
     "chunkContentSizeBytes should be multiplied by 1024" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--chunk", "32"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--chunk", "32"], false)
       options.chunkContentSizeBytes shouldBe 32 * 1024
     }
 
     // Item 16: --chunk now binds the KB-unit input field; chunkContentSizeBytes is derived once.
     "chunkContentSizeKbs should hold the raw --chunk input and chunkContentSizeBytes its KB*1024 value" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--chunk", "64"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--chunk", "64"], false)
       options.chunkContentSizeKbs shouldBe 64
       options.chunkContentSizeBytes shouldBe 64 * 1024
     }
 
     "minGzipSizeBytes should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--gzip", "2048"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--gzip", "2048"], false)
       options.minGzipSizeBytes shouldBe 2048
     }
 
     // ==================== HTTP Client Tests ====================
 
     "trustAllX509Certificates should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.trustAllX509Certificates.shouldBeFalse()
     }
 
     "trustAllX509Certificates should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--trust_all_x509"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--trust_all_x509"], false)
       options.trustAllX509Certificates.shouldBeTrue()
     }
 
     "httpsTrustStorePath and password should default to empty" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.httpsTrustStorePath shouldBe ""
       options.httpsTrustStorePassword shouldBe ""
     }
 
     "httpsTrustStorePath and password should be settable via command line" {
       val args =
-        listOf(
+        [
           "--name",
           "test",
           "--proxy",
@@ -126,67 +127,67 @@ class AgentOptionsTest : StringSpec() {
           "/etc/agent/truststore.jks",
           "--https_truststore_password",
           "s3cr3t",
-        )
+        ]
       val options = AgentOptions(args, false)
       options.httpsTrustStorePath shouldBe "/etc/agent/truststore.jks"
       options.httpsTrustStorePassword shouldBe "s3cr3t"
     }
 
     "maxConcurrentHttpClients should have positive default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.maxConcurrentHttpClients shouldBeGreaterThan 0
     }
 
     "httpClientTimeoutSecs should have positive default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.httpClientTimeoutSecs shouldBeGreaterThan 0
     }
 
     // ==================== Cache Settings Tests ====================
 
     "maxCacheSize should have valid default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.maxCacheSize shouldBeGreaterThan 0
     }
 
     "maxCacheAgeMins should have valid default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.maxCacheAgeMins shouldBeGreaterThan 0
     }
 
     "maxCacheIdleMins should have valid default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.maxCacheIdleMins shouldBeGreaterThan 0
     }
 
     "cacheCleanupIntervalMins should have valid default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.cacheCleanupIntervalMins shouldBeGreaterThan 0
     }
 
     // ==================== gRPC Settings Tests ====================
 
     "keepAliveWithoutCalls should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.keepAliveWithoutCalls.shouldBeFalse()
     }
 
     "keepAliveWithoutCalls should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--keepalive_without_calls"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--keepalive_without_calls"],
         false,
       )
       options.keepAliveWithoutCalls.shouldBeTrue()
     }
 
     "unaryDeadlineSecs should have positive default" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.unaryDeadlineSecs shouldBeGreaterThan 0
     }
 
     "unaryDeadlineSecs should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--unary_deadline_secs", "60"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--unary_deadline_secs", "60"],
         false,
       )
       options.unaryDeadlineSecs shouldBe 60
@@ -195,25 +196,25 @@ class AgentOptionsTest : StringSpec() {
     // ==================== Constructor Variants ====================
 
     "list constructor should work" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.agentName shouldBe "test"
     }
 
     "configVals should be populated after construction" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.configVals.agent.name.shouldNotBeNull()
     }
 
     // ==================== Override Authority Tests ====================
 
     "overrideAuthority should default to empty" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.overrideAuthority shouldBe ""
     }
 
     "overrideAuthority should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--override", "my-authority"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--override", "my-authority"],
         false,
       )
       options.overrideAuthority shouldBe "my-authority"
@@ -222,48 +223,48 @@ class AgentOptionsTest : StringSpec() {
     // ==================== CLI Args for HTTP Client and Cache ====================
 
     "maxConcurrentHttpClients should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_concurrent_clients", "25"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_concurrent_clients", "25"],
         false,
       )
       options.maxConcurrentHttpClients shouldBe 25
     }
 
     "httpClientTimeoutSecs should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--client_timeout_secs", "120"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--client_timeout_secs", "120"],
         false,
       )
       options.httpClientTimeoutSecs shouldBe 120
     }
 
     "maxCacheSize should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_size", "200"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_size", "200"],
         false,
       )
       options.maxCacheSize shouldBe 200
     }
 
     "maxCacheAgeMins should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_age_mins", "60"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_age_mins", "60"],
         false,
       )
       options.maxCacheAgeMins shouldBe 60
     }
 
     "maxCacheIdleMins should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_idle_mins", "20"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_idle_mins", "20"],
         false,
       )
       options.maxCacheIdleMins shouldBe 20
     }
 
     "cacheCleanupIntervalMins should be settable via command line" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "15"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "15"],
         false,
       )
       options.cacheCleanupIntervalMins shouldBe 15
@@ -277,14 +278,14 @@ class AgentOptionsTest : StringSpec() {
     // would gzip everything.
     "Finding 11: reconnectPauseSecs of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.internal.reconnectPauseSecs=0"), false)
+        agentOptions(["--name", "test", "--proxy", "host", "-Dagent.internal.reconnectPauseSecs=0"], false)
       }
     }
 
     "Finding 11: scrapeRequestBacklogUnhealthySize of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "-Dagent.internal.scrapeRequestBacklogUnhealthySize=0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "-Dagent.internal.scrapeRequestBacklogUnhealthySize=0"],
           false,
         )
       }
@@ -292,19 +293,19 @@ class AgentOptionsTest : StringSpec() {
 
     "Finding 11: minGzipSizeBytes of -1 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=-5"), false)
+        agentOptions(["--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=-5"], false)
       }
     }
 
     "Finding 11: minGzipSizeBytes of 0 should be accepted (gzip every non-empty payload)" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=0"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "-Dagent.minGzipSizeBytes=0"], false)
       options.minGzipSizeBytes shouldBe 0
     }
 
     "maxConcurrentHttpClients of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--max_concurrent_clients", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--max_concurrent_clients", "0"],
           false,
         )
       }
@@ -312,8 +313,8 @@ class AgentOptionsTest : StringSpec() {
 
     "httpClientTimeoutSecs of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--client_timeout_secs", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--client_timeout_secs", "0"],
           false,
         )
       }
@@ -323,8 +324,8 @@ class AgentOptionsTest : StringSpec() {
     // These tests verify that 1 is now accepted and 0 is still rejected.
 
     "maxCacheSize of 1 should be accepted" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_size", "1"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_size", "1"],
         false,
       )
       options.maxCacheSize shouldBe 1
@@ -332,16 +333,16 @@ class AgentOptionsTest : StringSpec() {
 
     "maxCacheSize of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--max_cache_size", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--max_cache_size", "0"],
           false,
         )
       }
     }
 
     "maxCacheAgeMins of 1 should be accepted" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_age_mins", "1"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_age_mins", "1"],
         false,
       )
       options.maxCacheAgeMins shouldBe 1
@@ -349,16 +350,16 @@ class AgentOptionsTest : StringSpec() {
 
     "maxCacheAgeMins of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--max_cache_age_mins", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--max_cache_age_mins", "0"],
           false,
         )
       }
     }
 
     "maxCacheIdleMins of 1 should be accepted" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--max_cache_idle_mins", "1"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--max_cache_idle_mins", "1"],
         false,
       )
       options.maxCacheIdleMins shouldBe 1
@@ -366,16 +367,16 @@ class AgentOptionsTest : StringSpec() {
 
     "maxCacheIdleMins of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--max_cache_idle_mins", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--max_cache_idle_mins", "0"],
           false,
         )
       }
     }
 
     "cacheCleanupIntervalMins of 1 should be accepted" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "1"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "1"],
         false,
       )
       options.cacheCleanupIntervalMins shouldBe 1
@@ -383,8 +384,8 @@ class AgentOptionsTest : StringSpec() {
 
     "cacheCleanupIntervalMins of 0 should throw IllegalArgumentException" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--cache_cleanup_interval_mins", "0"],
           false,
         )
       }
@@ -398,16 +399,16 @@ class AgentOptionsTest : StringSpec() {
     // the KB value is positive and checks for overflow before the conversion.
 
     "Bug #9: chunkContentSizeBytes should correctly convert KB to bytes" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--chunk", "64"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--chunk", "64"],
         false,
       )
       options.chunkContentSizeBytes shouldBe 64 * 1024
     }
 
     "Bug #9: chunkContentSizeBytes of 1 KB should be accepted" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--chunk", "1"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--chunk", "1"],
         false,
       )
       options.chunkContentSizeBytes shouldBe 1024
@@ -416,8 +417,8 @@ class AgentOptionsTest : StringSpec() {
     "Bug #9: chunkContentSizeBytes at max safe KB value should be accepted" {
       // Int.MAX_VALUE / 1024 = 2097151
       val maxSafeKb = (Int.MAX_VALUE / 1024).toString()
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--chunk", maxSafeKb),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--chunk", maxSafeKb],
         false,
       )
       options.chunkContentSizeBytes shouldBe (Int.MAX_VALUE / 1024) * 1024
@@ -427,8 +428,8 @@ class AgentOptionsTest : StringSpec() {
       // Int.MAX_VALUE / 1024 + 1 = 2097152, which overflows when multiplied by 1024
       val overflowKb = (Int.MAX_VALUE / 1024 + 1).toString()
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--chunk", overflowKb),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--chunk", overflowKb],
           false,
         )
       }
@@ -436,8 +437,8 @@ class AgentOptionsTest : StringSpec() {
 
     "Bug #9: chunkContentSizeBytes of 0 should throw" {
       shouldThrow<IllegalArgumentException> {
-        AgentOptions(
-          listOf("--name", "test", "--proxy", "host", "--chunk", "0"),
+        agentOptions(
+          ["--name", "test", "--proxy", "host", "--chunk", "0"],
           false,
         )
       }

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -304,10 +304,10 @@ class AgentPathManagerTest : StringSpec() {
       val manager = AgentPathManager(agent)
 
       manager.reconcileDiscoveredPaths(
-        listOf(
+        [
           DiscoveredPath("a", "a_metrics", "http://a/m", "{}"),
           DiscoveredPath("b", "b_metrics", "http://b/m", "{}"),
-        ),
+        ],
       )
 
       manager["a_metrics"].shouldNotBeNull().source shouldBe PathSource.DISCOVERED
@@ -321,12 +321,12 @@ class AgentPathManagerTest : StringSpec() {
       val manager = AgentPathManager(agent)
 
       manager.reconcileDiscoveredPaths(
-        listOf(
+        [
           DiscoveredPath("a", "a_metrics", "http://a/m", "{}"),
           DiscoveredPath("b", "b_metrics", "http://b/m", "{}"),
-        ),
+        ],
       )
-      manager.reconcileDiscoveredPaths(listOf(DiscoveredPath("b", "b_metrics", "http://b/m", "{}")))
+      manager.reconcileDiscoveredPaths([DiscoveredPath("b", "b_metrics", "http://b/m", "{}")])
 
       manager["a_metrics"].shouldBeNull()
       manager["b_metrics"].shouldNotBeNull()
@@ -338,7 +338,7 @@ class AgentPathManagerTest : StringSpec() {
       val grpc = agent.grpcService
       val manager = AgentPathManager(agent)
 
-      val desired = listOf(DiscoveredPath("a", "a_metrics", "http://a/m", "{}"))
+      val desired = [DiscoveredPath("a", "a_metrics", "http://a/m", "{}")]
       manager.reconcileDiscoveredPaths(desired)
       manager.reconcileDiscoveredPaths(desired)
 
@@ -351,8 +351,8 @@ class AgentPathManagerTest : StringSpec() {
       val grpc = agent.grpcService
       val manager = AgentPathManager(agent)
 
-      manager.reconcileDiscoveredPaths(listOf(DiscoveredPath("a", "a_metrics", "http://a/v1", "{}")))
-      manager.reconcileDiscoveredPaths(listOf(DiscoveredPath("a", "a_metrics", "http://a/v2", "{}")))
+      manager.reconcileDiscoveredPaths([DiscoveredPath("a", "a_metrics", "http://a/v1", "{}")])
+      manager.reconcileDiscoveredPaths([DiscoveredPath("a", "a_metrics", "http://a/v2", "{}")])
 
       manager["a_metrics"].shouldNotBeNull().url shouldBe "http://a/v2"
       coVerify(exactly = 1) { grpc.unregisterPathOnProxy("a_metrics") }
@@ -366,7 +366,7 @@ class AgentPathManagerTest : StringSpec() {
 
       // Register a static baseline path, then try to discover the same path with a different url.
       manager.registerPath("shared", "http://static/m")
-      manager.reconcileDiscoveredPaths(listOf(DiscoveredPath("shared", "shared", "http://discovered/m", "{}")))
+      manager.reconcileDiscoveredPaths([DiscoveredPath("shared", "shared", "http://discovered/m", "{}")])
 
       val context = manager["shared"].shouldNotBeNull()
       context.source shouldBe PathSource.STATIC
@@ -380,8 +380,8 @@ class AgentPathManagerTest : StringSpec() {
       val manager = AgentPathManager(agent)
 
       manager.registerPath("static_path", "http://static/m")
-      manager.reconcileDiscoveredPaths(listOf(DiscoveredPath("d", "disc_path", "http://d/m", "{}")))
-      manager.reconcileDiscoveredPaths(emptyList())
+      manager.reconcileDiscoveredPaths([DiscoveredPath("d", "disc_path", "http://d/m", "{}")])
+      manager.reconcileDiscoveredPaths([])
 
       manager["disc_path"].shouldBeNull()
       manager["static_path"].shouldNotBeNull().source shouldBe PathSource.STATIC

--- a/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentPathManagerTest.kt
@@ -381,7 +381,7 @@ class AgentPathManagerTest : StringSpec() {
 
       manager.registerPath("static_path", "http://static/m")
       manager.reconcileDiscoveredPaths([DiscoveredPath("d", "disc_path", "http://d/m", "{}")])
-      manager.reconcileDiscoveredPaths([])
+      manager.reconcileDiscoveredPaths(emptyList())
 
       manager["disc_path"].shouldBeNull()
       manager["static_path"].shouldNotBeNull().source shouldBe PathSource.STATIC

--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -38,7 +38,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.Agent
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 import io.prometheus.common.ConfigLoadException
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import kotlinx.coroutines.CompletableDeferred
@@ -57,13 +57,9 @@ import ch.qos.logback.classic.Logger as LogbackLogger
 
 class AgentTest : StringSpec() {
   private fun createTestAgent(vararg extraArgs: String): Agent {
-    val args =
-      buildList {
-        addAll(["--proxy", "localhost:$PROXY_AGENT_PORT"])
-        addAll(extraArgs)
-      }
+    val args = ["--proxy", "localhost:$PROXY_AGENT_PORT"] + extraArgs
     return Agent(
-      options = AgentOptions(args, exitOnMissingConfig = false),
+      options = agentOptions(args, exitOnMissingConfig = false),
       inProcessServerName = "agent-test-${System.nanoTime()}",
       testMode = true,
     )

--- a/src/test/kotlin/io/prometheus/agent/AgentTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentTest.kt
@@ -19,7 +19,6 @@
 package io.prometheus.agent
 
 import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger as LogbackLogger
 import com.google.common.util.concurrent.RateLimiter
 import io.grpc.Status
 import io.grpc.StatusException
@@ -39,6 +38,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.Agent
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 import io.prometheus.common.ConfigLoadException
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import kotlinx.coroutines.CompletableDeferred
@@ -47,17 +47,19 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.minusAssign
 import kotlin.concurrent.atomics.plusAssign
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import org.slf4j.LoggerFactory
+import ch.qos.logback.classic.Logger as LogbackLogger
 
 class AgentTest : StringSpec() {
   private fun createTestAgent(vararg extraArgs: String): Agent {
     val args =
-      mutableListOf("--proxy", "localhost:$PROXY_AGENT_PORT").apply {
+      buildList {
+        addAll(["--proxy", "localhost:$PROXY_AGENT_PORT"])
         addAll(extraArgs)
       }
     return Agent(
@@ -117,7 +119,7 @@ class AgentTest : StringSpec() {
     "EmbeddedAgentInfo.shutdown() should terminate the agent service, not leave the run loop reconnecting" {
       val agent =
         Agent(
-          options = AgentOptions(listOf("--proxy", "localhost:$PROXY_AGENT_PORT"), exitOnMissingConfig = false),
+          options = agentOptions(["--proxy", "localhost:$PROXY_AGENT_PORT"], exitOnMissingConfig = false),
           inProcessServerName = "embedded-stop-test-${System.nanoTime()}",
           testMode = true,
         ) { startAsync() }

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -178,7 +178,7 @@ class HttpClientCacheTest : StringSpec() {
 
       try {
         // Fill cache to capacity with distinct timestamps so LRU order is deterministic
-        val entries = mutableListOf<CacheEntry>()
+        val entries: MutableList<CacheEntry> = []
         for (i in 1..5) {
           val key = ClientKey("user$i", "pass$i")
           val entry = lruCache.getOrCreateClient(key) { createMockHttpClient() }
@@ -452,7 +452,7 @@ class HttpClientCacheTest : StringSpec() {
       )
 
       // Populate cache to give the cleanup coroutine work to do
-      val entries = mutableListOf<CacheEntry>()
+      val entries: MutableList<CacheEntry> = []
       for (i in 1..5) {
         val key = ClientKey("user$i", "pass$i")
         val entry = fastCleanupCache.getOrCreateClient(key) { createMockHttpClient() }
@@ -869,7 +869,7 @@ class HttpClientCacheTest : StringSpec() {
 
       try {
         // Create multiple entries
-        val entries = mutableListOf<CacheEntry>()
+        val entries: MutableList<CacheEntry> = []
         for (i in 1..3) {
           val key = ClientKey("user$i", "pass$i")
           val entry = testCache.getOrCreateClient(key) { createMockHttpClient() }

--- a/src/test/kotlin/io/prometheus/agent/discovery/PathDiscoveryServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/discovery/PathDiscoveryServiceTest.kt
@@ -36,7 +36,7 @@ class PathDiscoveryServiceTest : StringSpec() {
     }
 
     "a successful read reconciles the desired set" {
-      val desired = listOf(DiscoveredPath("a", "a_metrics", "http://a/m", "{}"))
+      val desired = [DiscoveredPath("a", "a_metrics", "http://a/m", "{}")]
       val pathManager = mockk<AgentPathManager>(relaxed = true)
       val service = PathDiscoveryService(pathManager, { desired }, 30)
 
@@ -47,11 +47,11 @@ class PathDiscoveryServiceTest : StringSpec() {
 
     "a successful empty read reconciles to empty (removes all discovered)" {
       val pathManager = mockk<AgentPathManager>(relaxed = true)
-      val service = PathDiscoveryService(pathManager, { emptyList() }, 30)
+      val service = PathDiscoveryService(pathManager, { [] }, 30)
 
       service.reconcileOnce()
 
-      coVerify(exactly = 1) { pathManager.reconcileDiscoveredPaths(emptyList()) }
+      coVerify(exactly = 1) { pathManager.reconcileDiscoveredPaths([]) }
     }
   }
 }

--- a/src/test/kotlin/io/prometheus/agent/discovery/PathDiscoveryServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/discovery/PathDiscoveryServiceTest.kt
@@ -47,11 +47,11 @@ class PathDiscoveryServiceTest : StringSpec() {
 
     "a successful empty read reconciles to empty (removes all discovered)" {
       val pathManager = mockk<AgentPathManager>(relaxed = true)
-      val service = PathDiscoveryService(pathManager, { [] }, 30)
+      val service = PathDiscoveryService(pathManager, { emptyList() }, 30)
 
       service.reconcileOnce()
 
-      coVerify(exactly = 1) { pathManager.reconcileDiscoveredPaths([]) }
+      coVerify(exactly = 1) { pathManager.reconcileDiscoveredPaths(emptyList()) }
     }
   }
 }

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -34,54 +34,52 @@ import io.ktor.server.routing.routing
 import io.prometheus.agent.AgentOptions
 import io.prometheus.common.BaseOptions.Companion.resolveBoolean
 import io.prometheus.proxy.ProxyOptions
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import java.io.File
 import java.net.URI
 import kotlin.io.path.createTempDirectory
 import io.ktor.server.cio.CIO as ServerCIO
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
 
 class BaseOptionsTest : StringSpec() {
   init {
     // ==================== Shared Option Defaults (via ProxyOptions) ====================
 
     "adminEnabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.adminEnabled.shouldBeFalse()
     }
 
     "metricsEnabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.metricsEnabled.shouldBeFalse()
     }
 
     "debugEnabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.debugEnabled.shouldBeFalse()
     }
 
     "transportFilterDisabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.transportFilterDisabled.shouldBeFalse()
     }
 
     "certChainFilePath should default to empty" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.certChainFilePath.shouldBeEmpty()
     }
 
     "privateKeyFilePath should default to empty" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.privateKeyFilePath.shouldBeEmpty()
     }
 
     "trustCertCollectionFilePath should default to empty" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.trustCertCollectionFilePath.shouldBeEmpty()
     }
 
     "logLevel should default to empty" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.logLevel.shouldBeEmpty()
     }
 
@@ -115,7 +113,7 @@ class BaseOptionsTest : StringSpec() {
     // ==================== Transport Filter and TLS ====================
 
     "isTlsEnabled should be false when no TLS options set" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.isTlsEnabled shouldBe false
     }
 
@@ -181,7 +179,7 @@ class BaseOptionsTest : StringSpec() {
     // ==================== Dynamic Parameters ====================
 
     "dynamic params should be empty by default" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.dynamicParams.size shouldBe 0
     }
 
@@ -382,7 +380,7 @@ class BaseOptionsTest : StringSpec() {
     // ==================== ConfigVals Tests ====================
 
     "configVals should be initialized after construction" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.configVals.proxy.http.port shouldBeGreaterThan 0
       options.configVals.proxy.admin.pingPath.shouldNotBeEmpty()
     }

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -34,99 +34,101 @@ import io.ktor.server.routing.routing
 import io.prometheus.agent.AgentOptions
 import io.prometheus.common.BaseOptions.Companion.resolveBoolean
 import io.prometheus.proxy.ProxyOptions
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import java.io.File
 import java.net.URI
 import kotlin.io.path.createTempDirectory
 import io.ktor.server.cio.CIO as ServerCIO
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 
 class BaseOptionsTest : StringSpec() {
   init {
     // ==================== Shared Option Defaults (via ProxyOptions) ====================
 
     "adminEnabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.adminEnabled.shouldBeFalse()
     }
 
     "metricsEnabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.metricsEnabled.shouldBeFalse()
     }
 
     "debugEnabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.debugEnabled.shouldBeFalse()
     }
 
     "transportFilterDisabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.transportFilterDisabled.shouldBeFalse()
     }
 
     "certChainFilePath should default to empty" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.certChainFilePath.shouldBeEmpty()
     }
 
     "privateKeyFilePath should default to empty" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.privateKeyFilePath.shouldBeEmpty()
     }
 
     "trustCertCollectionFilePath should default to empty" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.trustCertCollectionFilePath.shouldBeEmpty()
     }
 
     "logLevel should default to empty" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.logLevel.shouldBeEmpty()
     }
 
     // ==================== Admin Option Overrides ====================
 
     "adminEnabled should be settable via -r flag" {
-      val options = ProxyOptions(listOf("-r"))
+      val options = proxyOptions(["-r"])
       options.adminEnabled shouldBe true
     }
 
     "adminPort should be settable via -i flag" {
-      val options = ProxyOptions(listOf("-i", "9000"))
+      val options = proxyOptions(["-i", "9000"])
       options.adminPort shouldBe 9000
     }
 
     "metricsEnabled should be settable via -e flag" {
-      val options = ProxyOptions(listOf("-e"))
+      val options = proxyOptions(["-e"])
       options.metricsEnabled shouldBe true
     }
 
     "metricsPort should be settable via -m flag" {
-      val options = ProxyOptions(listOf("-m", "9100"))
+      val options = proxyOptions(["-m", "9100"])
       options.metricsPort shouldBe 9100
     }
 
     "debugEnabled should be settable via -b flag" {
-      val options = ProxyOptions(listOf("-b"))
+      val options = proxyOptions(["-b"])
       options.debugEnabled shouldBe true
     }
 
     // ==================== Transport Filter and TLS ====================
 
     "isTlsEnabled should be false when no TLS options set" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.isTlsEnabled shouldBe false
     }
 
     // Bug #3: isTlsEnabled requires BOTH cert and key (AND, not OR)
     "isTlsEnabled should be true when both cert and key are set" {
-      val options = ProxyOptions(listOf("-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"))
+      val options = proxyOptions(["-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"])
       options.isTlsEnabled shouldBe true
     }
 
     "partial TLS config with only cert should fail fast" {
       val ex =
         shouldThrow<IllegalArgumentException> {
-          ProxyOptions(listOf("-t", "/path/to/cert.pem"))
+          proxyOptions(["-t", "/path/to/cert.pem"])
         }
       ex.message shouldContain "private key file is missing"
     }
@@ -134,80 +136,80 @@ class BaseOptionsTest : StringSpec() {
     "partial TLS config with only key should fail fast" {
       val ex =
         shouldThrow<IllegalArgumentException> {
-          ProxyOptions(listOf("-k", "/path/to/key.pem"))
+          proxyOptions(["-k", "/path/to/key.pem"])
         }
       ex.message shouldContain "certificate chain file is missing"
     }
 
     "transportFilterDisabled should be settable via --tf_disabled" {
-      val options = ProxyOptions(listOf("--tf_disabled"))
+      val options = proxyOptions(["--tf_disabled"])
       options.transportFilterDisabled shouldBe true
     }
 
     "transportFilterDisabled should accept hyphenated variant --tf-disabled" {
-      val options = ProxyOptions(listOf("--tf-disabled"))
+      val options = proxyOptions(["--tf-disabled"])
       options.transportFilterDisabled shouldBe true
     }
 
     "certChainFilePath should be settable via -t flag" {
-      val options = ProxyOptions(listOf("-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"))
+      val options = proxyOptions(["-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"])
       options.certChainFilePath shouldBe "/path/to/cert.pem"
     }
 
     "privateKeyFilePath should be settable via -k flag" {
-      val options = ProxyOptions(listOf("-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"))
+      val options = proxyOptions(["-t", "/path/to/cert.pem", "-k", "/path/to/key.pem"])
       options.privateKeyFilePath shouldBe "/path/to/key.pem"
     }
 
     "trustCertCollectionFilePath should be settable via -s flag" {
-      val options = ProxyOptions(listOf("-s", "/path/to/trust.pem"))
+      val options = proxyOptions(["-s", "/path/to/trust.pem"])
       options.trustCertCollectionFilePath shouldBe "/path/to/trust.pem"
     }
 
     // ==================== KeepAlive Settings ====================
 
     "keepAliveTimeSecs should be settable via --keepalive_time_secs" {
-      val options = ProxyOptions(listOf("--keepalive_time_secs", "600"))
+      val options = proxyOptions(["--keepalive_time_secs", "600"])
       options.keepAliveTimeSecs shouldBe 600L
     }
 
     "keepAliveTimeoutSecs should be settable via --keepalive_timeout_secs" {
-      val options = ProxyOptions(listOf("--keepalive_timeout_secs", "30"))
+      val options = proxyOptions(["--keepalive_timeout_secs", "30"])
       options.keepAliveTimeoutSecs shouldBe 30L
     }
 
     // ==================== Dynamic Parameters ====================
 
     "dynamic params should be empty by default" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.dynamicParams.size shouldBe 0
     }
 
     "dynamic params should capture -D values" {
-      val options = ProxyOptions(listOf("-Dproxy.http.port=9999"))
+      val options = proxyOptions(["-Dproxy.http.port=9999"])
       options.dynamicParams.size shouldBe 1
     }
 
     // ==================== Shared Defaults via AgentOptions ====================
 
     "agent adminEnabled should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.adminEnabled.shouldBeFalse()
     }
 
     "agent metricsEnabled should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.metricsEnabled.shouldBeFalse()
     }
 
     "agent debugEnabled should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.debugEnabled.shouldBeFalse()
     }
 
     "agent logLevel should be settable via --log_level" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--log_level", "DEBUG"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--log_level", "DEBUG"],
         false,
       )
       options.logLevel shouldBe "DEBUG"
@@ -227,7 +229,7 @@ class BaseOptionsTest : StringSpec() {
           """.trimIndent(),
         )
 
-        val options = ProxyOptions(listOf("-c", confFile.absolutePath))
+        val options = proxyOptions(["-c", confFile.absolutePath])
         options.proxyPort shouldBe 9999
       } finally {
         tempDir.deleteRecursively()
@@ -250,7 +252,7 @@ class BaseOptionsTest : StringSpec() {
           """.trimIndent(),
         )
 
-        val options = ProxyOptions(listOf("-c", jsonFile.absolutePath))
+        val options = proxyOptions(["-c", jsonFile.absolutePath])
         options.proxyPort shouldBe 7777
       } finally {
         tempDir.deleteRecursively()
@@ -263,7 +265,7 @@ class BaseOptionsTest : StringSpec() {
         val propsFile = File(tempDir, "test.properties")
         propsFile.writeText("proxy.http.port=6666")
 
-        val options = ProxyOptions(listOf("-c", propsFile.absolutePath))
+        val options = proxyOptions(["-c", propsFile.absolutePath])
         options.proxyPort shouldBe 6666
       } finally {
         tempDir.deleteRecursively()
@@ -284,7 +286,7 @@ class BaseOptionsTest : StringSpec() {
     }
 
     "dynamic params should strip surrounding quotes" {
-      val options = ProxyOptions(listOf("-Dproxy.http.port=\"5555\""))
+      val options = proxyOptions(["-Dproxy.http.port=\"5555\""])
       options.proxyPort shouldBe 5555
     }
 
@@ -303,7 +305,7 @@ class BaseOptionsTest : StringSpec() {
           """.trimIndent(),
         )
 
-        val options = ProxyOptions(listOf("-c", confFile.absolutePath))
+        val options = proxyOptions(["-c", confFile.absolutePath])
         options.proxyPort shouldBe 8888
         // Variable substitution resolved: admin.port = proxy.http.port = 8888
         options.configVals.proxy.admin.port shouldBe 8888
@@ -339,7 +341,7 @@ class BaseOptionsTest : StringSpec() {
       // validator during parse(). Now the version flag is checked after parsing,
       // so constructing with other flags should not exit.
       // This test verifies normal construction still works (no exitProcess during parsing).
-      val options = ProxyOptions(listOf("-b"))
+      val options = proxyOptions(["-b"])
       options.debugEnabled shouldBe true
     }
 
@@ -353,14 +355,14 @@ class BaseOptionsTest : StringSpec() {
     "Finding 5: invalid CLI option throws ConfigLoadException when exitOnMissingConfig is false" {
       val ex =
         shouldThrow<ConfigLoadException> {
-          AgentOptions(listOf("--proxy", "host", "--admin_port", "not_a_number"), exitOnMissingConfig = false)
+          agentOptions(["--proxy", "host", "--admin_port", "not_a_number"], exitOnMissingConfig = false)
         }
       ex.message.shouldNotBeEmpty()
     }
 
     "Finding 5: unknown CLI flag throws ConfigLoadException when exitOnMissingConfig is false" {
       shouldThrow<ConfigLoadException> {
-        AgentOptions(listOf("--proxy", "host", "--this-flag-does-not-exist"), exitOnMissingConfig = false)
+        agentOptions(["--proxy", "host", "--this-flag-does-not-exist"], exitOnMissingConfig = false)
       }
     }
 
@@ -380,7 +382,7 @@ class BaseOptionsTest : StringSpec() {
     // ==================== ConfigVals Tests ====================
 
     "configVals should be initialized after construction" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.configVals.proxy.http.port shouldBeGreaterThan 0
       options.configVals.proxy.admin.pingPath.shouldNotBeEmpty()
     }
@@ -553,7 +555,7 @@ class BaseOptionsTest : StringSpec() {
     }
     try {
       val port = server.startAndAwaitReady()
-      val options = ProxyOptions(listOf("-c", "http://localhost:$port/$fileName"))
+      val options = proxyOptions(["-c", "http://localhost:$port/$fileName"])
       options.proxyPort shouldBe expectedPort
     } finally {
       server.stop(0, 0)

--- a/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/EnvVarsTest.kt
@@ -166,7 +166,7 @@ class EnvVarsTest : StringSpec() {
     // ==================== Enum Completeness Tests ====================
 
     "EnvVars enum should contain all expected proxy variables" {
-      val proxyVars = listOf(
+      val proxyVars = [
         EnvVars.PROXY_CONFIG,
         EnvVars.PROXY_PORT,
         EnvVars.AGENT_PORT,
@@ -181,7 +181,7 @@ class EnvVarsTest : StringSpec() {
         EnvVars.MAX_CONNECTION_AGE_SECS,
         EnvVars.MAX_CONNECTION_AGE_GRACE_SECS,
         EnvVars.PROXY_LOG_LEVEL,
-      )
+      ]
 
       proxyVars.forEach { envVar ->
         // Verify each enum constant exists and has a name
@@ -196,7 +196,7 @@ class EnvVarsTest : StringSpec() {
     "EnvVars entries should contain all defined constants" {
       val allNames = EnvVars.entries.map { it.name }
 
-      allNames shouldContainAll listOf(
+      allNames shouldContainAll [
         "PROXY_CONFIG",
         "PROXY_PORT",
         "AGENT_PORT",
@@ -244,13 +244,13 @@ class EnvVarsTest : StringSpec() {
         "KEEPALIVE_TIME_SECS",
         "KEEPALIVE_TIMEOUT_SECS",
         "UNARY_DEADLINE_SECS",
-      )
+      ]
     }
 
     "entry count should match completeness list size to prevent drift" {
       // Guard against M11-style bugs: if someone adds an enum entry but forgets to
       // update the count test or the completeness list, this test will catch it.
-      val allExpected = listOf(
+      val allExpected = [
         "PROXY_CONFIG",
         "PROXY_PORT",
         "AGENT_PORT",
@@ -298,7 +298,7 @@ class EnvVarsTest : StringSpec() {
         "OVERRIDE_AUTHORITY",
         "KEEPALIVE_TIME_SECS",
         "KEEPALIVE_TIMEOUT_SECS",
-      )
+      ]
       val actualNames = EnvVars.entries.map { it.name }.sorted()
       val expectedNames = allExpected.sorted()
 
@@ -424,7 +424,7 @@ class EnvVarsTest : StringSpec() {
     // ==================== Agent Variables ====================
 
     "EnvVars enum should contain all expected agent variables" {
-      val agentVars = listOf(
+      val agentVars = [
         EnvVars.AGENT_CONFIG,
         EnvVars.PROXY_HOSTNAME,
         EnvVars.AGENT_NAME,
@@ -440,7 +440,7 @@ class EnvVarsTest : StringSpec() {
         EnvVars.CLIENT_TIMEOUT_SECS,
         EnvVars.UNARY_DEADLINE_SECS,
         EnvVars.AGENT_LOG_LEVEL,
-      )
+      ]
 
       agentVars.forEach { envVar ->
         envVar.name.shouldNotBeEmpty()

--- a/src/test/kotlin/io/prometheus/common/TestOptions.kt
+++ b/src/test/kotlin/io/prometheus/common/TestOptions.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.common
+
+import io.prometheus.agent.AgentOptions
+import io.prometheus.proxy.ProxyOptions
+
+// Test-only factories that build ProxyOptions/AgentOptions from a List<String>.
+// They pin the List<String> constructor overload so call sites can pass a collection
+// literal (e.g. proxyOptions(["-p", "8080"])) without hitting the Array-vs-List overload
+// ambiguity that a bare literal would create against the raw constructors.
+fun proxyOptions(args: List<String>): ProxyOptions = ProxyOptions(args)
+
+fun agentOptions(
+  args: List<String>,
+  exitOnMissingConfig: Boolean,
+): AgentOptions = AgentOptions(args, exitOnMissingConfig)

--- a/src/test/kotlin/io/prometheus/containers/ContainersProxyHttpTest.kt
+++ b/src/test/kotlin/io/prometheus/containers/ContainersProxyHttpTest.kt
@@ -66,14 +66,14 @@ class ContainersProxyHttpTest : StringSpec() {
         proxyContainer(
           network,
           env = mapOf("ADMIN_ENABLED" to "true", "METRICS_ENABLED" to "true", "SD_ENABLED" to "true"),
-          exposedPorts = listOf(PROXY_HTTP_PORT, PROXY_METRICS_PORT, PROXY_ADMIN_PORT),
+          exposedPorts = [PROXY_HTTP_PORT, PROXY_METRICS_PORT, PROXY_ADMIN_PORT],
         )
       val agent =
         agentContainer(
           network,
           configResource = "containers/agent-http.conf",
           env = mapOf("ADMIN_ENABLED" to "true", "METRICS_ENABLED" to "true"),
-          exposedPorts = listOf(AGENT_METRICS_PORT, AGENT_ADMIN_PORT),
+          exposedPorts = [AGENT_METRICS_PORT, AGENT_ADMIN_PORT],
         )
       val httpClient = httpClient()
 
@@ -95,7 +95,7 @@ class ContainersProxyHttpTest : StringSpec() {
 
       afterSpec {
         httpClient.close()
-        listOf(agent, proxy, metricsStub).forEach { container ->
+        [agent, proxy, metricsStub].forEach { container ->
           try {
             container.stop()
           } catch (_: Exception) {

--- a/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
+++ b/src/test/kotlin/io/prometheus/containers/ContainersScalingTest.kt
@@ -67,14 +67,14 @@ class ContainersScalingTest : StringSpec() {
       withData(nameFn = { it.toString() }, scalingScenarios) { s ->
         val network = Network.newNetwork()
         val client = httpClient()
-        val stubs = mutableListOf<GenericContainer<*>>()
-        val agents = mutableListOf<GenericContainer<*>>()
+        val stubs: MutableList<GenericContainer<*>> = []
+        val agents: MutableList<GenericContainer<*>> = []
         val agentMemMib = s.agentMemoryMib()
         val proxy =
           proxyContainer(
             network,
             env = mapOf("METRICS_ENABLED" to "true"),
-            exposedPorts = listOf(PROXY_HTTP_PORT, PROXY_METRICS_PORT),
+            exposedPorts = [PROXY_HTTP_PORT, PROXY_METRICS_PORT],
           ).withMemoryMib(PROXY_MEM_MIB)
         try {
           // --- unique-path agents (dimensions: agents × endpoints, payload size) ---
@@ -111,7 +111,7 @@ class ContainersScalingTest : StringSpec() {
                 network,
                 alias = "scale-cons-agent-$k",
                 configText =
-                  agentConfig("scale-cons-agent-$k", stubAlias, listOf(CONSOLIDATED_PATH to "c"), consolidated = true),
+                  agentConfig("scale-cons-agent-$k", stubAlias, [CONSOLIDATED_PATH to "c"], consolidated = true),
                 waitLogRegex = ".*Registered .* as /$CONSOLIDATED_PATH.*",
               ).withMemoryMib(agentMemMib)
           }
@@ -248,18 +248,18 @@ private fun boolEnv(
  * touches each dimension (baseline, agents × endpoints, payload size, consolidated fan-out).
  */
 private val scaleEnvVars =
-  listOf(
+  [
     "SCALE_AGENTS",
     "SCALE_ENDPOINTS_PER_AGENT",
     "SCALE_SERIES_PER_ENDPOINT",
     "SCALE_CONSOLIDATED_AGENTS",
     "SCALE_CONCURRENT",
     "SCALE_CONCURRENCY_LIMIT",
-  )
+  ]
 
 private val scalingScenarios: List<ScalingScenario> =
   if (scaleEnvVars.any { System.getenv(it) != null })
-    listOf(
+    [
       ScalingScenario(
         agentCount = intEnv("SCALE_AGENTS", 2),
         endpointsPerAgent = intEnv("SCALE_ENDPOINTS_PER_AGENT", 2),
@@ -268,14 +268,14 @@ private val scalingScenarios: List<ScalingScenario> =
         concurrentScrapes = boolEnv("SCALE_CONCURRENT", true),
         concurrencyLimit = intEnv("SCALE_CONCURRENCY_LIMIT", 0),
       ),
-    )
+    ]
   else
-    listOf(
+    [
       ScalingScenario(1, 1, 1, 0, false),
       ScalingScenario(2, 3, 1, 0, true),
       ScalingScenario(2, 2, 2000, 0, false),
       ScalingScenario(2, 1, 1, 3, true),
-    )
+    ]
 
 /** `seriesPerEndpoint` filler series plus a sentinel line whose value is unique per (agent, endpoint). */
 private fun endpointText(

--- a/src/test/kotlin/io/prometheus/containers/ContainersSmokeTest.kt
+++ b/src/test/kotlin/io/prometheus/containers/ContainersSmokeTest.kt
@@ -59,7 +59,7 @@ class ContainersSmokeTest : StringSpec() {
 
       afterSpec {
         httpClient.close()
-        listOf(prometheus, agent, proxy, metricsStub).forEach { container ->
+        [prometheus, agent, proxy, metricsStub].forEach { container ->
           try {
             container.stop()
           } catch (_: Exception) {

--- a/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
+++ b/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
@@ -96,7 +96,7 @@ object ContainerTestSupport {
     network: Network,
     image: ImageFromDockerfile = proxyImage(),
     env: Map<String, String> = emptyMap(),
-    exposedPorts: List<Int> = listOf(PROXY_HTTP_PORT),
+    exposedPorts: List<Int> = [PROXY_HTTP_PORT],
     hostFiles: Map<String, String> = emptyMap(),
     wait: WaitStrategy = Wait.forListeningPort(),
   ): GenericContainer<*> =
@@ -122,7 +122,7 @@ object ContainerTestSupport {
     configResource: String = "containers/agent.conf",
     configText: String? = null,
     env: Map<String, String> = emptyMap(),
-    exposedPorts: List<Int> = emptyList(),
+    exposedPorts: List<Int> = [],
     classpathFiles: Map<String, String> = emptyMap(),
     hostFiles: Map<String, String> = emptyMap(),
     waitLogRegex: String = ".*Registered .* as /.*",

--- a/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
+++ b/src/test/kotlin/io/prometheus/containers/support/ContainerTestSupport.kt
@@ -122,7 +122,7 @@ object ContainerTestSupport {
     configResource: String = "containers/agent.conf",
     configText: String? = null,
     env: Map<String, String> = emptyMap(),
-    exposedPorts: List<Int> = [],
+    exposedPorts: List<Int> = emptyList(),
     classpathFiles: Map<String, String> = emptyMap(),
     hostFiles: Map<String, String> = emptyMap(),
     waitLogRegex: String = ".*Registered .* as /.*",

--- a/src/test/kotlin/io/prometheus/harness/AgentDiscoveryTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/AgentDiscoveryTest.kt
@@ -55,13 +55,13 @@ class AgentDiscoveryTest : StringSpec() {
       val agent =
         TestUtils.startAgent(
           args =
-            listOf(
+            [
               "--proxy",
               "localhost:$AGENT_PORT",
               "-Dagent.discovery.enabled=true",
               "-Dagent.discovery.file.path=${discoveryFile.absolutePath}",
               "-Dagent.discovery.reconcileIntervalSecs=1",
-            ),
+            ],
         )
 
       try {
@@ -98,7 +98,7 @@ class AgentDiscoveryTest : StringSpec() {
       ProxyOptions(
         buildList {
           addAll(CONFIG_ARG)
-          addAll(listOf("--agent_port", agentPort.toString()))
+          addAll(["--agent_port", agentPort.toString()])
           add("-Dproxy.admin.enabled=false")
           add("-Dproxy.metrics.enabled=false")
         },
@@ -111,7 +111,7 @@ class AgentDiscoveryTest : StringSpec() {
     agent: Agent,
   ) {
     coroutineScope {
-      for (service in listOf(proxy, agent)) {
+      for (service in [proxy, agent]) {
         launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
       }
     }

--- a/src/test/kotlin/io/prometheus/harness/AgentPathAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/AgentPathAuthTest.kt
@@ -74,7 +74,7 @@ class AgentPathAuthTest : StringSpec() {
       ProxyOptions(
         buildList {
           addAll(CONFIG_ARG)
-          addAll(listOf("--agent_port", agentPort.toString()))
+          addAll(["--agent_port", agentPort.toString()])
           add("-Dproxy.admin.enabled=false")
           add("-Dproxy.metrics.enabled=false")
         },
@@ -92,8 +92,8 @@ class AgentPathAuthTest : StringSpec() {
         args =
           buildList {
             addAll(CONFIG_ARG)
-            addAll(listOf("--proxy", "localhost:$agentPort"))
-            addAll(listOf("--agent_token", token))
+            addAll(["--proxy", "localhost:$agentPort"])
+            addAll(["--agent_token", token])
             add("-Dagent.admin.enabled=false")
             add("-Dagent.metrics.enabled=false")
           },
@@ -107,7 +107,7 @@ class AgentPathAuthTest : StringSpec() {
     agent: Agent,
   ) {
     coroutineScope {
-      for (service in listOf(proxy, agent)) {
+      for (service in [proxy, agent]) {
         launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
       }
     }
@@ -127,7 +127,7 @@ class AgentPathAuthTest : StringSpec() {
 
     private fun localOrGitHub(path: String): String = if (File(path).exists()) path else "$GH_PREFIX$path"
 
-    private val CONFIG_ARG = listOf("--config", localOrGitHub(AUTH_CONFIG_FILE))
+    private val CONFIG_ARG = ["--config", localOrGitHub(AUTH_CONFIG_FILE)]
 
     // Dedicated ports to avoid clashing with the shared harness ports and the other auth tests.
     private const val HTTP_PORT = 9515

--- a/src/test/kotlin/io/prometheus/harness/AgentTokenAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/AgentTokenAuthTest.kt
@@ -80,8 +80,8 @@ class AgentTokenAuthTest : StringSpec() {
       ProxyOptions(
         buildList {
           addAll(CONFIG_ARG)
-          addAll(listOf("--agent_port", agentPort.toString()))
-          addAll(listOf("--agent_token", token))
+          addAll(["--agent_port", agentPort.toString()])
+          addAll(["--agent_token", token])
           add("-Dproxy.admin.enabled=false")
           add("-Dproxy.metrics.enabled=false")
         },
@@ -99,8 +99,8 @@ class AgentTokenAuthTest : StringSpec() {
         args =
           buildList {
             addAll(CONFIG_ARG)
-            addAll(listOf("--proxy", "localhost:$agentPort"))
-            addAll(listOf("--agent_token", token))
+            addAll(["--proxy", "localhost:$agentPort"])
+            addAll(["--agent_token", token])
             add("-Dagent.admin.enabled=false")
             add("-Dagent.metrics.enabled=false")
           },
@@ -114,7 +114,7 @@ class AgentTokenAuthTest : StringSpec() {
     agent: Agent,
   ) {
     coroutineScope {
-      for (service in listOf(proxy, agent)) {
+      for (service in [proxy, agent]) {
         launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
       }
     }

--- a/src/test/kotlin/io/prometheus/harness/HarnessConstants.kt
+++ b/src/test/kotlin/io/prometheus/harness/HarnessConstants.kt
@@ -52,7 +52,7 @@ object HarnessConstants {
 
   private fun localOrGitHub(path: String): String = if (File(path).exists()) path else "$GH_PREFIX$path"
 
-  val CONFIG_ARG = listOf("--config", localOrGitHub(HARNESS_CONFIG_FILE))
+  val CONFIG_ARG = ["--config", localOrGitHub(HARNESS_CONFIG_FILE)]
 
   val OPTIONS_CONFIG = localOrGitHub(JUNIT_FILE)
 }

--- a/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
@@ -34,11 +34,11 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.common.startAndAwaitReady
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.server.cio.CIO as ServerCIO
 
@@ -65,7 +65,7 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
         }
       val stubPort = stub.startAndAwaitReady()
 
-      val args = [
+      val proxyArgs = [
         "-Dproxy.admin.enabled=false",
         "-Dproxy.metrics.enabled=false",
         // Fail a lost scrape fast so the buggy path doesn't block the whole scrape timeout.
@@ -73,7 +73,7 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
       ]
       val proxy =
         Proxy(
-          options = proxyOptions(CONFIG_ARG + args),
+          options = proxyOptions(CONFIG_ARG + proxyArgs),
           proxyPort = httpPort,
           inProcessServerName = serverName,
           testMode = true,
@@ -81,14 +81,14 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
 
       val client = HttpClient(CIO)
       try {
-        val args = [
+        val agentArgs = [
           "-Dagent.admin.enabled=false",
           "-Dagent.metrics.enabled=false",
           "-Dagent.internal.heartbeatEnabled=false",
         ]
         val agent =
           Agent(
-            options = agentOptions(CONFIG_ARG + args, exitOnMissingConfig = false),
+            options = agentOptions(CONFIG_ARG + agentArgs, exitOnMissingConfig = false),
             inProcessServerName = serverName,
             testMode = true,
           ) { startSync() }

--- a/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
@@ -34,11 +34,11 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.common.startAndAwaitReady
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
-import io.prometheus.proxy.ProxyOptions
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.server.cio.CIO as ServerCIO
 
@@ -65,18 +65,15 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
         }
       val stubPort = stub.startAndAwaitReady()
 
+      val args = [
+        "-Dproxy.admin.enabled=false",
+        "-Dproxy.metrics.enabled=false",
+        // Fail a lost scrape fast so the buggy path doesn't block the whole scrape timeout.
+        "-Dproxy.internal.scrapeRequestTimeoutSecs=5",
+      ]
       val proxy =
         Proxy(
-          options =
-            ProxyOptions(
-              CONFIG_ARG +
-                listOf(
-                  "-Dproxy.admin.enabled=false",
-                  "-Dproxy.metrics.enabled=false",
-                  // Fail a lost scrape fast so the buggy path doesn't block the whole scrape timeout.
-                  "-Dproxy.internal.scrapeRequestTimeoutSecs=5",
-                ),
-            ),
+          options = proxyOptions(CONFIG_ARG + args),
           proxyPort = httpPort,
           inProcessServerName = serverName,
           testMode = true,
@@ -84,18 +81,14 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
 
       val client = HttpClient(CIO)
       try {
+        val args = [
+          "-Dagent.admin.enabled=false",
+          "-Dagent.metrics.enabled=false",
+          "-Dagent.internal.heartbeatEnabled=false",
+        ]
         val agent =
           Agent(
-            options =
-              AgentOptions(
-                CONFIG_ARG +
-                  listOf(
-                    "-Dagent.admin.enabled=false",
-                    "-Dagent.metrics.enabled=false",
-                    "-Dagent.internal.heartbeatEnabled=false",
-                  ),
-                exitOnMissingConfig = false,
-              ),
+            options = agentOptions(CONFIG_ARG + args, exitOnMissingConfig = false),
             inProcessServerName = serverName,
             testMode = true,
           ) { startSync() }

--- a/src/test/kotlin/io/prometheus/harness/InProcessIdleShutdownTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessIdleShutdownTest.kt
@@ -24,10 +24,10 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
-import io.prometheus.proxy.ProxyOptions
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
@@ -49,22 +49,20 @@ class InProcessIdleShutdownTest : StringSpec() {
       val serverName = "idle-shutdown-${System.nanoTime()}"
       val httpPort = 9525
 
+      val args = ["-Dproxy.admin.enabled=false", "-Dproxy.metrics.enabled=false"]
       val proxy =
         Proxy(
-          options = ProxyOptions(CONFIG_ARG + listOf("-Dproxy.admin.enabled=false", "-Dproxy.metrics.enabled=false")),
+          options = proxyOptions(CONFIG_ARG + args),
           proxyPort = httpPort,
           inProcessServerName = serverName,
           testMode = true,
         ) { startSync() }
 
       try {
+        val args = ["-Dagent.admin.enabled=false", "-Dagent.metrics.enabled=false"]
         val agent =
           Agent(
-            options =
-              AgentOptions(
-                CONFIG_ARG + listOf("-Dagent.admin.enabled=false", "-Dagent.metrics.enabled=false"),
-                exitOnMissingConfig = false,
-              ),
+            options = agentOptions(CONFIG_ARG + args, exitOnMissingConfig = false),
             inProcessServerName = serverName,
             testMode = true,
           ) { startSync() }

--- a/src/test/kotlin/io/prometheus/harness/InProcessIdleShutdownTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessIdleShutdownTest.kt
@@ -24,10 +24,10 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
@@ -49,20 +49,20 @@ class InProcessIdleShutdownTest : StringSpec() {
       val serverName = "idle-shutdown-${System.nanoTime()}"
       val httpPort = 9525
 
-      val args = ["-Dproxy.admin.enabled=false", "-Dproxy.metrics.enabled=false"]
+      val proxyArgs = ["-Dproxy.admin.enabled=false", "-Dproxy.metrics.enabled=false"]
       val proxy =
         Proxy(
-          options = proxyOptions(CONFIG_ARG + args),
+          options = proxyOptions(CONFIG_ARG + proxyArgs),
           proxyPort = httpPort,
           inProcessServerName = serverName,
           testMode = true,
         ) { startSync() }
 
       try {
-        val args = ["-Dagent.admin.enabled=false", "-Dagent.metrics.enabled=false"]
+        val agentArgs = ["-Dagent.admin.enabled=false", "-Dagent.metrics.enabled=false"]
         val agent =
           Agent(
-            options = agentOptions(CONFIG_ARG + args, exitOnMissingConfig = false),
+            options = agentOptions(CONFIG_ARG + agentArgs, exitOnMissingConfig = false),
             inProcessServerName = serverName,
             testMode = true,
           ) { startSync() }

--- a/src/test/kotlin/io/prometheus/harness/InProcessReconnectTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessReconnectTest.kt
@@ -51,11 +51,11 @@ class InProcessReconnectTest : StringSpec() {
             scrapeTimeoutSecs = DEFAULT_SCRAPE_TIMEOUT_SECS,
             chunkContentSizeBytes = DEFAULT_CHUNK_SIZE_BYTES,
             maxConcurrentClients = HARNESS_CONFIG.concurrentClients,
-            args = listOf(
+            args = [
               "-Dagent.internal.heartbeatMaxInactivitySecs=1",
               "-Dagent.internal.heartbeatCheckPauseMillis=200",
               "-Dagent.internal.reconnectPauseSecs=1",
-            ),
+            ],
           )
         },
       )

--- a/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsMutualAuthRejectionTest.kt
@@ -51,10 +51,10 @@ class TlsMutualAuthRejectionTest : StringSpec() {
         ProxyOptions(
           buildList {
             addAll(CONFIG_ARG)
-            addAll(listOf("--agent_port", AGENT_PORT.toString()))
-            addAll(listOf("--cert", "testing/certs/server1.pem"))
-            addAll(listOf("--key", "testing/certs/server1.key"))
-            addAll(listOf("--trust", "testing/certs/ca.pem"))
+            addAll(["--agent_port", AGENT_PORT.toString()])
+            addAll(["--cert", "testing/certs/server1.pem"])
+            addAll(["--key", "testing/certs/server1.key"])
+            addAll(["--trust", "testing/certs/ca.pem"])
             add("-Dproxy.admin.enabled=false")
             add("-Dproxy.metrics.enabled=false")
           },
@@ -67,10 +67,10 @@ class TlsMutualAuthRejectionTest : StringSpec() {
           args =
             buildList {
               addAll(CONFIG_ARG)
-              addAll(listOf("--proxy", "localhost:$AGENT_PORT"))
+              addAll(["--proxy", "localhost:$AGENT_PORT"])
               // Trust the proxy's server cert, but present NO client certificate (no --cert/--key).
-              addAll(listOf("--trust", "testing/certs/ca.pem"))
-              addAll(listOf("--override", "foo.test.google.fr"))
+              addAll(["--trust", "testing/certs/ca.pem"])
+              addAll(["--override", "foo.test.google.fr"])
               add("-Dagent.admin.enabled=false")
               add("-Dagent.metrics.enabled=false")
             },
@@ -86,7 +86,7 @@ class TlsMutualAuthRejectionTest : StringSpec() {
         // The test block is itself a suspend function, so suspend via coroutineScope rather than
         // blocking the thread with runBlocking (mirrors the teardown in HarnessTests).
         coroutineScope {
-          for (service in listOf(proxy, agent)) {
+          for (service in [proxy, agent]) {
             launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
           }
         }

--- a/src/test/kotlin/io/prometheus/harness/TlsNoMutualAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsNoMutualAuthTest.kt
@@ -49,14 +49,14 @@ class TlsNoMutualAuthTest :
         proxySetup = {
           startProxy(
             serverName = "nomutualauth",
-            args = listOf(
+            args = [
               "--agent_port",
               "50440",
               "--cert",
               "testing/certs/server1.pem",
               "--key",
               "testing/certs/server1.key",
-            ),
+            ],
           )
         },
         agentSetup = {
@@ -65,14 +65,14 @@ class TlsNoMutualAuthTest :
             scrapeTimeoutSecs = DEFAULT_SCRAPE_TIMEOUT_SECS,
             chunkContentSizeBytes = DEFAULT_CHUNK_SIZE_BYTES,
             maxConcurrentClients = HARNESS_CONFIG.concurrentClients,
-            args = listOf(
+            args = [
               "--proxy",
               "localhost:50440",
               "--trust",
               "testing/certs/ca.pem",
               "--override",
               "foo.test.google.fr",
-            ),
+            ],
           )
         },
       )

--- a/src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/TlsWithMutualAuthTest.kt
@@ -49,7 +49,7 @@ class TlsWithMutualAuthTest :
         proxySetup = {
           startProxy(
             serverName = "withmutualauth",
-            args = listOf(
+            args = [
               "--agent_port",
               "50440",
               "--cert",
@@ -58,7 +58,7 @@ class TlsWithMutualAuthTest :
               "testing/certs/server1.key",
               "--trust",
               "testing/certs/ca.pem",
-            ),
+            ],
           )
         },
         agentSetup = {
@@ -67,7 +67,7 @@ class TlsWithMutualAuthTest :
             scrapeTimeoutSecs = DEFAULT_SCRAPE_TIMEOUT_SECS,
             chunkContentSizeBytes = DEFAULT_CHUNK_SIZE_BYTES,
             maxConcurrentClients = HARNESS_CONFIG.concurrentClients,
-            args = listOf(
+            args = [
               "--proxy",
               "localhost:50440",
               "--cert",
@@ -78,7 +78,7 @@ class TlsWithMutualAuthTest :
               "testing/certs/ca.pem",
               "--override",
               "foo.test.google.fr",
-            ),
+            ],
           )
         },
       )

--- a/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/BasicHarnessTests.kt
@@ -101,7 +101,7 @@ internal object BasicHarnessTests {
     caller: String,
   ) {
     logger.debug { "Calling threadedAddRemovePathsTest() from $caller" }
-    val paths: MutableList<String> = mutableListOf()
+    val paths: MutableList<String> = []
 
     // Take into account pre-existing paths already registered
     val originalSize = pathManager.pathMapSize()

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSetup.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSetup.kt
@@ -60,7 +60,7 @@ open class HarnessSetup {
 
   protected fun takeDownProxyAndAgent() {
     runBlocking {
-      for (service in listOf(proxy, agent)) {
+      for (service in [proxy, agent]) {
         logger.info { "Stopping ${service.simpleClassName}" }
         launch(Dispatchers.IO + exceptionHandler(logger)) { service.stopSync() }
       }

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
@@ -21,10 +21,10 @@ package io.prometheus.harness.support
 import io.github.oshai.kotlinlogging.KLogger
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
 import io.prometheus.harness.HarnessConstants.PROXY_PORT
-import io.prometheus.proxy.ProxyOptions
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -74,22 +74,21 @@ object TestUtils {
     adminEnabled: Boolean = false,
     debugEnabled: Boolean = false,
     metricsEnabled: Boolean = false,
-    args: List<String> = emptyList(),
+    args: List<String> = [],
   ): Proxy {
 //    logger.apply {
 //      info { getBanner("banners/proxy.txt", logger) }
 //      info { getVersionDesc(false) }
 //    }
 
-    val proxyOptions = ProxyOptions(
-      mutableListOf<String>()
-        .apply {
-          addAll(CONFIG_ARG)
-          addAll(args)
-          add("-Dproxy.admin.enabled=$adminEnabled")
-          add("-Dproxy.admin.debugEnabled=$debugEnabled")
-          add("-Dproxy.metrics.enabled=$metricsEnabled")
-        },
+    val proxyOptions = proxyOptions(
+      buildList {
+        addAll(CONFIG_ARG)
+        addAll(args)
+        add("-Dproxy.admin.enabled=$adminEnabled")
+        add("-Dproxy.admin.debugEnabled=$debugEnabled")
+        add("-Dproxy.metrics.enabled=$metricsEnabled")
+      },
     )
     return Proxy(
       options = proxyOptions,
@@ -107,28 +106,27 @@ object TestUtils {
     scrapeTimeoutSecs: Int = -1,
     chunkContentSizeBytes: Int = -1,
     maxConcurrentClients: Int = -1,
-    args: List<String> = emptyList(),
+    args: List<String> = [],
   ): Agent {
 //    logger.apply {
 //      info { getBanner("banners/agent.txt", logger) }
 //      info { getVersionDesc(false) }
 //    }
 
-    val agentOptions = AgentOptions(
-      args = mutableListOf<String>()
-        .apply {
-          addAll(CONFIG_ARG)
-          addAll(args)
-          add("-Dagent.admin.enabled=$adminEnabled")
-          add("-Dagent.admin.debugEnabled=$debugEnabled")
-          add("-Dagent.metrics.enabled=$metricsEnabled")
-          if (scrapeTimeoutSecs != -1)
-            add("-Dagent.scrapeTimeoutSecs=$scrapeTimeoutSecs")
-          if (chunkContentSizeBytes != -1)
-            add("-Dagent.chunkContentSizeBytes=$chunkContentSizeBytes")
-          if (maxConcurrentClients != -1)
-            add("-Dagent.http.maxConcurrentClients=$maxConcurrentClients")
-        },
+    val agentOptions = agentOptions(
+      args = buildList {
+        addAll(CONFIG_ARG)
+        addAll(args)
+        add("-Dagent.admin.enabled=$adminEnabled")
+        add("-Dagent.admin.debugEnabled=$debugEnabled")
+        add("-Dagent.metrics.enabled=$metricsEnabled")
+        if (scrapeTimeoutSecs != -1)
+          add("-Dagent.scrapeTimeoutSecs=$scrapeTimeoutSecs")
+        if (chunkContentSizeBytes != -1)
+          add("-Dagent.chunkContentSizeBytes=$chunkContentSizeBytes")
+        if (maxConcurrentClients != -1)
+          add("-Dagent.http.maxConcurrentClients=$maxConcurrentClients")
+      },
       exitOnMissingConfig = false,
     )
     return Agent(options = agentOptions, inProcessServerName = serverName, testMode = true) { startSync() }

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessSupport.kt
@@ -21,10 +21,10 @@ package io.prometheus.harness.support
 import io.github.oshai.kotlinlogging.KLogger
 import io.prometheus.Agent
 import io.prometheus.Proxy
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.common.agentOptions
 import io.prometheus.harness.HarnessConstants.CONFIG_ARG
 import io.prometheus.harness.HarnessConstants.PROXY_PORT
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -74,7 +74,7 @@ object TestUtils {
     adminEnabled: Boolean = false,
     debugEnabled: Boolean = false,
     metricsEnabled: Boolean = false,
-    args: List<String> = [],
+    args: List<String> = emptyList(),
   ): Proxy {
 //    logger.apply {
 //      info { getBanner("banners/proxy.txt", logger) }
@@ -106,7 +106,7 @@ object TestUtils {
     scrapeTimeoutSecs: Int = -1,
     chunkContentSizeBytes: Int = -1,
     maxConcurrentClients: Int = -1,
-    args: List<String> = [],
+    args: List<String> = emptyList(),
   ): Agent {
 //    logger.apply {
 //      info { getBanner("banners/agent.txt", logger) }

--- a/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminEmptyPathTest.kt
@@ -42,13 +42,13 @@ class AdminEmptyPathTest : StringSpec() {
         proxySetup = {
           startProxy(
             adminEnabled = true,
-            args = listOf(
+            args = [
               "-Dproxy.admin.port=8098",
               "-Dproxy.admin.pingPath=\"\"",
               "-Dproxy.admin.versionPath=\"\"",
               "-Dproxy.admin.healthCheckPath=\"\"",
               "-Dproxy.admin.threadDumpPath=\"\"",
-            ),
+            ],
           )
         },
         agentSetup = { startAgent(adminEnabled = true) },

--- a/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/AdminNonDefaultPathTest.kt
@@ -46,13 +46,13 @@ class AdminNonDefaultPathTest : StringSpec() {
         proxySetup = {
           startProxy(
             adminEnabled = true,
-            args = listOf(
+            args = [
               "-Dproxy.admin.port=8099",
               "-Dproxy.admin.pingPath=pingPath2",
               "-Dproxy.admin.versionPath=versionPath2",
               "-Dproxy.admin.healthCheckPath=healthCheckPath2",
               "-Dproxy.admin.threadDumpPath=threadDumpPath2",
-            ),
+            ],
           )
         },
         agentSetup = { startAgent(adminEnabled = true) },

--- a/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
@@ -30,6 +30,8 @@ import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
 import io.prometheus.harness.HarnessConstants.OPTIONS_CONFIG
 import io.prometheus.proxy.ProxyOptions
+import io.prometheus.agent.AgentOptions.Companion.agentOptions
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 
 class OptionsTest : StringSpec() {
   private fun readProxyOptions(argList: List<String>) = ProxyOptions(argList).configVals
@@ -40,7 +42,7 @@ class OptionsTest : StringSpec() {
     // ==================== Proxy Default Values Tests ====================
 
     "should use default values when no config is provided" {
-      val configVals = readProxyOptions(listOf())
+      val configVals = readProxyOptions([])
       configVals.proxy
         .apply {
           http.port shouldBe PROXY_HTTP_PORT
@@ -49,7 +51,7 @@ class OptionsTest : StringSpec() {
     }
 
     "should override defaults with config file values" {
-      val configVals = readProxyOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readProxyOptions(["--config", OPTIONS_CONFIG])
       configVals.proxy
         .apply {
           http.port shouldBe 8181
@@ -58,7 +60,7 @@ class OptionsTest : StringSpec() {
     }
 
     "should override defaults with unquoted system property values" {
-      val configVals = readProxyOptions(listOf("-Dproxy.http.port=9393", "-Dproxy.internal.zipkin.enabled=true"))
+      val configVals = readProxyOptions(["-Dproxy.http.port=9393", "-Dproxy.internal.zipkin.enabled=true"])
       configVals.proxy
         .apply {
           http.port shouldBe 9393
@@ -67,17 +69,17 @@ class OptionsTest : StringSpec() {
     }
 
     "should override defaults with quoted system property values" {
-      val configVals = readProxyOptions(listOf("-Dproxy.http.port=9394"))
+      val configVals = readProxyOptions(["-Dproxy.http.port=9394"])
       configVals.proxy.http.port shouldBe 9394
     }
 
     "should parse path configs from config file" {
-      val configVals = readAgentOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readAgentOptions(["--config", OPTIONS_CONFIG])
       configVals.agent.pathConfigs.size shouldBe 3
     }
 
     "should have correct proxy default port values" {
-      ProxyOptions(listOf())
+      proxyOptions([])
         .apply {
           proxyPort shouldBe PROXY_HTTP_PORT
           proxyAgentPort shouldBe PROXY_AGENT_PORT
@@ -85,7 +87,7 @@ class OptionsTest : StringSpec() {
     }
 
     "should have correct agent default values" {
-      val options = AgentOptions(listOf("--name", "test-name", "--proxy", "host5"), false)
+      val options = agentOptions(["--name", "test-name", "--proxy", "host5"], false)
       options
         .apply {
           metricsEnabled shouldBe false
@@ -98,7 +100,7 @@ class OptionsTest : StringSpec() {
     // ==================== Complex Agent Path Configuration Tests (2.1.1) ====================
 
     "verifyPathConfigs should parse multiple path entries correctly" {
-      val configVals = readAgentOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readAgentOptions(["--config", OPTIONS_CONFIG])
       val pathConfigs = configVals.agent.pathConfigs
 
       pathConfigs.size shouldBe 3
@@ -108,7 +110,7 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyPathConfigs should have correct properties for each path" {
-      val configVals = readAgentOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readAgentOptions(["--config", OPTIONS_CONFIG])
       val pathConfigs = configVals.agent.pathConfigs
 
       // Verify each path config has all required properties
@@ -120,7 +122,7 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyPathConfigs should differentiate between paths" {
-      val configVals = readAgentOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readAgentOptions(["--config", OPTIONS_CONFIG])
       val pathConfigs = configVals.agent.pathConfigs
 
       // Ensure all paths are unique
@@ -133,7 +135,7 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyAgentHttpClientDefaults should have valid defaults" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.apply {
         // HTTP client settings should have sensible defaults after config loading
         // The defaults come from the built-in configuration, not command line args
@@ -142,24 +144,24 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyAgentChunkSettings should accept custom chunk size" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--chunk", "64"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--chunk", "64"], false)
       // chunkContentSizeBytes is multiplied by 1024 in processing
       options.chunkContentSizeBytes shouldBe 64 * 1024
     }
 
     "verifyAgentGzipSettings should accept custom gzip threshold" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--gzip", "1024"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--gzip", "1024"], false)
       options.minGzipSizeBytes shouldBe 1024
     }
 
     "verifyAgentConsolidated mode can be enabled via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "-o"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "-o"], false)
       options.consolidated.shouldBeTrue()
     }
 
     "verifyAgentScrapeSettings should accept timeout and retries" {
-      val options = AgentOptions(
-        listOf("--name", "test", "--proxy", "host", "--timeout", "30", "--max_retries", "5"),
+      val options = agentOptions(
+        ["--name", "test", "--proxy", "host", "--timeout", "30", "--max_retries", "5"],
         false,
       )
       options.scrapeTimeoutSecs shouldBe 30
@@ -169,18 +171,18 @@ class OptionsTest : StringSpec() {
     // ==================== Proxy Configuration Edge Cases (2.1.2) ====================
 
     "verifyProxyPortOverride should override default port" {
-      val options = ProxyOptions(listOf("-p", "$PROMETHEUS_PORT"))
+      val options = proxyOptions(["-p", "$PROMETHEUS_PORT"])
       options.proxyPort shouldBe PROMETHEUS_PORT
     }
 
     "verifyProxyAgentPortOverride should override default agent port" {
-      val options = ProxyOptions(listOf("-a", "50052"))
+      val options = proxyOptions(["-a", "50052"])
       options.proxyAgentPort shouldBe 50052
     }
 
     "verifyProxyServiceDiscovery should be configurable" {
-      val options = ProxyOptions(
-        listOf("--sd_enabled", "--sd_path", "/sd", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"),
+      val options = proxyOptions(
+        ["--sd_enabled", "--sd_path", "/sd", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"],
       )
       options.sdEnabled.shouldBeTrue()
       options.sdPath shouldBe "/sd"
@@ -188,20 +190,20 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyProxyReflection can be disabled" {
-      val options = ProxyOptions(listOf("--ref_disabled"))
+      val options = proxyOptions(["--ref_disabled"])
       options.reflectionDisabled.shouldBeTrue()
     }
 
     "verifyProxyGrpcSettings should accept custom timeouts" {
-      val options = ProxyOptions(
-        listOf(
+      val options = proxyOptions(
+        [
           "--handshake_timeout_secs",
           "60",
           "--permit_keepalive_time_secs",
           "120",
           "--max_connection_idle_secs",
           "300",
-        ),
+        ],
       )
       options.handshakeTimeoutSecs shouldBe 60L
       options.permitKeepAliveTimeSecs shouldBe 120L
@@ -209,29 +211,29 @@ class OptionsTest : StringSpec() {
     }
 
     "verifyProxyConnectionAge settings should be configurable" {
-      val options = ProxyOptions(listOf("--max_connection_age_secs", "3600", "--max_connection_age_grace_secs", "60"))
+      val options = proxyOptions(["--max_connection_age_secs", "3600", "--max_connection_age_grace_secs", "60"])
       options.maxConnectionAgeSecs shouldBe 3600L
       options.maxConnectionAgeGraceSecs shouldBe 60L
     }
 
     "verifyProxyKeepAlive without calls should be configurable" {
-      val options = ProxyOptions(listOf("--permit_keepalive_without_calls"))
+      val options = proxyOptions(["--permit_keepalive_without_calls"])
       options.permitKeepAliveWithoutCalls.shouldBeTrue()
     }
 
     "verifyProxySystemPropertyOverride should work for port" {
-      val configVals = readProxyOptions(listOf("-Dproxy.http.port=7777"))
+      val configVals = readProxyOptions(["-Dproxy.http.port=7777"])
       configVals.proxy.http.port shouldBe 7777
     }
 
     "verifyProxyConfigFileOverride should take precedence over defaults" {
-      val configVals = readProxyOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readProxyOptions(["--config", OPTIONS_CONFIG])
       // junit-test.conf sets port to 8181
       configVals.proxy.http.port shouldBe 8181
     }
 
     "verifyProxyInternalSettings from config" {
-      val configVals = readProxyOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readProxyOptions(["--config", OPTIONS_CONFIG])
       // zipkin is enabled in junit-test.conf
       configVals.proxy.internal.zipkin.enabled.shouldBeTrue()
     }
@@ -245,7 +247,7 @@ class OptionsTest : StringSpec() {
       val propKey = "proxy.http.port"
       val original = System.getProperty(propKey)
       try {
-        readProxyOptions(listOf("-D$propKey=6161"))
+        readProxyOptions(["-D$propKey=6161"])
 
         // System property should NOT have been set
         System.getProperty(propKey) shouldBe original
@@ -256,24 +258,24 @@ class OptionsTest : StringSpec() {
     }
 
     "dynamic param with quoted value should apply to config correctly" {
-      val configVals = readProxyOptions(listOf("-Dproxy.http.port=\"7272\""))
+      val configVals = readProxyOptions(["-Dproxy.http.port=\"7272\""])
 
       // Quotes are stripped and config reflects the bare value
       configVals.proxy.http.port shouldBe 7272
     }
 
     "dynamic param should apply to config correctly" {
-      val configVals = readProxyOptions(listOf("-Dproxy.http.port=8282"))
+      val configVals = readProxyOptions(["-Dproxy.http.port=8282"])
 
       // Config should reflect the value
       configVals.proxy.http.port shouldBe 8282
     }
 
     "multiple dynamic params should not leak any system properties" {
-      val keys = listOf("proxy.http.port", "proxy.internal.zipkin.enabled")
+      val keys = ["proxy.http.port", "proxy.internal.zipkin.enabled"]
       val originals = keys.associateWith { System.getProperty(it) }
       try {
-        readProxyOptions(listOf("-Dproxy.http.port=5555", "-Dproxy.internal.zipkin.enabled=true"))
+        readProxyOptions(["-Dproxy.http.port=5555", "-Dproxy.internal.zipkin.enabled=true"])
 
         // No system properties should have been set
         keys.forEach { key ->
@@ -290,24 +292,24 @@ class OptionsTest : StringSpec() {
     // ==================== Agent Trust and KeepAlive Tests ====================
 
     "agent trustAllX509Certificates should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--trust_all_x509"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--trust_all_x509"], false)
       options.trustAllX509Certificates.shouldBeTrue()
     }
 
     "agent trustAllX509Certificates should default to false" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.trustAllX509Certificates.shouldBeFalse()
     }
 
     "agent keepAliveWithoutCalls should be settable via command line" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host", "--keepalive_without_calls"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host", "--keepalive_without_calls"], false)
       options.keepAliveWithoutCalls.shouldBeTrue()
     }
 
     // ==================== Agent HTTP Client Cache Default Tests ====================
 
     "agent HTTP client cache settings should have valid defaults" {
-      val options = AgentOptions(listOf("--name", "test", "--proxy", "host"), false)
+      val options = agentOptions(["--name", "test", "--proxy", "host"], false)
       options.maxCacheSize shouldBeGreaterThan 1
       options.maxCacheAgeMins shouldBeGreaterThan 1
       options.maxCacheIdleMins shouldBeGreaterThan 1
@@ -317,7 +319,7 @@ class OptionsTest : StringSpec() {
     // ==================== Agent Internal Config Defaults ====================
 
     "agent internal config should have expected defaults" {
-      val configVals = readAgentOptions(listOf())
+      val configVals = readAgentOptions([])
       configVals.agent.internal.apply {
         cioTimeoutSecs shouldBe 90
         heartbeatEnabled.shouldBeTrue()
@@ -331,14 +333,14 @@ class OptionsTest : StringSpec() {
     // ==================== Config Precedence Tests ====================
 
     "dynamic param should override config file value" {
-      val configVals = readProxyOptions(listOf("--config", OPTIONS_CONFIG, "-Dproxy.http.port=4444"))
+      val configVals = readProxyOptions(["--config", OPTIONS_CONFIG, "-Dproxy.http.port=4444"])
       // Dynamic param (4444) should override junit-test.conf (8181)
       configVals.proxy.http.port shouldBe 4444
     }
 
     "multiple dynamic params should all be applied" {
       val configVals = readProxyOptions(
-        listOf("-Dproxy.http.port=3333", "-Dproxy.internal.zipkin.enabled=true"),
+        ["-Dproxy.http.port=3333", "-Dproxy.internal.zipkin.enabled=true"],
       )
       configVals.proxy.http.port shouldBe 3333
       configVals.proxy.internal.zipkin.enabled.shouldBeTrue()
@@ -347,12 +349,12 @@ class OptionsTest : StringSpec() {
     // ==================== Proxy Request Logging and Path Config Labels ====================
 
     "proxy requestLoggingEnabled should default to true" {
-      val configVals = readProxyOptions(listOf())
+      val configVals = readProxyOptions([])
       configVals.proxy.http.requestLoggingEnabled.shouldBeTrue()
     }
 
     "agent path config labels should default to empty JSON object" {
-      val configVals = readAgentOptions(listOf("--config", OPTIONS_CONFIG))
+      val configVals = readAgentOptions(["--config", OPTIONS_CONFIG])
       val pathConfigs = configVals.agent.pathConfigs
       pathConfigs.forEach { pathConfig ->
         pathConfig.labels.shouldNotBeEmpty()
@@ -361,7 +363,7 @@ class OptionsTest : StringSpec() {
     }
 
     "agent proxy hostname and port should have defaults from config" {
-      val configVals = readAgentOptions(listOf())
+      val configVals = readAgentOptions([])
       configVals.agent.proxy.hostname shouldBe "localhost"
       configVals.agent.proxy.port shouldBe PROXY_AGENT_PORT
     }

--- a/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/misc/OptionsTest.kt
@@ -30,8 +30,8 @@ import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
 import io.prometheus.harness.HarnessConstants.OPTIONS_CONFIG
 import io.prometheus.proxy.ProxyOptions
-import io.prometheus.agent.AgentOptions.Companion.agentOptions
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.agentOptions
+import io.prometheus.common.proxyOptions
 
 class OptionsTest : StringSpec() {
   private fun readProxyOptions(argList: List<String>) = ProxyOptions(argList).configVals
@@ -42,7 +42,7 @@ class OptionsTest : StringSpec() {
     // ==================== Proxy Default Values Tests ====================
 
     "should use default values when no config is provided" {
-      val configVals = readProxyOptions([])
+      val configVals = readProxyOptions(emptyList())
       configVals.proxy
         .apply {
           http.port shouldBe PROXY_HTTP_PORT
@@ -79,7 +79,7 @@ class OptionsTest : StringSpec() {
     }
 
     "should have correct proxy default port values" {
-      proxyOptions([])
+      proxyOptions(emptyList())
         .apply {
           proxyPort shouldBe PROXY_HTTP_PORT
           proxyAgentPort shouldBe PROXY_AGENT_PORT
@@ -319,7 +319,7 @@ class OptionsTest : StringSpec() {
     // ==================== Agent Internal Config Defaults ====================
 
     "agent internal config should have expected defaults" {
-      val configVals = readAgentOptions([])
+      val configVals = readAgentOptions(emptyList())
       configVals.agent.internal.apply {
         cioTimeoutSecs shouldBe 90
         heartbeatEnabled.shouldBeTrue()
@@ -349,7 +349,7 @@ class OptionsTest : StringSpec() {
     // ==================== Proxy Request Logging and Path Config Labels ====================
 
     "proxy requestLoggingEnabled should default to true" {
-      val configVals = readProxyOptions([])
+      val configVals = readProxyOptions(emptyList())
       configVals.proxy.http.requestLoggingEnabled.shouldBeTrue()
     }
 
@@ -363,7 +363,7 @@ class OptionsTest : StringSpec() {
     }
 
     "agent proxy hostname and port should have defaults from config" {
-      val configVals = readAgentOptions([])
+      val configVals = readAgentOptions(emptyList())
       configVals.agent.proxy.hostname shouldBe "localhost"
       configVals.agent.proxy.port shouldBe PROXY_AGENT_PORT
     }

--- a/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
@@ -105,7 +105,7 @@ class AgentAuthManagerTest : StringSpec() {
     }
 
     "the legacy token resolves to an allow-all identity" {
-      val manager = AgentAuthManager.create(authEntries = [], legacyToken = "legacy-secret")
+      val manager = AgentAuthManager.create(authEntries = emptyList(), legacyToken = "legacy-secret")
       val identity = manager.resolveToken("legacy-secret")
       identity?.name shouldBe LEGACY_IDENTITY_NAME
       identity?.isAuthorized("any_path")?.shouldBeTrue()
@@ -126,28 +126,28 @@ class AgentAuthManagerTest : StringSpec() {
     // ---- isEnabled ----
 
     "isEnabled is false when no identities and no legacy token are configured" {
-      AgentAuthManager.create([], "").isEnabled.shouldBeFalse()
+      AgentAuthManager.create(emptyList(), "").isEnabled.shouldBeFalse()
     }
 
     "isEnabled is true when only the legacy token is configured" {
-      AgentAuthManager.create([], "legacy-secret").isEnabled.shouldBeTrue()
+      AgentAuthManager.create(emptyList(), "legacy-secret").isEnabled.shouldBeTrue()
     }
 
     "isEnabled is true when per-agent identities are configured" {
-      AgentAuthManager.create([AuthEntry("team_a", "tok_a", [])], "").isEnabled.shouldBeTrue()
+      AgentAuthManager.create([AuthEntry("team_a", "tok_a", emptyList())], "").isEnabled.shouldBeTrue()
     }
 
     // ---- fail-fast construction ----
 
     "an empty identity name is rejected" {
       shouldThrow<IllegalArgumentException> {
-        AgentAuthManager.create([AuthEntry("", "tok", [])], "")
+        AgentAuthManager.create([AuthEntry("", "tok", emptyList())], "")
       }
     }
 
     "an empty identity token is rejected" {
       shouldThrow<IllegalArgumentException> {
-        AgentAuthManager.create([AuthEntry("team_a", "", [])], "")
+        AgentAuthManager.create([AuthEntry("team_a", "", emptyList())], "")
       }
     }
 
@@ -155,8 +155,8 @@ class AgentAuthManagerTest : StringSpec() {
       shouldThrow<IllegalArgumentException> {
         AgentAuthManager.create(
           [
-            AuthEntry("team_a", "tok_a", []),
-            AuthEntry("team_a", "tok_b", []),
+            AuthEntry("team_a", "tok_a", emptyList()),
+            AuthEntry("team_a", "tok_b", emptyList()),
           ],
           "",
         )
@@ -166,7 +166,7 @@ class AgentAuthManagerTest : StringSpec() {
     "a per-agent identity named like the legacy identity collides with the legacy token" {
       shouldThrow<IllegalArgumentException> {
         AgentAuthManager.create(
-          [AuthEntry(LEGACY_IDENTITY_NAME, "tok", [])],
+          [AuthEntry(LEGACY_IDENTITY_NAME, "tok", emptyList())],
           legacyToken = "legacy-secret",
         )
       }

--- a/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
@@ -84,10 +84,10 @@ class AgentAuthManagerTest : StringSpec() {
       val manager =
         AgentAuthManager.create(
           authEntries =
-            listOf(
-              AuthEntry("team_a", "tok_a", listOf("team_a_*")),
-              AuthEntry("team_b", "tok_b", listOf("team_b_*")),
-            ),
+            [
+              AuthEntry("team_a", "tok_a", ["team_a_*"]),
+              AuthEntry("team_b", "tok_b", ["team_b_*"]),
+            ],
           legacyToken = "",
         )
       manager.resolveToken("tok_a")?.name shouldBe "team_a"
@@ -95,17 +95,17 @@ class AgentAuthManagerTest : StringSpec() {
     }
 
     "resolveToken returns null for an unknown token" {
-      val manager = AgentAuthManager.create(listOf(AuthEntry("team_a", "tok_a", listOf("team_a_*"))), "")
+      val manager = AgentAuthManager.create([AuthEntry("team_a", "tok_a", ["team_a_*"])], "")
       manager.resolveToken("nope").shouldBeNull()
     }
 
     "resolveToken rejects a same-length but different token" {
-      val manager = AgentAuthManager.create(listOf(AuthEntry("team_a", "abcdef", listOf("*"))), "")
+      val manager = AgentAuthManager.create([AuthEntry("team_a", "abcdef", ["*"])], "")
       manager.resolveToken("abcxyz").shouldBeNull()
     }
 
     "the legacy token resolves to an allow-all identity" {
-      val manager = AgentAuthManager.create(authEntries = emptyList(), legacyToken = "legacy-secret")
+      val manager = AgentAuthManager.create(authEntries = [], legacyToken = "legacy-secret")
       val identity = manager.resolveToken("legacy-secret")
       identity?.name shouldBe LEGACY_IDENTITY_NAME
       identity?.isAuthorized("any_path")?.shouldBeTrue()
@@ -114,7 +114,7 @@ class AgentAuthManagerTest : StringSpec() {
     "the legacy token coexists with per-agent identities" {
       val manager =
         AgentAuthManager.create(
-          authEntries = listOf(AuthEntry("team_a", "tok_a", listOf("team_a_*"))),
+          authEntries = [AuthEntry("team_a", "tok_a", ["team_a_*"])],
           legacyToken = "legacy-secret",
         )
       manager.resolveToken("tok_a")?.name shouldBe "team_a"
@@ -126,38 +126,38 @@ class AgentAuthManagerTest : StringSpec() {
     // ---- isEnabled ----
 
     "isEnabled is false when no identities and no legacy token are configured" {
-      AgentAuthManager.create(emptyList(), "").isEnabled.shouldBeFalse()
+      AgentAuthManager.create([], "").isEnabled.shouldBeFalse()
     }
 
     "isEnabled is true when only the legacy token is configured" {
-      AgentAuthManager.create(emptyList(), "legacy-secret").isEnabled.shouldBeTrue()
+      AgentAuthManager.create([], "legacy-secret").isEnabled.shouldBeTrue()
     }
 
     "isEnabled is true when per-agent identities are configured" {
-      AgentAuthManager.create(listOf(AuthEntry("team_a", "tok_a", emptyList())), "").isEnabled.shouldBeTrue()
+      AgentAuthManager.create([AuthEntry("team_a", "tok_a", [])], "").isEnabled.shouldBeTrue()
     }
 
     // ---- fail-fast construction ----
 
     "an empty identity name is rejected" {
       shouldThrow<IllegalArgumentException> {
-        AgentAuthManager.create(listOf(AuthEntry("", "tok", emptyList())), "")
+        AgentAuthManager.create([AuthEntry("", "tok", [])], "")
       }
     }
 
     "an empty identity token is rejected" {
       shouldThrow<IllegalArgumentException> {
-        AgentAuthManager.create(listOf(AuthEntry("team_a", "", emptyList())), "")
+        AgentAuthManager.create([AuthEntry("team_a", "", [])], "")
       }
     }
 
     "duplicate identity names are rejected" {
       shouldThrow<IllegalArgumentException> {
         AgentAuthManager.create(
-          listOf(
-            AuthEntry("team_a", "tok_a", emptyList()),
-            AuthEntry("team_a", "tok_b", emptyList()),
-          ),
+          [
+            AuthEntry("team_a", "tok_a", []),
+            AuthEntry("team_a", "tok_b", []),
+          ],
           "",
         )
       }
@@ -166,7 +166,7 @@ class AgentAuthManagerTest : StringSpec() {
     "a per-agent identity named like the legacy identity collides with the legacy token" {
       shouldThrow<IllegalArgumentException> {
         AgentAuthManager.create(
-          listOf(AuthEntry(LEGACY_IDENTITY_NAME, "tok", emptyList())),
+          [AuthEntry(LEGACY_IDENTITY_NAME, "tok", [])],
           legacyToken = "legacy-secret",
         )
       }

--- a/src/test/kotlin/io/prometheus/proxy/AgentAuthServerInterceptorTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentAuthServerInterceptorTest.kt
@@ -34,7 +34,7 @@ import io.prometheus.proxy.AgentAuthManager.AuthEntry
 class AgentAuthServerInterceptorTest : StringSpec() {
   private val authManager =
     AgentAuthManager.create(
-      authEntries = listOf(AuthEntry("team_a", "s3cret", listOf("team_a_*"))),
+      authEntries = [AuthEntry("team_a", "s3cret", ["team_a_*"])],
       legacyToken = "",
     )
 
@@ -95,7 +95,7 @@ class AgentAuthServerInterceptorTest : StringSpec() {
     "token of the same length but different value should be rejected (constant-time path)" {
       val interceptor =
         AgentAuthServerInterceptor(
-          AgentAuthManager.create(listOf(AuthEntry("team_a", "abcdef", listOf("*"))), ""),
+          AgentAuthManager.create([AuthEntry("team_a", "abcdef", ["*"])], ""),
         )
       val mockCall = mockk<ServerCall<Any, Any>>(relaxed = true)
       val mockHandler = mockk<ServerCallHandler<Any, Any>>(relaxed = true)

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextCleanupServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextCleanupServiceTest.kt
@@ -250,7 +250,7 @@ class AgentContextCleanupServiceTest : StringSpec() {
       // Subsequent calls (during the re-check) return 1s (active).
       val agentContext = mockk<AgentContext>(relaxed = true)
       every { agentContext.agentId } returns "revived-agent"
-      every { agentContext.inactivityDuration } returnsMany listOf(5.seconds, 1.seconds)
+      every { agentContext.inactivityDuration } returnsMany [5.seconds, 1.seconds]
 
       agentContextManager.putAgentContext("revived-agent", agentContext)
 

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -243,7 +243,7 @@ class AgentContextManagerTest : StringSpec() {
 
       val removed = manager.removeChunkedContextsForAgent("agent-A")
 
-      removed.sorted() shouldBe listOf(1L, 2L)
+      removed.sorted() shouldBe [1L, 2L]
       manager.chunkedContextSize shouldBe 1
       manager.getChunkedContext(3L).shouldNotBeNull()
       manager.getChunkedContext(1L).shouldBeNull()
@@ -252,7 +252,7 @@ class AgentContextManagerTest : StringSpec() {
 
     "removeChunkedContextsForAgent should return an empty list for an unknown agent" {
       val manager = AgentContextManager(isTestMode = true)
-      manager.removeChunkedContextsForAgent("nobody") shouldBe emptyList()
+      manager.removeChunkedContextsForAgent("nobody") shouldBe []
     }
 
     // ==================== Non-Zero Backlog Aggregation ====================

--- a/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentContextManagerTest.kt
@@ -252,7 +252,7 @@ class AgentContextManagerTest : StringSpec() {
 
     "removeChunkedContextsForAgent should return an empty list for an unknown agent" {
       val manager = AgentContextManager(isTestMode = true)
-      manager.removeChunkedContextsForAgent("nobody") shouldBe []
+      manager.removeChunkedContextsForAgent("nobody") shouldBe emptyList()
     }
 
     // ==================== Non-Zero Backlog Aggregation ====================

--- a/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
@@ -18,7 +18,7 @@ package io.prometheus.proxy
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 
 class ProxyDynamicConfigTest : StringSpec() {
   init {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyDynamicConfigTest.kt
@@ -18,51 +18,52 @@ package io.prometheus.proxy
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 
 class ProxyDynamicConfigTest : StringSpec() {
   init {
     "proxy.internal.maxZippedContentSizeMBytes should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.maxZippedContentSizeMBytes=12"))
+      val options = proxyOptions(["-Dproxy.internal.maxZippedContentSizeMBytes=12"])
       options.configVals.proxy.internal.maxZippedContentSizeMBytes shouldBe 12
     }
 
     "proxy.internal.maxUnzippedContentSizeMBytes should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=25"))
+      val options = proxyOptions(["-Dproxy.internal.maxUnzippedContentSizeMBytes=25"])
       options.configVals.proxy.internal.maxUnzippedContentSizeMBytes shouldBe 25
     }
 
     "proxy.internal.staleAgentCheckEnabled should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.staleAgentCheckEnabled=false"))
+      val options = proxyOptions(["-Dproxy.internal.staleAgentCheckEnabled=false"])
       options.configVals.proxy.internal.staleAgentCheckEnabled shouldBe false
     }
 
     "proxy.internal.maxAgentInactivitySecs should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.maxAgentInactivitySecs=120"))
+      val options = proxyOptions(["-Dproxy.internal.maxAgentInactivitySecs=120"])
       options.configVals.proxy.internal.maxAgentInactivitySecs shouldBe 120
     }
 
     "proxy.internal.staleAgentCheckPauseSecs should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.staleAgentCheckPauseSecs=20"))
+      val options = proxyOptions(["-Dproxy.internal.staleAgentCheckPauseSecs=20"])
       options.configVals.proxy.internal.staleAgentCheckPauseSecs shouldBe 20
     }
 
     "proxy.internal.scrapeRequestTimeoutSecs should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.scrapeRequestTimeoutSecs=45"))
+      val options = proxyOptions(["-Dproxy.internal.scrapeRequestTimeoutSecs=45"])
       options.configVals.proxy.internal.scrapeRequestTimeoutSecs shouldBe 45
     }
 
     "proxy.internal.scrapeRequestBacklogUnhealthySize should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.scrapeRequestBacklogUnhealthySize=50"))
+      val options = proxyOptions(["-Dproxy.internal.scrapeRequestBacklogUnhealthySize=50"])
       options.configVals.proxy.internal.scrapeRequestBacklogUnhealthySize shouldBe 50
     }
 
     "proxy.internal.scrapeRequestMapUnhealthySize should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.scrapeRequestMapUnhealthySize=60"))
+      val options = proxyOptions(["-Dproxy.internal.scrapeRequestMapUnhealthySize=60"])
       options.configVals.proxy.internal.scrapeRequestMapUnhealthySize shouldBe 60
     }
 
     "proxy.internal.chunkContextMapUnhealthySize should be settable via -D" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.chunkContextMapUnhealthySize=70"))
+      val options = proxyOptions(["-Dproxy.internal.chunkContextMapUnhealthySize=70"])
       options.configVals.proxy.internal.chunkContextMapUnhealthySize shouldBe 70
     }
   }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
@@ -52,7 +52,7 @@ import io.prometheus.Proxy
 import io.prometheus.common.startAndAwaitReady
 import org.slf4j.event.Level
 import io.ktor.server.cio.CIO as ServerCIO
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 
 // Tests for ProxyHttpConfig which configures Ktor server plugins for the proxy HTTP service.
 // Note: Full integration tests with testApplication would require ktor-server-test-host dependency.
@@ -69,7 +69,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
   private fun createTestProxy(): Proxy =
     Proxy(
-      options = proxyOptions([]),
+      options = proxyOptions(emptyList()),
       inProcessServerName = "config-test-${System.nanoTime()}",
       testMode = true,
     )

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
@@ -52,6 +52,7 @@ import io.prometheus.Proxy
 import io.prometheus.common.startAndAwaitReady
 import org.slf4j.event.Level
 import io.ktor.server.cio.CIO as ServerCIO
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 
 // Tests for ProxyHttpConfig which configures Ktor server plugins for the proxy HTTP service.
 // Note: Full integration tests with testApplication would require ktor-server-test-host dependency.
@@ -68,7 +69,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
   private fun createTestProxy(): Proxy =
     Proxy(
-      options = ProxyOptions(listOf()),
+      options = proxyOptions([]),
       inProcessServerName = "config-test-${System.nanoTime()}",
       testMode = true,
     )

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -47,6 +47,7 @@ import io.mockk.spyk
 import io.prometheus.Proxy
 import io.prometheus.common.ScrapeResults
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -61,7 +62,7 @@ import io.ktor.server.cio.CIO as ServerCIO
 // ensureLeadingSlash() to ensure consistent route registration regardless of config format.
 @Suppress("LargeClass")
 class ProxyHttpRoutesTest : StringSpec() {
-  private val testProxies = mutableListOf<Proxy>()
+  private val testProxies: MutableList<Proxy> = []
 
   init {
     afterTest {
@@ -90,15 +91,11 @@ class ProxyHttpRoutesTest : StringSpec() {
 
   private fun createSpyProxyForSubmit(
     timeoutSecs: Int = 1,
-    args: List<String> = emptyList(),
+    args: List<String> = [],
   ): Proxy {
     val proxy = spyk(
       Proxy(
-        options = ProxyOptions(
-          listOf(
-            "-Dproxy.internal.scrapeRequestTimeoutSecs=$timeoutSecs",
-          ) + args,
-        ),
+        options = proxyOptions(["-Dproxy.internal.scrapeRequestTimeoutSecs=$timeoutSecs"] + args),
         inProcessServerName = "proxy-submit-test-${System.nanoTime()}",
         testMode = true,
       ),
@@ -111,9 +108,7 @@ class ProxyHttpRoutesTest : StringSpec() {
   private fun createSpyProxyForRoutes(vararg extraArgs: String): Proxy {
     val proxy = spyk(
       Proxy(
-        options = ProxyOptions(
-          listOf(*extraArgs),
-        ),
+        options = proxyOptions(listOf(*extraArgs)),
         inProcessServerName = "proxy-routes-test-${System.nanoTime()}",
         testMode = true,
       ),
@@ -278,7 +273,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       results.statusCode shouldBe HttpStatusCode.OK
       results.contentType shouldBe ContentType.Text.Plain.withCharset(Charsets.UTF_8)
       results.contentText shouldBe ""
-      results.updateMsgs shouldBe emptyList()
+      results.updateMsgs shouldBe []
     }
 
     "ResponseResults should accept custom values" {
@@ -286,12 +281,12 @@ class ProxyHttpRoutesTest : StringSpec() {
         statusCode = HttpStatusCode.ServiceUnavailable,
         contentType = ContentType.Application.Json.withCharset(Charsets.UTF_8),
         contentText = """{"error":"proxy stopped"}""",
-        updateMsgs = listOf("proxy_stopped"),
+        updateMsgs = ["proxy_stopped"],
       )
 
       results.statusCode shouldBe HttpStatusCode.ServiceUnavailable
       results.contentText shouldBe """{"error":"proxy stopped"}"""
-      results.updateMsgs shouldBe listOf("proxy_stopped")
+      results.updateMsgs shouldBe ["proxy_stopped"]
     }
 
     "ResponseResults copy should produce modified instance" {
@@ -300,12 +295,12 @@ class ProxyHttpRoutesTest : StringSpec() {
       val modified = results.copy(
         statusCode = HttpStatusCode.NotFound,
         contentText = "modified content",
-        updateMsgs = listOf("modified_msg"),
+        updateMsgs = ["modified_msg"],
       )
 
       modified.statusCode shouldBe HttpStatusCode.NotFound
       modified.contentText shouldBe "modified content"
-      modified.updateMsgs shouldBe listOf("modified_msg")
+      modified.updateMsgs shouldBe ["modified_msg"]
     }
 
     // ==================== ClosedSendChannelException Handling Tests ====================
@@ -670,7 +665,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       // Set a very small limit for testing via system property
       val proxy = createSpyProxyForSubmit(
         timeoutSecs = 30,
-        args = listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=0"),
+        args = ["-Dproxy.internal.maxUnzippedContentSizeMBytes=0"],
       )
 
       val agentContext = AgentContext("test-remote")
@@ -977,7 +972,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     // the bodies. This selection was previously only exercised by the Docker-gated consolidated test.
     "mergeResponseResults should prefer OK status and the OK result's contentType" {
       val okContentType = ContentType.Application.Json
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "unavailable",
@@ -992,7 +987,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_a 1.0",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeResponseResults(results)
 
@@ -1003,7 +998,7 @@ class ProxyHttpRoutesTest : StringSpec() {
 
     // No agent returns OK: the merged status is the first distinct status code (statusCodes[0]).
     "mergeResponseResults should return the first status code when no agent returns OK" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "unavailable",
@@ -1014,7 +1009,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           updateMsg = "not_found",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeResponseResults(results)
 
@@ -1024,7 +1019,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     // No agent returns OK: the contentType falls back to the first distinct contentType (contentTypes[0]).
     "mergeResponseResults should fall back to the first contentType when no agent returns OK" {
       val firstContentType = ContentType.Application.Json
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "unavailable",
@@ -1037,7 +1032,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8),
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeResponseResults(results)
 
@@ -1052,7 +1047,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     // strips intermediate "# EOF" markers and appends a single one at the end.
 
     "Bug #13: mergeContentTexts should strip intermediate EOF markers" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1065,7 +1060,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n# EOF",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1079,7 +1074,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #13: mergeContentTexts should not add EOF when no results have it" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1092,7 +1087,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1102,14 +1097,14 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #13: mergeContentTexts should return single result unchanged" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
           contentText = "metric_a 1.0\n# EOF",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1118,7 +1113,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #13: mergeContentTexts should handle three agents with EOF" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1137,7 +1132,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_c 3.0\n# EOF",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1156,7 +1151,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     // results with empty contentText before merging.
 
     "Bug #4: mergeContentTexts should exclude empty content from failed agents" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1169,7 +1164,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1178,7 +1173,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #4: mergeContentTexts should handle multiple failed agents with one success" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "timed_out",
@@ -1197,7 +1192,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1205,7 +1200,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #4: mergeContentTexts should return empty string when all agents fail" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
           updateMsg = "timed_out",
@@ -1218,7 +1213,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1229,7 +1224,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       // Without the fix, the empty string from the failed agent would be joined in,
       // producing three consecutive newlines between the two metrics.
       // With the fix, the empty result is filtered out first.
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1248,7 +1243,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_c 3.0\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1261,7 +1256,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #4: mergeContentTexts should handle failed agents with EOF results" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1280,7 +1275,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_c 3.0\n# EOF",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1292,7 +1287,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #13: mergeContentTexts should handle mixed EOF and non-EOF results" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1305,7 +1300,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1327,7 +1322,7 @@ class ProxyHttpRoutesTest : StringSpec() {
 
     "Bug #14: mergeContentTexts should not produce double newlines with trailing whitespace" {
       // Agent1 has EOF with trailing newline; Agent2 has trailing newline but no EOF
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1340,7 +1335,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1353,7 +1348,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     }
 
     "Bug #14: mergeContentTexts should trim trailing whitespace from non-EOF results" {
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1366,7 +1361,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1377,7 +1372,7 @@ class ProxyHttpRoutesTest : StringSpec() {
 
     "Bug #14: mergeContentTexts should handle mixed trailing whitespace with EOF" {
       // Three agents: two with trailing newlines + EOF, one without EOF but with trailing whitespace
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1396,7 +1391,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_c 3.0\n# EOF\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 
@@ -1411,7 +1406,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     "Bug #14: mergeContentTexts should produce clean output with no trailing whitespace per entry" {
       // Verify that each entry's trailing whitespace is stripped before joining,
       // regardless of whether the entry has EOF
-      val results = listOf(
+      val results = [
         ScrapeRequestResponse(
           statusCode = HttpStatusCode.OK,
           updateMsg = "success",
@@ -1424,7 +1419,7 @@ class ProxyHttpRoutesTest : StringSpec() {
           contentText = "metric_b 2.0\n\n\n",
           fetchDuration = 10.milliseconds,
         ),
-      )
+      ]
 
       val merged = ProxyHttpRoutes.mergeContentTexts(results)
 

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -47,7 +47,7 @@ import io.mockk.spyk
 import io.prometheus.Proxy
 import io.prometheus.common.ScrapeResults
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -91,7 +91,7 @@ class ProxyHttpRoutesTest : StringSpec() {
 
   private fun createSpyProxyForSubmit(
     timeoutSecs: Int = 1,
-    args: List<String> = [],
+    args: List<String> = emptyList(),
   ): Proxy {
     val proxy = spyk(
       Proxy(
@@ -108,7 +108,7 @@ class ProxyHttpRoutesTest : StringSpec() {
   private fun createSpyProxyForRoutes(vararg extraArgs: String): Proxy {
     val proxy = spyk(
       Proxy(
-        options = proxyOptions(listOf(*extraArgs)),
+        options = proxyOptions(extraArgs.asList()),
         inProcessServerName = "proxy-routes-test-${System.nanoTime()}",
         testMode = true,
       ),
@@ -273,7 +273,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       results.statusCode shouldBe HttpStatusCode.OK
       results.contentType shouldBe ContentType.Text.Plain.withCharset(Charsets.UTF_8)
       results.contentText shouldBe ""
-      results.updateMsgs shouldBe []
+      results.updateMsgs shouldBe emptyList()
     }
 
     "ResponseResults should accept custom values" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -27,71 +27,72 @@ import io.kotest.matchers.string.shouldContain
 import io.prometheus.common.TestPorts.PROMETHEUS_PORT
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
+import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
 
 class ProxyOptionsTest : StringSpec() {
   init {
     // ==================== Default Values ====================
 
     "default proxyPort should be $PROXY_HTTP_PORT" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.proxyPort shouldBe PROXY_HTTP_PORT
     }
 
     "default proxyAgentPort should be $PROXY_AGENT_PORT" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.proxyAgentPort shouldBe PROXY_AGENT_PORT
     }
 
     "sdEnabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.sdEnabled.shouldBeFalse()
     }
 
     "reflectionDisabled should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.reflectionDisabled.shouldBeFalse()
     }
 
     "handshakeTimeoutSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.handshakeTimeoutSecs shouldBe -1L
     }
 
     "permitKeepAliveWithoutCalls should default to false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.permitKeepAliveWithoutCalls.shouldBeFalse()
     }
 
     "maxConnectionIdleSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.maxConnectionIdleSecs shouldBe -1L
     }
 
     "maxConnectionAgeSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.maxConnectionAgeSecs shouldBe -1L
     }
 
     "maxConnectionAgeGraceSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.maxConnectionAgeGraceSecs shouldBe -1L
     }
 
     // ==================== Command-Line Override Tests ====================
 
     "proxyPort should be settable via -p flag" {
-      val options = ProxyOptions(listOf("-p", "$PROMETHEUS_PORT"))
+      val options = proxyOptions(["-p", "$PROMETHEUS_PORT"])
       options.proxyPort shouldBe PROMETHEUS_PORT
     }
 
     "proxyAgentPort should be settable via -a flag" {
-      val options = ProxyOptions(listOf("-a", "50052"))
+      val options = proxyOptions(["-a", "50052"])
       options.proxyAgentPort shouldBe 50052
     }
 
     "sdEnabled should be settable via command line" {
-      val options = ProxyOptions(
-        listOf("--sd_enabled", "--sd_path", "/sd", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"),
+      val options = proxyOptions(
+        ["--sd_enabled", "--sd_path", "/sd", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"],
       )
       options.sdEnabled.shouldBeTrue()
       options.sdPath shouldBe "/sd"
@@ -99,52 +100,52 @@ class ProxyOptionsTest : StringSpec() {
     }
 
     "reflectionDisabled should be settable via --ref_disabled" {
-      val options = ProxyOptions(listOf("--ref_disabled"))
+      val options = proxyOptions(["--ref_disabled"])
       options.reflectionDisabled.shouldBeTrue()
     }
 
     "reflectionDisabled should accept hyphenated variant --ref-disabled" {
-      val options = ProxyOptions(listOf("--ref-disabled"))
+      val options = proxyOptions(["--ref-disabled"])
       options.reflectionDisabled.shouldBeTrue()
     }
 
     // ==================== gRPC Configuration Tests ====================
 
     "handshakeTimeoutSecs should be settable" {
-      val options = ProxyOptions(listOf("--handshake_timeout_secs", "60"))
+      val options = proxyOptions(["--handshake_timeout_secs", "60"])
       options.handshakeTimeoutSecs shouldBe 60L
     }
 
     "permitKeepAliveTimeSecs should be settable" {
-      val options = ProxyOptions(listOf("--permit_keepalive_time_secs", "120"))
+      val options = proxyOptions(["--permit_keepalive_time_secs", "120"])
       options.permitKeepAliveTimeSecs shouldBe 120L
     }
 
     "maxConnectionIdleSecs should be settable" {
-      val options = ProxyOptions(listOf("--max_connection_idle_secs", "300"))
+      val options = proxyOptions(["--max_connection_idle_secs", "300"])
       options.maxConnectionIdleSecs shouldBe 300L
     }
 
     "maxConnectionAgeSecs should be settable" {
-      val options = ProxyOptions(listOf("--max_connection_age_secs", "3600"))
+      val options = proxyOptions(["--max_connection_age_secs", "3600"])
       options.maxConnectionAgeSecs shouldBe 3600L
     }
 
     "maxConnectionAgeGraceSecs should be settable" {
-      val options = ProxyOptions(listOf("--max_connection_age_grace_secs", "60"))
+      val options = proxyOptions(["--max_connection_age_grace_secs", "60"])
       options.maxConnectionAgeGraceSecs shouldBe 60L
     }
 
     "permitKeepAliveWithoutCalls should be settable" {
-      val options = ProxyOptions(listOf("--permit_keepalive_without_calls"))
+      val options = proxyOptions(["--permit_keepalive_without_calls"])
       options.permitKeepAliveWithoutCalls.shouldBeTrue()
     }
 
     // ==================== Combined Settings Tests ====================
 
     "multiple gRPC settings should be settable together" {
-      val options = ProxyOptions(
-        listOf(
+      val options = proxyOptions(
+        [
           "--handshake_timeout_secs",
           "30",
           "--permit_keepalive_time_secs",
@@ -156,7 +157,7 @@ class ProxyOptionsTest : StringSpec() {
           "--max_connection_age_grace_secs",
           "30",
           "--permit_keepalive_without_calls",
-        ),
+        ],
       )
       options.handshakeTimeoutSecs shouldBe 30L
       options.permitKeepAliveTimeSecs shouldBe 60L
@@ -171,65 +172,65 @@ class ProxyOptionsTest : StringSpec() {
     // instead of surfacing opaque Ktor/gRPC builder exceptions later at server startup.
 
     "proxyPort of 0 should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--port", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--port", "0"]) }
       exception.message shouldContain "proxyPort"
     }
 
     "proxyPort above 65535 should be rejected" {
-      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--port", "70000")) }
+      shouldThrow<IllegalArgumentException> { proxyOptions(["--port", "70000"]) }
     }
 
     // adminPort/metricsPort were previously unvalidated, unlike proxyPort/proxyAgentPort, so an
     // out-of-range value surfaced only as an opaque bind failure. Validate them consistently.
     "adminPort of 0 should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--admin_port", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--admin_port", "0"]) }
       exception.message shouldContain "adminPort"
     }
 
     "adminPort above 65535 should be rejected" {
-      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--admin_port", "70000")) }
+      shouldThrow<IllegalArgumentException> { proxyOptions(["--admin_port", "70000"]) }
     }
 
     "metricsPort of 0 should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--metrics_port", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--metrics_port", "0"]) }
       exception.message shouldContain "metricsPort"
     }
 
     "metricsPort above 65535 should be rejected" {
-      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--metrics_port", "70000")) }
+      shouldThrow<IllegalArgumentException> { proxyOptions(["--metrics_port", "70000"]) }
     }
 
     "proxyAgentPort of 0 should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--agent_port", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--agent_port", "0"]) }
       exception.message shouldContain "proxyAgentPort"
     }
 
     "a zero gRPC handshake timeout should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--handshake_timeout_secs", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--handshake_timeout_secs", "0"]) }
       exception.message shouldContain "handshakeTimeoutSecs"
     }
 
     "a zero gRPC max-connection-idle timeout should be rejected" {
-      shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--max_connection_idle_secs", "0")) }
+      shouldThrow<IllegalArgumentException> { proxyOptions(["--max_connection_idle_secs", "0"]) }
     }
 
     "the -1 sentinel should be accepted for gRPC timeouts" {
-      val options = ProxyOptions(listOf("--handshake_timeout_secs", "-1"))
+      val options = proxyOptions(["--handshake_timeout_secs", "-1"])
       options.handshakeTimeoutSecs shouldBe -1L
     }
 
     "a zero gRPC keepalive time should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--keepalive_time_secs", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--keepalive_time_secs", "0"]) }
       exception.message shouldContain "keepAliveTimeSecs"
     }
 
     "a zero gRPC keepalive timeout should be rejected" {
-      val exception = shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("--keepalive_timeout_secs", "0")) }
+      val exception = shouldThrow<IllegalArgumentException> { proxyOptions(["--keepalive_timeout_secs", "0"]) }
       exception.message shouldContain "keepAliveTimeoutSecs"
     }
 
     "the -1 sentinel should be accepted for gRPC keepalive timeouts" {
-      val options = ProxyOptions(listOf("--keepalive_time_secs", "-1", "--keepalive_timeout_secs", "-1"))
+      val options = proxyOptions(["--keepalive_time_secs", "-1", "--keepalive_timeout_secs", "-1"])
       options.keepAliveTimeSecs shouldBe -1L
       options.keepAliveTimeoutSecs shouldBe -1L
     }
@@ -240,13 +241,13 @@ class ProxyOptionsTest : StringSpec() {
 
     "a non-positive staleAgentCheckPauseSecs should be rejected" {
       val exception =
-        shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("-Dproxy.internal.staleAgentCheckPauseSecs=0")) }
+        shouldThrow<IllegalArgumentException> { proxyOptions(["-Dproxy.internal.staleAgentCheckPauseSecs=0"]) }
       exception.message shouldContain "staleAgentCheckPauseSecs"
     }
 
     "a non-positive maxAgentInactivitySecs should be rejected" {
       val exception =
-        shouldThrow<IllegalArgumentException> { ProxyOptions(listOf("-Dproxy.internal.maxAgentInactivitySecs=0")) }
+        shouldThrow<IllegalArgumentException> { proxyOptions(["-Dproxy.internal.maxAgentInactivitySecs=0"]) }
       exception.message shouldContain "maxAgentInactivitySecs"
     }
 
@@ -254,13 +255,13 @@ class ProxyOptionsTest : StringSpec() {
     "a negative maxUnzippedContentSizeMBytes should be rejected" {
       val exception =
         shouldThrow<IllegalArgumentException> {
-          ProxyOptions(listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=-1"))
+          proxyOptions(["-Dproxy.internal.maxUnzippedContentSizeMBytes=-1"])
         }
       exception.message shouldContain "maxUnzippedContentSizeMBytes"
     }
 
     "a zero maxUnzippedContentSizeMBytes should be accepted (reject-all limit)" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.maxUnzippedContentSizeMBytes=0"))
+      val options = proxyOptions(["-Dproxy.internal.maxUnzippedContentSizeMBytes=0"])
       options.configVals.proxy.internal.maxUnzippedContentSizeMBytes shouldBe 0
     }
 
@@ -270,50 +271,50 @@ class ProxyOptionsTest : StringSpec() {
     "Finding 11: a negative maxZippedContentSizeMBytes should be rejected" {
       val exception =
         shouldThrow<IllegalArgumentException> {
-          ProxyOptions(listOf("-Dproxy.internal.maxZippedContentSizeMBytes=-1"))
+          proxyOptions(["-Dproxy.internal.maxZippedContentSizeMBytes=-1"])
         }
       exception.message shouldContain "maxZippedContentSizeMBytes"
     }
 
     "Finding 11: a zero maxZippedContentSizeMBytes should be accepted (reject-all limit)" {
-      val options = ProxyOptions(listOf("-Dproxy.internal.maxZippedContentSizeMBytes=0"))
+      val options = proxyOptions(["-Dproxy.internal.maxZippedContentSizeMBytes=0"])
       options.configVals.proxy.internal.maxZippedContentSizeMBytes shouldBe 0
     }
 
     // ==================== Constructor Variants Tests ====================
 
     "list constructor should work" {
-      val options = ProxyOptions(listOf("-p", "7070"))
+      val options = proxyOptions(["-p", "7070"])
       options.proxyPort shouldBe 7070
     }
 
     "configVals should be populated after construction" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.configVals.proxy.http.port shouldBe PROXY_HTTP_PORT
     }
 
     // ==================== KeepAlive Defaults Tests ====================
 
     "keepAliveTimeSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.keepAliveTimeSecs shouldBe -1L
     }
 
     "keepAliveTimeoutSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.keepAliveTimeoutSecs shouldBe -1L
     }
 
     "permitKeepAliveTimeSecs should default to -1" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.permitKeepAliveTimeSecs shouldBe -1L
     }
 
     // ==================== Bug #8: SD config values should be set when SD enabled ====================
 
     "sdPath and sdTargetPrefix should be accessible when sdEnabled is true" {
-      val options = ProxyOptions(
-        listOf("--sd_enabled", "--sd_path", "/discovery", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"),
+      val options = proxyOptions(
+        ["--sd_enabled", "--sd_path", "/discovery", "--sd_target_prefix", "http://proxy:$PROXY_HTTP_PORT"],
       )
       options.sdEnabled.shouldBeTrue()
       options.sdPath shouldBe "/discovery"
@@ -321,7 +322,7 @@ class ProxyOptionsTest : StringSpec() {
     }
 
     "sdPath and sdTargetPrefix should be set when sdEnabled is false" {
-      val options = ProxyOptions(listOf())
+      val options = proxyOptions([])
       options.sdEnabled.shouldBeFalse()
       // Values should still be assigned from config defaults (even when SD disabled)
       // Bug #8 fix ensures these values are logged regardless of sdEnabled state

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -27,54 +27,54 @@ import io.kotest.matchers.string.shouldContain
 import io.prometheus.common.TestPorts.PROMETHEUS_PORT
 import io.prometheus.common.TestPorts.PROXY_AGENT_PORT
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
-import io.prometheus.proxy.ProxyOptions.Companion.proxyOptions
+import io.prometheus.common.proxyOptions
 
 class ProxyOptionsTest : StringSpec() {
   init {
     // ==================== Default Values ====================
 
     "default proxyPort should be $PROXY_HTTP_PORT" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.proxyPort shouldBe PROXY_HTTP_PORT
     }
 
     "default proxyAgentPort should be $PROXY_AGENT_PORT" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.proxyAgentPort shouldBe PROXY_AGENT_PORT
     }
 
     "sdEnabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.sdEnabled.shouldBeFalse()
     }
 
     "reflectionDisabled should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.reflectionDisabled.shouldBeFalse()
     }
 
     "handshakeTimeoutSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.handshakeTimeoutSecs shouldBe -1L
     }
 
     "permitKeepAliveWithoutCalls should default to false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.permitKeepAliveWithoutCalls.shouldBeFalse()
     }
 
     "maxConnectionIdleSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.maxConnectionIdleSecs shouldBe -1L
     }
 
     "maxConnectionAgeSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.maxConnectionAgeSecs shouldBe -1L
     }
 
     "maxConnectionAgeGraceSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.maxConnectionAgeGraceSecs shouldBe -1L
     }
 
@@ -289,24 +289,24 @@ class ProxyOptionsTest : StringSpec() {
     }
 
     "configVals should be populated after construction" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.configVals.proxy.http.port shouldBe PROXY_HTTP_PORT
     }
 
     // ==================== KeepAlive Defaults Tests ====================
 
     "keepAliveTimeSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.keepAliveTimeSecs shouldBe -1L
     }
 
     "keepAliveTimeoutSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.keepAliveTimeoutSecs shouldBe -1L
     }
 
     "permitKeepAliveTimeSecs should default to -1" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.permitKeepAliveTimeSecs shouldBe -1L
     }
 
@@ -322,7 +322,7 @@ class ProxyOptionsTest : StringSpec() {
     }
 
     "sdPath and sdTargetPrefix should be set when sdEnabled is false" {
-      val options = proxyOptions([])
+      val options = proxyOptions(emptyList())
       options.sdEnabled.shouldBeFalse()
       // Values should still be assigned from config defaults (even when SD disabled)
       // Bug #8 fix ensures these values are logged regardless of sdEnabled state

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
@@ -40,6 +40,7 @@ import io.prometheus.Proxy
 import io.prometheus.common.ConfigVals
 import io.prometheus.common.DefaultObjects.EMPTY_INSTANCE
 import io.prometheus.grpc.ChunkedScrapeResponse
+import io.prometheus.grpc.ScrapeRequest
 import io.prometheus.grpc.ScrapeResponse
 import io.prometheus.grpc.agentInfo
 import io.prometheus.grpc.chunkData
@@ -320,7 +321,7 @@ class ProxyServiceImplTest : StringSpec() {
       every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
       every { pathManager.pathMapSize } returns 0
 
-      val identity = AgentIdentity("team_a", ByteArray(0), listOf(AgentAuthManager.globToRegex("team_a_*")))
+      val identity = AgentIdentity("team_a", ByteArray(0), [AgentAuthManager.globToRegex("team_a_*")])
       val request = registerPathRequest {
         agentId = testAgentId
         path = deniedPath
@@ -356,7 +357,7 @@ class ProxyServiceImplTest : StringSpec() {
       every { proxy.pathManager.addPath(allowedPath, any(), mockAgentContext) } returns null
       every { proxy.pathManager.pathMapSize } returns 1
 
-      val identity = AgentIdentity("team_a", ByteArray(0), listOf(AgentAuthManager.globToRegex("team_a_*")))
+      val identity = AgentIdentity("team_a", ByteArray(0), [AgentAuthManager.globToRegex("team_a_*")])
       val request = registerPathRequest {
         agentId = testAgentId
         path = allowedPath
@@ -521,7 +522,7 @@ class ProxyServiceImplTest : StringSpec() {
       val testAgentId = "test-agent-123"
 
       every { mockAgentContext.agentId } returns testAgentId
-      every { mockAgentContext.isValid() } returnsMany listOf(true, false)
+      every { mockAgentContext.isValid() } returnsMany [true, false]
       coEvery { mockAgentContext.readScrapeRequest() } returns mockScrapeRequestWrapper andThen null
       every { mockScrapeRequestWrapper.scrapeRequest } returns mockScrapeRequest
       every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
@@ -533,7 +534,7 @@ class ProxyServiceImplTest : StringSpec() {
       val service = ProxyServiceImpl(proxy)
       val flow = service.readRequestsFromProxy(request)
 
-      val emittedRequests = mutableListOf<io.prometheus.grpc.ScrapeRequest>()
+      val emittedRequests: MutableList<ScrapeRequest> = []
       flow.collect { emittedRequests.add(it) }
 
       emittedRequests.size shouldBe 1
@@ -748,7 +749,7 @@ class ProxyServiceImplTest : StringSpec() {
       every { mockAgentContext.agentId } returns testAgentId
       every { mockAgentContext.isValid() } returns true
       // Simulate proxy stopping after first check
-      every { proxy.isRunning } returnsMany listOf(true, false)
+      every { proxy.isRunning } returnsMany [true, false]
       coEvery { mockAgentContext.readScrapeRequest() } returns null
       every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
 
@@ -756,7 +757,7 @@ class ProxyServiceImplTest : StringSpec() {
       val service = ProxyServiceImpl(proxy)
       val flow = service.readRequestsFromProxy(request)
 
-      val emittedRequests = mutableListOf<io.prometheus.grpc.ScrapeRequest>()
+      val emittedRequests: MutableList<ScrapeRequest> = []
       flow.collect { emittedRequests.add(it) }
 
       emittedRequests.size shouldBe 0
@@ -769,7 +770,7 @@ class ProxyServiceImplTest : StringSpec() {
 
       every { mockAgentContext.agentId } returns testAgentId
       // Valid for two iterations then invalid
-      every { mockAgentContext.isValid() } returnsMany listOf(true, true, false)
+      every { mockAgentContext.isValid() } returnsMany [true, true, false]
       // Return null both times (channel drained)
       coEvery { mockAgentContext.readScrapeRequest() } returns null
       every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
@@ -778,7 +779,7 @@ class ProxyServiceImplTest : StringSpec() {
       val service = ProxyServiceImpl(proxy)
       val flow = service.readRequestsFromProxy(request)
 
-      val emittedRequests = mutableListOf<io.prometheus.grpc.ScrapeRequest>()
+      val emittedRequests: MutableList<ScrapeRequest> = []
       flow.collect { emittedRequests.add(it) }
 
       // readScrapeRequest returned null, so nothing emitted
@@ -834,7 +835,7 @@ class ProxyServiceImplTest : StringSpec() {
 
       every { mockAgentContext.agentId } returns testAgentId
       // Valid for one iteration, then stream will be cancelled by the test
-      every { mockAgentContext.isValid() } returnsMany listOf(true, false)
+      every { mockAgentContext.isValid() } returnsMany [true, false]
       coEvery { mockAgentContext.readScrapeRequest() } returns mockScrapeRequestWrapper andThen null
       every { mockScrapeRequestWrapper.scrapeRequest } returns mockScrapeRequest
       every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
@@ -1318,7 +1319,7 @@ class ProxyServiceImplTest : StringSpec() {
       // Invalidate the agent context immediately so the loop exits
       agentContext.invalidate()
 
-      val results = mutableListOf<io.prometheus.grpc.ScrapeRequest>()
+      val results: MutableList<ScrapeRequest> = []
       service.readRequestsFromProxy(request).collect { results.add(it) }
 
       // Verify cleanup was called because transportFilterDisabled is true
@@ -1340,7 +1341,7 @@ class ProxyServiceImplTest : StringSpec() {
       // Invalidate the agent context immediately so the loop exits
       agentContext.invalidate()
 
-      val results = mutableListOf<io.prometheus.grpc.ScrapeRequest>()
+      val results: MutableList<ScrapeRequest> = []
       service.readRequestsFromProxy(request).collect { results.add(it) }
 
       // Verify cleanup was NOT called because transportFilterDisabled is false

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -38,7 +38,7 @@ import kotlinx.serialization.json.jsonPrimitive
 class ProxyTest : StringSpec() {
   private fun createTestProxy(vararg extraArgs: String) =
     Proxy(
-      options = ProxyOptions(buildList { addAll(extraArgs) }),
+      options = ProxyOptions(extraArgs.asList()),
       inProcessServerName = "proxy-test-${System.nanoTime()}",
       testMode = true,
     )

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -36,14 +36,12 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class ProxyTest : StringSpec() {
-  private fun createTestProxy(vararg extraArgs: String): Proxy {
-    val args = mutableListOf<String>().apply { addAll(extraArgs) }
-    return Proxy(
-      options = ProxyOptions(args),
+  private fun createTestProxy(vararg extraArgs: String) =
+    Proxy(
+      options = ProxyOptions(buildList { addAll(extraArgs) }),
       inProcessServerName = "proxy-test-${System.nanoTime()}",
       testMode = true,
     )
-  }
 
   private fun createAgentContext(
     name: String = "test-agent",

--- a/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
@@ -48,7 +48,7 @@ class ProxyUtilsTest : StringSpec() {
       val result = ProxyUtils.invalidAgentContextResponse("test-path", mockProxy)
 
       result.statusCode shouldBe HttpStatusCode.NotFound
-      result.updateMsgs shouldBe listOf("invalid_agent_context")
+      result.updateMsgs shouldBe ["invalid_agent_context"]
       verify { mockProxy.logActivity("Invalid AgentContext for /test-path") }
     }
 
@@ -58,7 +58,7 @@ class ProxyUtilsTest : StringSpec() {
       val result = ProxyUtils.invalidPathResponse("invalid-path", mockProxy)
 
       result.statusCode shouldBe HttpStatusCode.NotFound
-      result.updateMsgs shouldBe listOf("invalid_path")
+      result.updateMsgs shouldBe ["invalid_path"]
       verify { mockProxy.logActivity("Invalid path request /invalid-path") }
     }
 
@@ -68,7 +68,7 @@ class ProxyUtilsTest : StringSpec() {
       val result = ProxyUtils.emptyPathResponse(mockProxy)
 
       result.statusCode shouldBe HttpStatusCode.NotFound
-      result.updateMsgs shouldBe listOf("missing_path")
+      result.updateMsgs shouldBe ["missing_path"]
       verify { mockProxy.logActivity(any()) }
     }
 
@@ -76,7 +76,7 @@ class ProxyUtilsTest : StringSpec() {
       val result = ProxyUtils.proxyNotRunningResponse()
 
       result.statusCode shouldBe HttpStatusCode.ServiceUnavailable
-      result.updateMsgs shouldBe listOf("proxy_stopped")
+      result.updateMsgs shouldBe ["proxy_stopped"]
     }
 
     "incrementScrapeRequestCount should call metrics for non-empty type" {
@@ -137,10 +137,10 @@ class ProxyUtilsTest : StringSpec() {
       val result4 = ProxyUtils.proxyNotRunningResponse()
 
       // Each call returns its own independent instance
-      result1.updateMsgs shouldBe listOf("invalid_path")
-      result2.updateMsgs shouldBe listOf("invalid_agent_context")
-      result3.updateMsgs shouldBe listOf("missing_path")
-      result4.updateMsgs shouldBe listOf("proxy_stopped")
+      result1.updateMsgs shouldBe ["invalid_path"]
+      result2.updateMsgs shouldBe ["invalid_agent_context"]
+      result3.updateMsgs shouldBe ["missing_path"]
+      result4.updateMsgs shouldBe ["proxy_stopped"]
 
       // Copying one result does not affect others
       val modified = result1.copy(contentText = "modified")


### PR DESCRIPTION
## Summary

Extends the Kotlin experimental collection-literals migration (PR #203, which covered `src/main`) to the **test suite**, plus a post-conversion cleanup pass.

### Core conversion
- Enable `-Xcollection-literals` for Kotlin compilation (main + test) via a single `tasks.withType<KotlinCompile>().configureEach {}` block; `-Xreturn-value-checker` stays production-only.
- Convert list-typed `listOf(...)` / `emptyList()` in `src/test` to `[...]` / `[]`.
- Route `ProxyOptions(listOf(...))` / `AgentOptions(listOf(...), b)` calls through lowercase factories `proxyOptions([...])` / `agentOptions([...], b)`. A bare `[...]` passed to the raw constructors is ambiguous between their `Array<String>` and `List<String>` overloads; the single-`List` factories resolve it. Spread (`listOf(*extraArgs)`) cases keep `listOf` (collection literals can't splat).

### Cleanup (reuse / simplification / efficiency / altitude review)
- **Factories live in test source**, not production: `proxyOptions`/`agentOptions` are test-only helpers, so they're in `src/test/kotlin/io/prometheus/common/TestOptions.kt` rather than the `ProxyOptions`/`AgentOptions` companion objects — nothing test-only ships in the published `com.pambrose:prometheus-proxy` jar. The classes/constructors are public, so the helpers pin the `List` overload directly.
- **Empty immutable lists standardized on `emptyList()`.** HOCON `[]` inside `ConfigFactory.parseString("""...""")`, `MutableList<T> = []`, and `synchronizedList([])` are intentionally left as-is.
- Minor: `extraArgs.asList()` / `[...] + extraArgs` instead of `buildList`/spread; renamed shadowed `val args` → `proxyArgs`/`agentArgs` in the InProcess harness tests.

### Supporting production changes
A few `emptyList()`/`mutableListOf()` → `[]` conversions in `FileDiscoverySource`, `AgentAuthManager`, `HttpClientCache`, `ProxyPathManager` (allocation-neutral; `emptyList()` singletons preserved on warm paths).

## Verification
- ✅ `compileKotlin` + `compileTestKotlin`
- ✅ `lintKotlinMain` + `lintKotlinTest` + `detekt`
- ✅ Full `./gradlew test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)