### PR TITLE
Clarify that the interceptor rename references are historical

### DIFF
--- a/docs/FEATURE_PROPOSALS_JULY_2026.md
+++ b/docs/FEATURE_PROPOSALS_JULY_2026.md
@@ -277,7 +277,7 @@ contract — **not** a gRPC `PERMISSION_DENIED` status. The agent already surfac
 `RequestFailureException`. Consequently there is **no `.proto` change**. Authentication failures
 (unknown token) still close the call with `UNAUTHENTICATED`, unchanged.
 
-**Interceptor (diverged).** `AgentTokenServerInterceptor` was **replaced** by
+**Interceptor (diverged).** The original `AgentTokenServerInterceptor` was **replaced** by
 `AgentAuthServerInterceptor`, backed by a new `AgentAuthManager` that holds the identities, resolves
 tokens (constant-time SHA-256 digest compare), and compiles the globs. The single-token path is now
 simply one allow-all identity.
@@ -286,8 +286,8 @@ simply one allow-all identity.
 `config/config.conf` (+ regenerated `ConfigVals.java`), `src/main/resources/reference.conf`
 (`proxy.auth = []` backward-compat fallback — the generated `c.getList("auth")` is required-present),
 `Proxy.kt`, `ProxyGrpcService.kt`, `ProxyServiceImpl.registerPath`. Removed:
-`AgentTokenServerInterceptor.kt`. `ProxyOptions` / `EnvVars` were **not** touched — the identity list
-is config-file-only (a list of objects), like `agent.pathConfigs`.
+`AgentTokenServerInterceptor.kt` (the pre-rename interceptor). `ProxyOptions` / `EnvVars` were
+**not** touched — the identity list is config-file-only (a list of objects), like `agent.pathConfigs`.
 
 **Tests.** `AgentAuthManagerTest` (globs, token resolution, fail-fast validation),
 `AgentAuthServerInterceptorTest` (replaces the old interceptor test; also verifies the identity is


### PR DESCRIPTION
Follow-up to #209.

`docs/FEATURE_PROPOSALS_JULY_2026.md` mentions `AgentTokenServerInterceptor` twice. Unlike the references fixed in #209, neither is a dangling pointer — both describe the rename itself:

- **Interceptor (diverged).** "`AgentTokenServerInterceptor` was **replaced** by `AgentAuthServerInterceptor`…"
- **Files.** "Removed: `AgentTokenServerInterceptor.kt`."

Renaming them to match the current class would make both wrong: the first becomes "X was replaced by X", and the second would claim `AgentAuthServerInterceptor.kt` was removed when it is listed under **New:** two lines above.

Marked them as historical instead, so a reader grepping for the old name sees immediately that it no longer exists in the tree:

- "**The original** `AgentTokenServerInterceptor` was **replaced** by …"
- "Removed: `AgentTokenServerInterceptor.kt` **(the pre-rename interceptor)**."

Docs only — no code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)