### PR TITLE
Fix nits from the July 2026 review of the auth and discovery features

### DIFF
--- a/docs/security-agent-authentication.md
+++ b/docs/security-agent-authentication.md
@@ -94,8 +94,9 @@ not hand agent credentials or scrape-target secrets to connecting agents.
 
 - **Pre-shared agent token** (remediation item 1, now implemented): set a shared secret on both sides via
   `--agent_token` / `AGENT_TOKEN` / `proxy.agentToken` (proxy) and `agent.agentToken` (agent). The agent sends it
-  as a gRPC metadata header on every call; the proxy's `AgentTokenServerInterceptor`
-  (`proxy/AgentTokenServerInterceptor.kt`) rejects any RPC with a missing or mismatched token with
+  as a gRPC metadata header on every call; the proxy's `AgentAuthServerInterceptor`
+  (`proxy/AgentAuthServerInterceptor.kt`) resolves it via `AgentAuthManager` and rejects any RPC with a missing
+  or unrecognized token with
   `Status.UNAUTHENTICATED` (constant-time comparison). When the token is empty the historical open behavior is
   preserved, and the proxy logs a startup warning unless mutual TLS is configured. This is an app-level control that
   complements, but does not replace, mutual TLS.
@@ -115,8 +116,8 @@ In rough priority order:
 
 1. **Optional pre-shared agent token (lowest-friction app-level auth).** ✅ **Implemented.** A configurable
    secret (`--agent_token` / `AGENT_TOKEN` / `proxy.agentToken` on the proxy, `agent.agentToken` on the agent)
-   that agents send in a gRPC metadata header (`agent-token`). The proxy's `AgentTokenServerInterceptor` (added
-   to the interceptor chain alongside `ProxyServerInterceptor`) rejects any RPC lacking the correct token with
+   that agents send in a gRPC metadata header (`agent-token`). The proxy's `AgentAuthServerInterceptor` (added
+   to the interceptor chain alongside `ProxyServerInterceptor`) rejects any RPC lacking a recognized token with
    `Status.UNAUTHENTICATED`, using a constant-time comparison. When the token is empty, today's open behavior is
    preserved for backward compatibility — and the proxy logs a prominent startup **warning** that the agent port
    is unauthenticated (suppressed when mutual TLS is configured, since that already authenticates agents),

--- a/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
+++ b/src/main/kotlin/io/prometheus/agent/discovery/FileDiscoverySource.kt
@@ -41,7 +41,9 @@ internal class FileDiscoverySource(
   override fun read(): List<DiscoveredPath> {
     // setAllowMissing(false): a missing file throws instead of yielding an empty config, so it is
     // never mistaken for a valid-but-empty file (which would tear down every discovered path).
-    val config = ConfigFactory.parseFile(File(filePath), PARSE_OPTIONS)
+    // resolve(): parseFile() leaves substitutions unevaluated, so ${...} would throw NotResolved on
+    // the first getString() below. A no-op for files that use no substitutions.
+    val config = ConfigFactory.parseFile(File(filePath), PARSE_OPTIONS).resolve()
     val elements = if (config.hasPath(PATHS_KEY)) config.getConfigList(PATHS_KEY) else emptyList()
     return elements.map { element ->
       val path = element.getString("path") // required; a missing field throws (malformed)

--- a/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentAuthManager.kt
@@ -128,6 +128,20 @@ internal class AgentAuthManager private constructor(
       val duplicateNames = allIdentities.groupingBy { it.name }.eachCount().filterValues { it > 1 }.keys
       require(duplicateNames.isEmpty()) { "Duplicate proxy.auth identity names: ${duplicateNames.joinToString()}" }
 
+      // resolveToken() takes the first digest match, so a shared token makes every later identity
+      // dead config. Named identities are ordered ahead of the legacy one, so reusing the legacy
+      // token value would also silently narrow its allow-all scope. Compare digests, not tokens, and
+      // report only names so no token value reaches the logs.
+      val duplicateTokenNames =
+        allIdentities
+          .groupBy { it.tokenDigest.toList() }
+          .values
+          .filter { it.size > 1 }
+          .flatMap { group -> group.map { it.name } }
+      require(duplicateTokenNames.isEmpty()) {
+        "proxy.auth identities share a token: ${duplicateTokenNames.joinToString()}"
+      }
+
       if (allIdentities.isNotEmpty())
         logger.info { "Per-agent auth enabled with identities: ${allIdentities.joinToString { it.name }}" }
 

--- a/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyOptions.kt
@@ -284,8 +284,8 @@ class ProxyOptions(
           agentToken = AGENT_TOKEN.getEnv(proxyConfigVals.agentToken)
         // Never log the token value -- only whether one is configured.
         logger.info { "agentToken: ${if (agentToken.isEmpty()) "(none)" else "***"}" }
-        // Warn only when the agent port is genuinely open: no token AND no mutual-TLS trust store.
-        if (agentToken.isEmpty() && trustCertCollectionFilePath.isEmpty()) {
+        // Warn only when the agent port is genuinely open to any reachable peer.
+        if (isAgentPortUnauthenticated(agentToken, trustCertCollectionFilePath, proxyConfigVals.auth.size)) {
           logger.warn {
             "Agent gRPC port is unauthenticated -- no pre-shared agent token and no mutual-TLS trust store " +
               "are configured. Any reachable peer can register as an agent. Do not expose this port in production."
@@ -298,6 +298,20 @@ class ProxyOptions(
 
   internal companion object {
     private val logger = logger {}
+
+    /**
+     * True when the agent gRPC port accepts any reachable peer: no per-agent identities, no legacy
+     * shared token, and no mutual-TLS trust store.
+     *
+     * Extracted from the startup warning so the condition is directly testable — asserting on a log
+     * line would otherwise need an appender harness. Takes the identity *count* rather than the
+     * config object so the caller does not need a ConfigVals instance to evaluate it.
+     */
+    internal fun isAgentPortUnauthenticated(
+      agentToken: String,
+      trustCertCollectionFilePath: String,
+      authIdentityCount: Int,
+    ): Boolean = agentToken.isEmpty() && trustCertCollectionFilePath.isEmpty() && authIdentityCount == 0
 
     // gRPC timeout fields use -1L as the "leave the gRPC default in place" sentinel (the
     // `> -1L` guards in ProxyGrpcService rely on it). Any other non-positive value is invalid

--- a/src/test/kotlin/io/prometheus/agent/discovery/FileDiscoverySourceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/discovery/FileDiscoverySourceTest.kt
@@ -84,5 +84,37 @@ class FileDiscoverySourceTest : StringSpec() {
     "an empty file path is rejected" {
       shouldThrow<IllegalArgumentException> { FileDiscoverySource("").read() }
     }
+
+    // parseFile() returns an unresolved Config, so without an explicit resolve() any HOCON
+    // substitution throws ConfigException.NotResolved on the first getString(). PathDiscoveryService
+    // swallows that into a per-tick warning, so discovery would be silently dead for anyone using
+    // the substitution syntax that BaseOptions already supports for the main agent/proxy configs.
+    "resolves HOCON substitutions against the file's own keys" {
+      val path = writeTemp(
+        """
+        host = "app.internal"
+        paths = [ { path = "a_metrics", url = "http://"${'$'}{host}":9090/metrics" } ]
+        """.trimIndent(),
+      )
+
+      val result = FileDiscoverySource(path).read()
+
+      result.size shouldBe 1
+      result[0].url shouldBe "http://app.internal:9090/metrics"
+    }
+
+    "resolves optional substitutions that fall back to a literal" {
+      val path = writeTemp(
+        """
+        port = 9090
+        port = ${'$'}{?DISCOVERY_TEST_PORT_UNSET}
+        paths = [ { path = "a_metrics", url = "http://a:"${'$'}{port}"/metrics" } ]
+        """.trimIndent(),
+      )
+
+      val result = FileDiscoverySource(path).read()
+
+      result[0].url shouldBe "http://a:9090/metrics"
+    }
   }
 }

--- a/src/test/kotlin/io/prometheus/harness/AgentPathAuthTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/AgentPathAuthTest.kt
@@ -116,8 +116,10 @@ class AgentPathAuthTest : StringSpec() {
   companion object {
     private val logger = logger {}
 
+    // Only team_a's token is exercised here: the deny path is driven by having the team_a agent
+    // attempt a team_b_* registration. Resolving a *different* token to a different identity is
+    // covered at unit level by AgentAuthManagerTest.
     private const val TOKEN_A = "team-a-token"
-    private const val TOKEN_B = "team-b-token"
     private const val TARGET_URL = "http://localhost:9100/metrics"
 
     // The `proxy.auth` identity list is a HOCON list, which the -D property mechanism cannot express,

--- a/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/AgentAuthManagerTest.kt
@@ -171,5 +171,33 @@ class AgentAuthManagerTest : StringSpec() {
         )
       }
     }
+
+    // resolveToken() takes the first digest match, so two identities sharing a token silently
+    // collapse to whichever comes first — the second is dead config the operator never gets told
+    // about.
+    "duplicate identity tokens are rejected" {
+      shouldThrow<IllegalArgumentException> {
+        AgentAuthManager.create(
+          [
+            AuthEntry("team_a", "shared", emptyList()),
+            AuthEntry("team_b", "shared", emptyList()),
+          ],
+          "",
+        )
+      }
+    }
+
+    // The bite: per-agent identities are ordered ahead of the legacy identity, so reusing the legacy
+    // token value for a per-agent entry silently strips the legacy allow-all scope down to that
+    // entry's patterns — while the "legacy token is active as an allow-all identity" warning still
+    // fires, telling the operator the opposite of what is happening.
+    "a per-agent identity reusing the legacy token value is rejected" {
+      shouldThrow<IllegalArgumentException> {
+        AgentAuthManager.create(
+          [AuthEntry("team_a", "shared", ["team_a_*"])],
+          legacyToken = "shared",
+        )
+      }
+    }
   }
 }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyOptionsTest.kt
@@ -329,5 +329,41 @@ class ProxyOptionsTest : StringSpec() {
       options.sdPath shouldBe options.configVals.proxy.service.discovery.path
       options.sdTargetPrefix shouldBe options.configVals.proxy.service.discovery.targetPrefix
     }
+
+    // The startup "agent gRPC port is unauthenticated" warning predates per-agent identities. Left
+    // guarded on only the legacy token and mTLS, it fires for a proxy.auth-only config — the very
+    // setup the docs recommend — training operators to ignore a security-critical warning.
+
+    "the agent port counts as unauthenticated with no token, no trust store and no identities" {
+      ProxyOptions.isAgentPortUnauthenticated(
+        agentToken = "",
+        trustCertCollectionFilePath = "",
+        authIdentityCount = 0,
+      ).shouldBeTrue()
+    }
+
+    "per-agent identities alone authenticate the agent port" {
+      ProxyOptions.isAgentPortUnauthenticated(
+        agentToken = "",
+        trustCertCollectionFilePath = "",
+        authIdentityCount = 1,
+      ).shouldBeFalse()
+    }
+
+    "a legacy agent token alone authenticates the agent port" {
+      ProxyOptions.isAgentPortUnauthenticated(
+        agentToken = "tok",
+        trustCertCollectionFilePath = "",
+        authIdentityCount = 0,
+      ).shouldBeFalse()
+    }
+
+    "a mutual-TLS trust store alone authenticates the agent port" {
+      ProxyOptions.isAgentPortUnauthenticated(
+        agentToken = "",
+        trustCertCollectionFilePath = "/certs/ca.pem",
+        authIdentityCount = 0,
+      ).shouldBeFalse()
+    }
   }
 }


### PR DESCRIPTION
Five independent cleanups from the ultrareviews of #204 and #205. All were reported as `nit` severity. The correctness-relevant finding from that batch is split out into a separate PR.

## `FileDiscoverySource` does not resolve HOCON substitutions (#205)

`parseFile()` returns an *unresolved* `Config`, so any substitution in a discovery file threw `ConfigException.NotResolved` on the first `getString()`. `PathDiscoveryService.reconcileOnce()` swallows that into a per-tick warning, so discovery was silently dead — no paths ever appear — for anyone using the substitution syntax that `BaseOptions` already supports for the main agent/proxy configs, and that `README.md:337` implies by advertising the file as "HOCON or JSON".

Chained `.resolve()`, a no-op for files without substitutions.

## `AgentAuthManager` does not detect duplicate tokens

`create()` rejected duplicate identity *names* but not duplicate *tokens*. `resolveToken()` takes the first digest match, so a shared token silently made every later identity dead config.

The sharper case: named identities are ordered ahead of the legacy one, so a per-agent entry reusing the legacy `proxy.agentToken` value silently narrowed that token from allow-all down to the entry's patterns — while the "legacy token is active as an allow-all identity" startup warning still told the operator the opposite. That is exactly the mistake the documented migration path invites.

Now compares digests and reports only identity names, so no token value reaches the logs.

## The unauthenticated-port warning ignored `proxy.auth`

The "agent gRPC port is unauthenticated" startup warning predated per-agent identities and was still guarded on only the legacy token and the mTLS trust store. It therefore fired for a `proxy.auth`-only config — the setup the README and security docs recommend — contradicting the docs and training operators to ignore a security-critical warning.

Extracted the condition into `ProxyOptions.isAgentPortUnauthenticated()` so it is directly testable without a log-appender harness, following the pattern `CLAUDE.md` documents for the `EnvVars` parse helpers.

## Stale interceptor references in the security design doc

`docs/security-agent-authentication.md` still pointed at `AgentTokenServerInterceptor` and its file path, both renamed in #204. Repointed at `AgentAuthServerInterceptor`.

The `AgentTokenServerInterceptor` mentions in `docs/FEATURE_PROPOSALS_JULY_2026.md` are deliberately left alone — that prose reads "was **replaced** by", so it is historical, not a dangling pointer.

## Unused `TOKEN_B` in `AgentPathAuthTest`

Dropped the constant, which implied a second-agent scenario the spec does not have. Resolving a *different* token to a *different* identity is already covered at unit level by `AgentAuthManagerTest`.

## Testing

Eight new tests. The four behavioral ones — two substitution cases, two duplicate-token cases — were confirmed failing against the unfixed code first. Four more cover the `isAgentPortUnauthenticated` truth table.

Full suite green; detekt and kotlinter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)