### PR TITLE
Bind agentId to the connection on agent-facing RPCs

### DIFF
--- a/src/main/kotlin/io/prometheus/proxy/ProxyServerInterceptor.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServerInterceptor.kt
@@ -18,11 +18,14 @@
 
 package io.prometheus.proxy
 
+import io.grpc.Context
+import io.grpc.Contexts
 import io.grpc.ForwardingServerCall
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
+import io.prometheus.common.GrpcConstants.AGENT_ID
 import io.prometheus.common.GrpcConstants.META_AGENT_ID_KEY
 import io.prometheus.proxy.ProxyServerTransportFilter.Companion.AGENT_ID_KEY
 
@@ -31,15 +34,34 @@ internal class ProxyServerInterceptor : ServerInterceptor {
     call: ServerCall<ReqT, RespT>,
     requestHeaders: Metadata,
     handler: ServerCallHandler<ReqT, RespT>,
-  ): ServerCall.Listener<ReqT> =
-    handler.startCall(
+  ): ServerCall.Listener<ReqT> {
+    val forwardingCall =
       object : ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
         override fun sendHeaders(headers: Metadata) {
           // ATTRIB_AGENT_ID was assigned in ServerTransportFilter
           call.attributes.get(AGENT_ID_KEY)?.also { headers.put(META_AGENT_ID_KEY, it) }
           super.sendHeaders(headers)
         }
-      },
-      requestHeaders,
-    )
+      }
+
+    // Publish the transport-assigned agentId on the gRPC Context so ProxyServiceImpl can compare it
+    // against the caller-supplied request.agentId. Absent when transportFilterDisabled is set (no
+    // transport filter ran), in which case the call proceeds with the key unset.
+    val connectionAgentId =
+      call.attributes.get(AGENT_ID_KEY)
+        ?: return handler.startCall(forwardingCall, requestHeaders)
+
+    val context = Context.current().withValue(CONNECTION_AGENT_ID_KEY, connectionAgentId)
+    return Contexts.interceptCall(context, forwardingCall, requestHeaders, handler)
+  }
+
+  companion object {
+    /**
+     * The agentId the transport assigned to *this connection*, as opposed to the caller-supplied
+     * `request.agentId` on the wire. [ProxyServiceImpl] compares the two so one authenticated agent
+     * cannot act on another agent's [AgentContext]. Null when no transport filter ran (in-process
+     * tests, or `transportFilterDisabled`), in which case the comparison is skipped.
+     */
+    internal val CONNECTION_AGENT_ID_KEY: Context.Key<String> = Context.key(AGENT_ID)
+  }
 }

--- a/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyServiceImpl.kt
@@ -94,47 +94,82 @@ internal class ProxyServiceImpl(
     }
   }
 
-  override suspend fun registerAgent(request: RegisterAgentRequest): RegisterAgentResponse {
-    val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
-    if (agentContext == null) {
-      logger.error { "registerAgent() missing AgentContext agentId: ${request.agentId}" }
+  /**
+   * Rejects a request whose `agentId` is not the one the transport assigned to this connection.
+   *
+   * `request.agentId` is caller-supplied, and agentIds are sequential integers that the proxy echoes
+   * back to every client in the `agent-id` response header — so without this check an authenticated
+   * agent could enumerate its neighbors and pass a victim's agentId to act on the victim's
+   * [AgentContext] while presenting its own valid token.
+   *
+   * Returns null (allow) when the connection agentId is unset, which happens when no transport
+   * filter ran: `transportFilterDisabled` deployments and in-process tests. Those paths have no
+   * transport-assigned identity to compare against, so behavior there is unchanged.
+   */
+  private fun connectionMismatchReason(
+    requestAgentId: String,
+    rpcName: String,
+  ): String? {
+    val connectionAgentId = ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY.get()
+    return if (connectionAgentId == null || connectionAgentId == requestAgentId) {
+      null
     } else {
-      agentContext.assignProperties(request)
-      agentContext.markActivityTime(false)
-      logger.info { "Connected to $agentContext" }
+      logger.warn {
+        "Agent on connection $connectionAgentId sent agentId $requestAgentId to $rpcName(); rejecting"
+      }
+      "agentId $requestAgentId does not match the connection's agentId ($rpcName)"
     }
+  }
 
-    val isValid = agentContext != null
+  override suspend fun registerAgent(request: RegisterAgentRequest): RegisterAgentResponse {
+    val failureReason =
+      connectionMismatchReason(request.agentId, "registerAgent") ?: run {
+        val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
+        if (agentContext == null) {
+          logger.error { "registerAgent() missing AgentContext agentId: ${request.agentId}" }
+          "Invalid agentId: ${request.agentId} (registerAgent)"
+        } else {
+          agentContext.assignProperties(request)
+          agentContext.markActivityTime(false)
+          logger.info { "Connected to $agentContext" }
+          null
+        }
+      }
+
+    val isValid = failureReason == null
     return registerAgentResponse {
       valid = isValid
       agentId = request.agentId
       if (!isValid) {
-        reason = "Invalid agentId: ${request.agentId} (registerAgent)"
+        // Smart-cast to non-null: isValid == false implies failureReason != null.
+        reason = failureReason
       }
     }
   }
 
   override suspend fun registerPath(request: RegisterPathRequest): RegisterPathResponse {
-    val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
-    // addPath() (and the authorization check below) returns null on success or a failure message;
-    // failureReason is null iff valid.
+    // addPath() (and the binding/authorization checks below) return null on success or a failure
+    // message; failureReason is null iff valid.
     val failureReason =
-      if (agentContext == null) {
-        logger.error { "Missing AgentContext for agentId: ${request.agentId}" }
-        "Invalid agentId: ${request.agentId} (registerPath)"
-      } else {
-        // AGENT_IDENTITY_KEY is null when per-agent auth is disabled (no interceptor); an identity
-        // with no path patterns authorizes everything, so legacy single-token behavior is unchanged.
-        val identity = AgentAuthManager.AGENT_IDENTITY_KEY.get()
-        val reason =
-          if (identity != null && !identity.isAuthorized(request.path)) {
-            val normalizedPath = request.path.removePrefix("/")
-            logger.warn { "Agent identity '${identity.name}' denied registration of path /$normalizedPath" }
-            "Agent identity '${identity.name}' is not authorized to register path /$normalizedPath"
-          } else {
-            proxy.pathManager.addPath(request.path, request.labels, agentContext)
-          }
-        reason.also { agentContext.markActivityTime(false) }
+      connectionMismatchReason(request.agentId, "registerPath") ?: run {
+        val agentContext = proxy.agentContextManager.getAgentContext(request.agentId)
+        if (agentContext == null) {
+          logger.error { "Missing AgentContext for agentId: ${request.agentId}" }
+          "Invalid agentId: ${request.agentId} (registerPath)"
+        } else {
+          // AGENT_IDENTITY_KEY is null when per-agent auth is disabled (no interceptor); an identity
+          // with no path patterns authorizes everything, so legacy single-token behavior is unchanged.
+          val identity = AgentAuthManager.AGENT_IDENTITY_KEY.get()
+          val reason =
+            if (identity != null && !identity.isAuthorized(request.path)) {
+              val normalizedPath = request.path.removePrefix("/")
+              logger.warn { "Agent identity '${identity.name}' denied registration of path /$normalizedPath" }
+              "Agent identity '${identity.name}' is not authorized to register path /$normalizedPath"
+            } else {
+              proxy.pathManager.addPath(request.path, request.labels, agentContext)
+            }
+          reason.also { agentContext.markActivityTime(false) }
+        }
       }
 
     val isValid = failureReason == null
@@ -151,6 +186,14 @@ internal class ProxyServiceImpl(
 
   override suspend fun unregisterPath(request: UnregisterPathRequest): UnregisterPathResponse {
     val agentId = request.agentId
+    val mismatchReason = connectionMismatchReason(agentId, "unregisterPath")
+    if (mismatchReason != null) {
+      return unregisterPathResponse {
+        valid = false
+        reason = mismatchReason
+      }
+    }
+
     val agentContext = proxy.agentContextManager.getAgentContext(agentId)
     return if (agentContext == null) {
       logger.error { "Missing AgentContext for agentId: $agentId" }
@@ -185,6 +228,11 @@ internal class ProxyServiceImpl(
   override fun readRequestsFromProxy(request: AgentInfo): Flow<ScrapeRequest> =
     flow {
       val agentId = request.agentId
+      connectionMismatchReason(agentId, "readRequestsFromProxy")?.also { reason ->
+        // Thrown before the try/finally so the mismatched agentId never reaches the cleanup branch —
+        // a spoofed id must not be able to evict another agent's context.
+        throw StatusException(Status.PERMISSION_DENIED.withDescription(reason))
+      }
       try {
         val agentContext = proxy.agentContextManager.getAgentContext(agentId)
           ?: throw StatusException(

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServerInterceptorTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServerInterceptorTest.kt
@@ -23,6 +23,7 @@ import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -55,10 +56,49 @@ class ProxyServerInterceptorTest : StringSpec() {
       val mockCall = mockk<ServerCall<Any, Any>>(relaxed = true)
       val mockHandler = mockk<ServerCallHandler<Any, Any>>(relaxed = true)
       val requestHeaders = Metadata()
+      // Real (empty) attributes: a relaxed Attributes mock returns a bare Object from get(), which
+      // no real ServerCall ever does — interceptCall reads AGENT_ID_KEY up front to bind the
+      // connection agentId onto the Context.
+      every { mockCall.attributes } returns Attributes.EMPTY
 
       interceptor.interceptCall(mockCall, requestHeaders, mockHandler)
 
       verify { mockHandler.startCall(any(), eq(requestHeaders)) }
+    }
+
+    // With no transport-assigned agentId (transportFilterDisabled, or an in-process server with no
+    // transport filter), the Context key stays unset so ProxyServiceImpl skips the binding check.
+    "interceptCall should leave the connection agentId unset when the attribute is missing" {
+      val interceptor = ProxyServerInterceptor()
+
+      val mockCall = mockk<ServerCall<Any, Any>>(relaxed = true)
+      val mockHandler = mockk<ServerCallHandler<Any, Any>>(relaxed = true)
+      every { mockCall.attributes } returns Attributes.EMPTY
+      every { mockHandler.startCall(any(), any()) } answers {
+        ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY.get().shouldBeNull()
+        mockk(relaxed = true)
+      }
+
+      interceptor.interceptCall(mockCall, Metadata(), mockHandler)
+
+      verify { mockHandler.startCall(any(), any()) }
+    }
+
+    "interceptCall should bind the transport-assigned agentId onto the Context" {
+      val interceptor = ProxyServerInterceptor()
+
+      val mockCall = mockk<ServerCall<Any, Any>>(relaxed = true)
+      val mockHandler = mockk<ServerCallHandler<Any, Any>>(relaxed = true)
+      every { mockCall.attributes } returns Attributes.newBuilder().set(AGENT_ID_KEY, "agent-42").build()
+      every { mockHandler.startCall(any(), any()) } answers {
+        // Contexts.interceptCall attaches the Context for the duration of the downstream call.
+        ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY.get() shouldBe "agent-42"
+        mockk(relaxed = true)
+      }
+
+      interceptor.interceptCall(mockCall, Metadata(), mockHandler)
+
+      verify { mockHandler.startCall(any(), any()) }
     }
 
     "sendHeaders should inject agent-id from call attributes" {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
@@ -377,6 +377,171 @@ class ProxyServiceImplTest : StringSpec() {
       verify { proxy.pathManager.addPath(allowedPath, any(), mockAgentContext) }
     }
 
+    // ==================== agentId / connection binding ====================
+    //
+    // Path authorization checks the identity against request.path, but the AgentContext being acted
+    // on came from the caller-supplied request.agentId. agentIds are sequential integers that the
+    // proxy echoes back to each client, so an authenticated agent could enumerate its neighbors and
+    // pass a *victim's* agentId while presenting its own valid token — registering paths against the
+    // victim's context, unregistering the victim's paths, or draining the victim's scrape queue.
+    // The connection's true agentId now rides the gRPC Context and every RPC rejects a mismatch.
+
+    "registerPath should reject a request whose agentId is not the connection's" {
+      val proxy = createMockProxy()
+      val victimContext = mockk<AgentContext>(relaxed = true)
+      val attackerAgentId = "attacker-agent"
+      val victimAgentId = "victim-agent"
+
+      val pathManager = proxy.pathManager
+      every { victimContext.agentId } returns victimAgentId
+      every { proxy.agentContextManager.getAgentContext(victimAgentId) } returns victimContext
+      every { pathManager.pathMapSize } returns 0
+
+      // The attacker is authorized for team_a_* and asks for a team_a_* path, so the identity check
+      // passes — only the agentId binding stands between it and the victim's context.
+      val identity = AgentIdentity("team_a", ByteArray(0), [AgentAuthManager.globToRegex("team_a_*")])
+      val request = registerPathRequest {
+        agentId = victimAgentId
+        path = "team_a_metrics"
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val context =
+        Context.current()
+          .withValue(AgentAuthManager.AGENT_IDENTITY_KEY, identity)
+          .withValue(ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY, attackerAgentId)
+      val previous = context.attach()
+      val response =
+        try {
+          service.registerPath(request)
+        } finally {
+          context.detach(previous)
+        }
+
+      response.valid.shouldBeFalse()
+      response.pathId shouldBe -1
+      response.reason shouldContain "does not match"
+      // The victim's context must never be handed to addPath.
+      verify(exactly = 0) { pathManager.addPath(any(), any(), any()) }
+    }
+
+    "registerPath should allow a request whose agentId is the connection's" {
+      val proxy = createMockProxy()
+      val mockAgentContext = mockk<AgentContext>(relaxed = true)
+      val testAgentId = "own-agent"
+      val allowedPath = "team_a_metrics"
+
+      every { mockAgentContext.agentId } returns testAgentId
+      every { proxy.agentContextManager.getAgentContext(testAgentId) } returns mockAgentContext
+      every { proxy.pathManager.addPath(allowedPath, any(), mockAgentContext) } returns null
+      every { proxy.pathManager.pathMapSize } returns 1
+
+      val request = registerPathRequest {
+        agentId = testAgentId
+        path = allowedPath
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val context = Context.current().withValue(ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY, testAgentId)
+      val previous = context.attach()
+      val response =
+        try {
+          service.registerPath(request)
+        } finally {
+          context.detach(previous)
+        }
+
+      response.valid.shouldBeTrue()
+      verify { proxy.pathManager.addPath(allowedPath, any(), mockAgentContext) }
+    }
+
+    "unregisterPath should reject a request whose agentId is not the connection's" {
+      val proxy = createMockProxy()
+      val victimContext = mockk<AgentContext>(relaxed = true)
+      val pathManager = proxy.pathManager
+      val victimAgentId = "victim-agent"
+
+      every { proxy.agentContextManager.getAgentContext(victimAgentId) } returns victimContext
+
+      val request = unregisterPathRequest {
+        agentId = victimAgentId
+        path = "team_b_metrics"
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val context = Context.current().withValue(ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY, "attacker-agent")
+      val previous = context.attach()
+      val response =
+        try {
+          service.unregisterPath(request)
+        } finally {
+          context.detach(previous)
+        }
+
+      response.valid.shouldBeFalse()
+      response.reason shouldContain "does not match"
+      // unregisterPath has no identity gate of its own, so the binding check is the only guard.
+      coVerify(exactly = 0) { pathManager.removePath(any(), any()) }
+    }
+
+    "registerAgent should reject a request whose agentId is not the connection's" {
+      val proxy = createMockProxy()
+      val victimContext = mockk<AgentContext>(relaxed = true)
+      val victimAgentId = "victim-agent"
+
+      every { proxy.agentContextManager.getAgentContext(victimAgentId) } returns victimContext
+
+      val request = registerAgentRequest {
+        agentId = victimAgentId
+        agentName = "spoofed-name"
+        hostName = "spoofed-host"
+      }
+
+      val service = ProxyServiceImpl(proxy)
+      val context = Context.current().withValue(ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY, "attacker-agent")
+      val previous = context.attach()
+      val response =
+        try {
+          service.registerAgent(request)
+        } finally {
+          context.detach(previous)
+        }
+
+      response.valid.shouldBeFalse()
+      response.reason shouldContain "does not match"
+      // The victim's identifying metadata must not be overwritten.
+      verify(exactly = 0) { victimContext.assignProperties(any()) }
+    }
+
+    "readRequestsFromProxy should reject a request whose agentId is not the connection's" {
+      val proxy = createMockProxy()
+      val victimContext = mockk<AgentContext>(relaxed = true)
+      val victimAgentId = "victim-agent"
+
+      every { victimContext.agentId } returns victimAgentId
+      // Bounded so an unfixed build exits the stream loop instead of draining the queue forever.
+      every { victimContext.isValid() } returnsMany [true, false]
+      every { proxy.agentContextManager.getAgentContext(victimAgentId) } returns victimContext
+
+      val request = agentInfo { agentId = victimAgentId }
+
+      val service = ProxyServiceImpl(proxy)
+      val context = Context.current().withValue(ProxyServerInterceptor.CONNECTION_AGENT_ID_KEY, "attacker-agent")
+      val previous = context.attach()
+      val exception =
+        try {
+          shouldThrow<StatusException> {
+            service.readRequestsFromProxy(request).collect {}
+          }
+        } finally {
+          context.detach(previous)
+        }
+
+      exception.status.code shouldBe Status.PERMISSION_DENIED.code
+      // Draining the victim's scrape queue must not happen.
+      coVerify(exactly = 0) { victimContext.readScrapeRequest() }
+    }
+
     "unregisterPath should succeed with valid agent context" {
       val proxy = createMockProxy()
       val mockAgentContext = mockk<AgentContext>(relaxed = true)


### PR DESCRIPTION
Fixes a finding from the ultrareview of #204.

## The problem

Per-agent path authorization checked the resolved identity against `request.path`, but the `AgentContext` being acted on was looked up from the caller-supplied `request.agentId`, which was never compared to the agentId the transport assigned to the connection.

All four preconditions for exploitation held:

- `AgentContext.kt:51,159` — agentIds are sequential integers from an `AtomicLong`.
- `ProxyServerInterceptor.kt:39` — the proxy echoes each caller's own agentId back in the `agent-id` response header, so an attacker learns its own N and can probe `1..N-1`.
- `registerPath`, `registerAgent`, and `unregisterPath` each did a bare `getAgentContext(request.agentId)` lookup with no binding check.
- `unregisterPath` had no identity gate at all, on the premise that an agent can never own a path outside its patterns — which the register hijack breaks.

Net effect: any authenticated tenant could route scrapes into another tenant's queue, unregister another tenant's paths, overwrite their context metadata, or drain their scrape queue. It requires a valid token, so it is not remote-unauthenticated, but it does undercut the multi-tenant isolation #204 set out to provide.

## The fix

`ProxyServerInterceptor` now publishes the transport-assigned agentId on the gRPC `Context` (mirroring how `AgentAuthServerInterceptor` publishes the resolved identity). `registerAgent`, `registerPath`, `unregisterPath`, and `readRequestsFromProxy` reject a request whose `agentId` does not match it.

The Context key is unset when no transport filter ran — `transportFilterDisabled` deployments and in-process tests — where there is no transport-assigned identity to compare against, so those paths are unchanged.

## Testing

Five new tests in `ProxyServiceImplTest` (one rejection test per RPC, plus a positive control that a matching agentId still succeeds) and two in `ProxyServerInterceptorTest` covering the Context binding with and without the transport attribute. Each rejection test was confirmed failing against the unfixed code before the fix went in.

Verified with the full suite (1226 tests) including the Testcontainers end-to-end specs. `ContainersReconnectTest` is the relevant one here: it confirms an agent re-learns its agentId after the channel is replaced, so reconnection still works under the new check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)