### PR TITLE
Make AgentHttpServiceTest request counters atomic

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -52,6 +52,8 @@ import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import javax.net.ssl.X509TrustManager
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 import io.ktor.server.cio.CIO as ServerCIO
@@ -750,11 +752,11 @@ class AgentHttpServiceTest : StringSpec() {
     // ==================== Retry Policy Tests ====================
 
     "retry policy should not retry 400 Bad Request" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.BadRequest)
             call.respondText("bad request")
           }
@@ -775,7 +777,7 @@ class AgentHttpServiceTest : StringSpec() {
 
         service.fetchScrapeUrl(request)
 
-        requestCount shouldBe 1
+        requestCount.load() shouldBe 1
         service.close()
       } finally {
         server.stop(0, 0)
@@ -783,11 +785,11 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "retry policy should not retry 401 Unauthorized" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.Unauthorized)
             call.respondText("unauthorized")
           }
@@ -808,7 +810,7 @@ class AgentHttpServiceTest : StringSpec() {
 
         service.fetchScrapeUrl(request)
 
-        requestCount shouldBe 1
+        requestCount.load() shouldBe 1
         service.close()
       } finally {
         server.stop(0, 0)
@@ -816,11 +818,11 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "retry policy should not retry 403 Forbidden" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.Forbidden)
             call.respondText("forbidden")
           }
@@ -841,7 +843,7 @@ class AgentHttpServiceTest : StringSpec() {
 
         service.fetchScrapeUrl(request)
 
-        requestCount shouldBe 1
+        requestCount.load() shouldBe 1
         service.close()
       } finally {
         server.stop(0, 0)
@@ -849,11 +851,11 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "retry policy should retry 500 Internal Server Error" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.InternalServerError)
             call.respondText("server error")
           }
@@ -875,8 +877,8 @@ class AgentHttpServiceTest : StringSpec() {
         service.fetchScrapeUrl(request)
 
         // 1 initial + up to 2 retries = up to 3 total
-        requestCount shouldBeGreaterThan 1
-        requestCount shouldBeLessThanOrEqual 3
+        requestCount.load() shouldBeGreaterThan 1
+        requestCount.load() shouldBeLessThanOrEqual 3
         service.close()
       } finally {
         server.stop(0, 0)
@@ -884,11 +886,11 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "retry policy should retry 503 Service Unavailable" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.ServiceUnavailable)
             call.respondText("unavailable")
           }
@@ -909,8 +911,8 @@ class AgentHttpServiceTest : StringSpec() {
 
         service.fetchScrapeUrl(request)
 
-        requestCount shouldBeGreaterThan 1
-        requestCount shouldBeLessThanOrEqual 3
+        requestCount.load() shouldBeGreaterThan 1
+        requestCount.load() shouldBeLessThanOrEqual 3
         service.close()
       } finally {
         server.stop(0, 0)
@@ -918,11 +920,11 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "retry policy should not retry 404 Not Found" {
-      var requestCount = 0
+      val requestCount = AtomicInt(0)
       val server = embeddedServer(ServerCIO, port = 0) {
         routing {
           get("/metrics") {
-            requestCount++
+            requestCount.incrementAndFetch()
             call.response.status(HttpStatusCode.NotFound)
             call.respondText("not found")
           }
@@ -943,7 +945,7 @@ class AgentHttpServiceTest : StringSpec() {
 
         service.fetchScrapeUrl(request)
 
-        requestCount shouldBe 1
+        requestCount.load() shouldBe 1
         service.close()
       } finally {
         server.stop(0, 0)


### PR DESCRIPTION
## What this changes

The six retry/redirect specs in `AgentHttpServiceTest` count requests with a plain `var requestCount`, captured by the Ktor route handler:

```kotlin
var requestCount = 0
val server = embeddedServer(ServerCIO, port = 0) {
  routing { get("/metrics") { requestCount++ /* ... */ } }
}
```

The handler body runs on the engine's IO threads; the assertion reads the counter from the test coroutine. Nothing establishes a happens-before edge between the write and the read, so the assertion can observe a stale value.

Converted to `AtomicInt` with `incrementAndFetch()` / `load()`, matching the idiom adopted for the rest of the test suite in b0ebb6b.

## Honest caveat on the motivation

This PR came out of chasing a flake, and **the link between the two is unproven**.

`retry policy should retry 503 Service Unavailable` failed once during a full-suite run with:

```
org.opentest4j.AssertionFailedError: 0 should be > 1
```

`requestCount == 0` means the handler recorded no requests at all — not a partial retry count. I could not reproduce it in **16 subsequent attempts**:

| Condition | Runs | Reproductions |
|---|---|---|
| Test class in isolation | 8 | 0 |
| Test class under 2x-CPU busy load | 6 | 0 |
| Full suite | 2 | 0 |

Investigation ruled out two candidate causes:

- **Server not ready** — `startAndAwaitReady` (added in df16d13) requires three consecutive successful HTTP probes with a 60s timeout, so the server was demonstrably serving before the scrape.
- **Cross-test client-cache pollution** — `HttpClientCache` is constructed per `AgentHttpService` instance, not shared.

A stale read is consistent with the observed symptom, but I did not demonstrate that it caused it. The counters are genuinely unsafe as written and worth fixing on their own merits; if the flake recurs after this lands, the cause is elsewhere and this PR should not be treated as having closed it.

## Testing

Full suite green, detekt and kotlinter clean. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)