### PR TITLE
Latch the gRPC service closed on terminal agent shutdown

### DIFF
--- a/src/main/kotlin/io/prometheus/Agent.kt
+++ b/src/main/kotlin/io/prometheus/Agent.kt
@@ -557,8 +557,12 @@ class Agent(
   // returns, and the while(isRunning) loop exits. Without this, stopSync()/awaitTerminated() deadlocks
   // until a scrape arrives, the proxy evicts the agent, or the OS TCP timeout fires (finding 1).
   // Mirrors AgentContextCleanupService.triggerShutdown().
+  //
+  // Uses the permanent variant because Guava calls this exactly once: a run-loop iteration that read
+  // isRunning as true just before stopAsync() flipped it could otherwise reach resetGrpcStubs() and
+  // build a fresh channel that no second triggerShutdown() will ever break.
   override fun triggerShutdown() {
-    runCatchingCancellable { grpcService.shutDownChannel() }
+    runCatchingCancellable { grpcService.shutDownChannelPermanently() }
       .onFailure { e -> logger.warn(e) { "triggerShutdown() failed to shut down the gRPC channel: ${e.message}" } }
   }
 

--- a/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
+++ b/src/main/kotlin/io/prometheus/agent/AgentGrpcService.kt
@@ -28,7 +28,6 @@ import com.pambrose.common.utils.TlsContext.Companion.PLAINTEXT_CONTEXT
 import com.pambrose.common.utils.TlsUtils.buildClientTlsContext
 import com.google.protobuf.ByteString.copyFrom
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import io.grpc.ClientInterceptor
 import io.grpc.ClientInterceptors
 import io.grpc.ManagedChannel
 import io.prometheus.Agent
@@ -108,6 +107,11 @@ internal class AgentGrpcService(
 ) {
   private val grpcLock = ReentrantLock()
   private var grpcStarted by atomicBoolean(false)
+
+  // Latched by shutDownChannelPermanently() and never cleared: the agent is stopping for good, so no
+  // further channel may be created. Read and written only under grpcLock, which is what makes the
+  // stop-vs-reconnect ordering decisive rather than racy.
+  private var shutDownRequested by atomicBoolean(false)
   private val tracing by lazy { agent.zipkinReporterService.newTracing("grpc_client") }
   private val grpcTracing by lazy { GrpcTracing.create(tracing) }
 
@@ -178,16 +182,40 @@ internal class AgentGrpcService(
     }
 
   // Shuts the gRPC channel down without touching tracing, breaking any in-flight RPCs (e.g. an idle
-  // readRequestsFromProxy collect). Called from Agent.triggerShutdown() so stopSync() can unblock the
-  // run loop (finding 1); the full shutDown() (tracing included) still runs from the service shutDown()
-  // hook, and channel.shutdownNow() is idempotent so that later call is a no-op on the channel.
+  // readRequestsFromProxy collect). This is the *transient* teardown used by the heartbeat loop to force
+  // a reconnect, so it deliberately leaves the service able to build a new channel.
   fun shutDownChannel() =
     grpcLock.withLock {
       shutDownChannelLocked()
     }
 
+  // Terminal counterpart of shutDownChannel(), called from Agent.triggerShutdown() so stopSync() can
+  // unblock the run loop (finding 1). Guava invokes triggerShutdown() exactly once, so tearing the
+  // current channel down is not enough on its own: a run-loop iteration that read `while (isRunning)`
+  // as true just before stopAsync() flipped it can still reach resetGrpcStubs() and build a fresh live
+  // channel that nothing will ever break, parking run() in an idle collect and reinstating the deadlock.
+  // Latching shutDownRequested under grpcLock makes the outcome the same either way the race lands:
+  // reset-then-stop tears the new channel down, stop-then-reset never creates it.
+  //
+  // The full shutDown() (tracing included) still runs from the service shutDown() hook, and
+  // channel.shutdownNow() is idempotent so that later call is a no-op on the channel.
+  fun shutDownChannelPermanently() =
+    grpcLock.withLock {
+      shutDownRequested = true
+      shutDownChannelLocked()
+    }
+
   fun resetGrpcStubs() =
     grpcLock.withLock {
+      // A stop was already requested and the channel torn down; handing the run loop a fresh live
+      // channel now would leave it parked in a collect nothing can break (see shutDownChannelPermanently).
+      // Returning early leaves grpcStub pointing at the terminated channel, so the connectAgent() that
+      // follows fails fast and the run loop falls out of its already-false while (isRunning) test.
+      if (shutDownRequested) {
+        logger.info { "Skipping gRPC stub creation: shutdown already requested" }
+        return@withLock
+      }
+
       logger.info { "Creating gRPC stubs" }
 
       // Only tear down the channel on reconnect, NOT tracing: tracing/grpcTracing are one-shot lazy

--- a/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentGrpcServiceTest.kt
@@ -483,6 +483,49 @@ class AgentGrpcServiceTest : StringSpec() {
       service.shutDown()
     }
 
+    // ==================== Terminal shutdown must latch out later channel creation ====================
+
+    // Agent.triggerShutdown() tears down whatever channel exists at that instant, but Guava invokes it
+    // exactly once. A run-loop iteration that read `while (isRunning)` as true just before stopAsync()
+    // flipped it can then reach resetGrpcStubs() and build a brand-new live channel that nothing will
+    // ever break -- leaving run() parked in the idle readRequestsFromProxy collect and reinstating the
+    // very deadlock triggerShutdown() exists to prevent. Both callers of the transient teardown and the
+    // terminal one funnel through grpcLock, so latching the terminal case makes the ordering decisive:
+    // whichever runs first, no live channel survives a requested stop.
+
+    "shutDownChannel leaves the service able to rebuild a channel for a reconnect" {
+      val agent = createMockAgent("localhost:$PROXY_AGENT_PORT")
+      val service = AgentGrpcService(agent, agent.options, "test-server")
+
+      val oldChannel = service.channel
+
+      // The heartbeat teardown path (EVICTED / MAX_HEARTBEAT_FAILURES): break the connection so the run
+      // loop reconnects. This must NOT latch the service closed.
+      service.shutDownChannel()
+      service.resetGrpcStubs()
+
+      (service.channel !== oldChannel).shouldBeTrue()
+      service.channel.isShutdown.shouldBeFalse()
+
+      service.shutDown()
+    }
+
+    "shutDownChannelPermanently prevents resetGrpcStubs from building another channel" {
+      val agent = createMockAgent("localhost:$PROXY_AGENT_PORT")
+      val service = AgentGrpcService(agent, agent.options, "test-server")
+
+      // The Agent.triggerShutdown() path, racing a run-loop iteration that is about to reconnect.
+      service.shutDownChannelPermanently()
+      val terminatedChannel = service.channel
+
+      service.resetGrpcStubs()
+
+      (service.channel === terminatedChannel).shouldBeTrue()
+      service.channel.isShutdown.shouldBeTrue()
+
+      service.shutDown()
+    }
+
     // ==================== Finding 8: Zipkin tracing lifecycle across reconnects ====================
 
     // tracing/grpcTracing are one-shot lazy fields. resetGrpcStubs() runs on every reconnect and must


### PR DESCRIPTION
Closes a narrow shutdown race surfaced while reviewing #197.

## The race

`Agent.triggerShutdown()` tears down whatever channel exists at that instant, but Guava invokes it **exactly once**. A run-loop iteration that read `while (isRunning)` as true just before `stopAsync()` flipped it can still reach `resetGrpcStubs()` and build a brand-new live channel that nothing will ever break — parking `run()` in the idle `readRequestsFromProxy` collect and reinstating the very deadlock `triggerShutdown()` exists to prevent.

Two things left it unguarded: `grpcStarted` is set once and never reset, and `connectToProxy()` never re-checks `isRunning` after `resetGrpcStubs()`. The window is narrow — between the `isRunning` read and `resetGrpcStubs()` acquiring `grpcLock` — and requires a prior successful connection, hence low severity rather than medium.

## The fix

A `shutDownRequested` latch, set under `grpcLock` and never cleared, which makes `resetGrpcStubs()` return early. Because both paths acquire `grpcLock`, the race becomes a decision rather than a coin flip:

- **reset-then-stop** → the new channel gets torn down.
- **stop-then-reset** → it is never created.

Returning early leaves `grpcStub` pointing at the terminated channel, so the `connectAgent()` that follows fails fast and the run loop falls out of its already-false `while (isRunning)` test.

## Why `shutDownChannel()` is split rather than latched in place

It had **two callers with opposite intent**. The heartbeat loop calls it on `EVICTED` / `MAX_HEARTBEAT_FAILURES` precisely so the agent *will* reconnect; `triggerShutdown()` calls it because the agent is stopping for good. Latching the shared method would have traded a narrow shutdown race for a permanent inability to reconnect after a half-open transport — a much worse bug than the one being fixed.

- `shutDownChannel()` — transient teardown, still allows a rebuild. Heartbeat keeps using it.
- `shutDownChannelPermanently()` — terminal, sets the latch. Only `triggerShutdown()` uses it.

The latch is also deliberately **not** set by `shutDown()`, because the existing `concurrent shutDown and resetGrpcStubs should not deadlock` spec legitimately expects a rebuild after it.

## Test plan

Two specs in `AgentGrpcServiceTest`:

- `shutDownChannelPermanently prevents resetGrpcStubs from building another channel` — pins the terminal path.
- `shutDownChannel leaves the service able to rebuild a channel for a reconnect` — pins the transient path, so the fix cannot silently break reconnects. This one passed before and after; it exists to catch over-fixing, which was the real risk.

The terminal spec was driven from a genuine behavioral RED rather than a compile error: `shutDownChannelPermanently()` was first added as a plain alias of `shutDownChannel()`, observed to fail on a new channel actually being built, and only then latched.

`InProcessIdleShutdownTest` (the original finding-1 deadlock guard) and `InProcessHeartbeatDisabledTest` both still pass, confirming normal shutdown and the heartbeat-disabled path are intact.

`./gradlew build` green, detekt + kotlinter clean, coverage 96.19%.

Also drops a stray unused `io.grpc.ClientInterceptor` import in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)