### PR TITLE
Adopt Kotlin 2.4 explicit backing fields and multi-dollar strings

### DIFF
--- a/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
@@ -40,15 +40,15 @@ internal class AgentContextManager(
   private val agentContextMap = ConcurrentHashMap<String, AgentContext>()
   val agentContextSize: Int get() = agentContextMap.size
 
-  // Map scrape_id to ChunkedContext
-  private val chunkedContextMap = ConcurrentHashMap<Long, ChunkedContext>()
-  val chunkedContextSize: Int get() = chunkedContextMap.size
+  val chunkedContextSize: Int get() = chunkedContextMapView.size
 
   val totalAgentScrapeRequestBacklogSize: Int get() = agentContextMap.values.sumOf { it.scrapeRequestBacklogSize }
 
   val agentContextEntries: Set<Map.Entry<String, AgentContext>> get() = agentContextMap.entries
 
-  val chunkedContextMapView: Map<Long, ChunkedContext> get() = chunkedContextMap
+  // Map scrape_id to ChunkedContext
+  val chunkedContextMapView: Map<Long, ChunkedContext>
+    field = ConcurrentHashMap<Long, ChunkedContext>()
 
   fun addAgentContext(agentContext: AgentContext): AgentContext? {
     logger.info { "Registering agentId: ${agentContext.agentId}" }
@@ -68,12 +68,12 @@ internal class AgentContextManager(
     scrapeId: Long,
     context: ChunkedContext,
   ) {
-    chunkedContextMap[scrapeId] = context
+    chunkedContextMapView[scrapeId] = context
   }
 
-  fun getChunkedContext(scrapeId: Long): ChunkedContext? = chunkedContextMap[scrapeId]
+  fun getChunkedContext(scrapeId: Long): ChunkedContext? = chunkedContextMapView[scrapeId]
 
-  fun removeChunkedContext(scrapeId: Long): ChunkedContext? = chunkedContextMap.remove(scrapeId)
+  fun removeChunkedContext(scrapeId: Long): ChunkedContext? = chunkedContextMapView.remove(scrapeId)
 
   /**
    * Removes every in-flight [ChunkedContext] owned by [agentId] (e.g. when the agent disconnects or is
@@ -87,9 +87,9 @@ internal class AgentContextManager(
     // Return only the IDs this call actually removed. A concurrent writeChunkedResponsesToProxy can
     // complete (and remove) a matching context between the filter and the remove, so returning the
     // pre-removal snapshot would over-count what was reclaimed in the caller's log.
-    chunkedContextMap.entries
+    chunkedContextMapView.entries
       .filter { (_, context) -> context.agentId == agentId }
-      .mapNotNull { (scrapeId, _) -> if (chunkedContextMap.remove(scrapeId) != null) scrapeId else null }
+      .mapNotNull { (scrapeId, _) -> if (chunkedContextMapView.remove(scrapeId) != null) scrapeId else null }
 
   fun findStaleAgents(maxInactivity: Duration): List<Pair<String, AgentContext>> =
     agentContextMap

--- a/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/AgentContextManager.kt
@@ -46,7 +46,12 @@ internal class AgentContextManager(
 
   val agentContextEntries: Set<Map.Entry<String, AgentContext>> get() = agentContextMap.entries
 
-  // Map scrape_id to ChunkedContext
+  // Map scrape_id to ChunkedContext.
+  //
+  // The View suffix names the *external* contract: callers outside this class get a read-only Map.
+  // Inside the class the same name resolves to the ConcurrentHashMap backing field, so the put/remove
+  // calls below really are mutating the map itself -- not a copy, and not a violation of the read-only
+  // exposure the name promises everyone else.
   val chunkedContextMapView: Map<Long, ChunkedContext>
     field = ConcurrentHashMap<Long, ChunkedContext>()
 

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
@@ -34,7 +34,12 @@ import java.util.concurrent.ConcurrentHashMap
  * @see ProxyServiceImpl
  */
 internal class ScrapeRequestManager {
-  // Map scrape_id to ScrapeRequestWrapper
+  // Map scrape_id to ScrapeRequestWrapper.
+  //
+  // The View suffix names the *external* contract: callers outside this class get a read-only Map.
+  // Inside the class the same name resolves to the ConcurrentHashMap backing field, so the put/remove
+  // calls below really are mutating the map itself -- not a copy, and not a violation of the read-only
+  // exposure the name promises everyone else.
   val scrapeRequestMapView: Map<Long, ScrapeRequestWrapper>
     field = ConcurrentHashMap<Long, ScrapeRequestWrapper>()
 

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRequestManager.kt
@@ -35,24 +35,23 @@ import java.util.concurrent.ConcurrentHashMap
  */
 internal class ScrapeRequestManager {
   // Map scrape_id to ScrapeRequestWrapper
-  private val scrapeRequestMap = ConcurrentHashMap<Long, ScrapeRequestWrapper>()
+  val scrapeRequestMapView: Map<Long, ScrapeRequestWrapper>
+    field = ConcurrentHashMap<Long, ScrapeRequestWrapper>()
 
-  val scrapeRequestMapView: Map<Long, ScrapeRequestWrapper> get() = scrapeRequestMap
-
-  fun containsScrapeRequest(scrapeId: Long): Boolean = scrapeRequestMap.containsKey(scrapeId)
+  fun containsScrapeRequest(scrapeId: Long): Boolean = scrapeRequestMapView.containsKey(scrapeId)
 
   val scrapeMapSize: Int
-    get() = scrapeRequestMap.size
+    get() = scrapeRequestMapView.size
 
   fun addToScrapeRequestMap(scrapeRequest: ScrapeRequestWrapper): ScrapeRequestWrapper? {
     val scrapeId = scrapeRequest.scrapeId
     logger.debug { "Adding scrapeId: $scrapeId to scrapeRequestMap" }
-    return scrapeRequestMap.put(scrapeId, scrapeRequest)
+    return scrapeRequestMapView.put(scrapeId, scrapeRequest)
   }
 
   fun assignScrapeResults(scrapeResults: ScrapeResults) {
     val scrapeId = scrapeResults.srScrapeId
-    scrapeRequestMap[scrapeId]
+    scrapeRequestMapView[scrapeId]
       ?.also { wrapper ->
         wrapper.complete(scrapeResults)
         wrapper.agentContext.markActivityTime(true)
@@ -63,7 +62,7 @@ internal class ScrapeRequestManager {
     scrapeId: Long,
     failureReason: String,
   ) {
-    scrapeRequestMap[scrapeId]
+    scrapeRequestMapView[scrapeId]
       ?.also { wrapper ->
         wrapper.complete(
           ScrapeResults(
@@ -81,18 +80,18 @@ internal class ScrapeRequestManager {
     agentId: String,
     failureReason: String,
   ) {
-    scrapeRequestMap.values
+    scrapeRequestMapView.values
       .filter { it.agentContext.agentId == agentId }
       .forEach { failScrapeRequest(it.scrapeId, failureReason) }
   }
 
   fun failAllInFlightScrapeRequests(failureReason: String) {
-    scrapeRequestMap.values.forEach { failScrapeRequest(it.scrapeId, failureReason) }
+    scrapeRequestMapView.values.forEach { failScrapeRequest(it.scrapeId, failureReason) }
   }
 
   fun removeFromScrapeRequestMap(scrapeId: Long): ScrapeRequestWrapper? {
     logger.debug { "Removing scrapeId: $scrapeId from scrapeRequestMap" }
-    return scrapeRequestMap.remove(scrapeId)
+    return scrapeRequestMapView.remove(scrapeId)
   }
 
   companion object {

--- a/src/test/kotlin/io/prometheus/agent/discovery/FileDiscoverySourceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/discovery/FileDiscoverySourceTest.kt
@@ -91,9 +91,9 @@ class FileDiscoverySourceTest : StringSpec() {
     // the substitution syntax that BaseOptions already supports for the main agent/proxy configs.
     "resolves HOCON substitutions against the file's own keys" {
       val path = writeTemp(
-        """
+        $$"""
         host = "app.internal"
-        paths = [ { path = "a_metrics", url = "http://"${'$'}{host}":9090/metrics" } ]
+        paths = [ { path = "a_metrics", url = "http://"${host}":9090/metrics" } ]
         """.trimIndent(),
       )
 
@@ -105,10 +105,10 @@ class FileDiscoverySourceTest : StringSpec() {
 
     "resolves optional substitutions that fall back to a literal" {
       val path = writeTemp(
-        """
+        $$"""
         port = 9090
-        port = ${'$'}{?DISCOVERY_TEST_PORT_UNSET}
-        paths = [ { path = "a_metrics", url = "http://a:"${'$'}{port}"/metrics" } ]
+        port = ${?DISCOVERY_TEST_PORT_UNSET}
+        paths = [ { path = "a_metrics", url = "http://a:"${port}"/metrics" } ]
         """.trimIndent(),
       )
 

--- a/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
+++ b/src/test/kotlin/io/prometheus/harness/support/HarnessTests.kt
@@ -214,7 +214,7 @@ internal object HarnessTests {
             val counter = AtomicInt(0)
             repeat(args.sequentialQueryCount) { cnt ->
               val job =
-                launch(dispatcher + exceptionHandler(logger)) {
+                this@withTimeout.launch(dispatcher + exceptionHandler(logger)) {
                   callRandomProxyPath(client, args.proxyPort, pathMap, "Sequential $cnt")
                   counter += 1
                 }
@@ -237,7 +237,7 @@ internal object HarnessTests {
             val counter = AtomicInt(0)
             val jobs =
               List(args.parallelQueryCount) { cnt ->
-                launch(dispatcher + exceptionHandler(logger)) {
+                this@withTimeout.launch(dispatcher + exceptionHandler(logger)) {
                   delay((MIN_DELAY_MILLIS..MAX_DELAY_MILLIS).random().milliseconds)
                   callRandomProxyPath(client, args.proxyPort, pathMap, "Parallel $cnt")
                   counter += 1

--- a/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyServiceImplTest.kt
@@ -683,7 +683,7 @@ class ProxyServiceImplTest : StringSpec() {
       val proxy = createMockProxy(isRunning = true)
       val mockAgentContext = mockk<AgentContext>(relaxed = true)
       val mockScrapeRequestWrapper = mockk<ScrapeRequestWrapper>(relaxed = true)
-      val mockScrapeRequest = mockk<io.prometheus.grpc.ScrapeRequest>(relaxed = true)
+      val mockScrapeRequest = mockk<ScrapeRequest>(relaxed = true)
       val testAgentId = "test-agent-123"
 
       every { mockAgentContext.agentId } returns testAgentId
@@ -995,7 +995,7 @@ class ProxyServiceImplTest : StringSpec() {
       val proxy = createMockProxy(transportFilterDisabled = true, isRunning = true)
       val mockAgentContext = mockk<AgentContext>(relaxed = true)
       val mockScrapeRequestWrapper = mockk<ScrapeRequestWrapper>(relaxed = true)
-      val mockScrapeRequest = mockk<io.prometheus.grpc.ScrapeRequest>(relaxed = true)
+      val mockScrapeRequest = mockk<ScrapeRequest>(relaxed = true)
       val testAgentId = "test-agent-cancel-cleanup"
 
       every { mockAgentContext.agentId } returns testAgentId


### PR DESCRIPTION
A Kotlin modernization sweep that was sitting uncommitted in the working tree. **Not my work** — I verified and packaged it, but did not author it.

## Explicit backing fields

The two proxy managers each carried a private mutable map plus a public read-only forwarding property. Kotlin 2.4's explicit backing field syntax collapses that pair into one declaration:

```kotlin
// before
private val scrapeRequestMap = ConcurrentHashMap<Long, ScrapeRequestWrapper>()
val scrapeRequestMapView: Map<Long, ScrapeRequestWrapper> get() = scrapeRequestMap

// after
val scrapeRequestMapView: Map<Long, ScrapeRequestWrapper>
  field = ConcurrentHashMap<Long, ScrapeRequestWrapper>()
```

Callers outside the class still see a read-only `Map`; inside the class the `ConcurrentHashMap` is directly addressable, so both the separate private field and the forwarding getter disappear. Applied to `ScrapeRequestManager` and `AgentContextManager`.

This preserves the read-only-exposure pattern the July 2026 review called out as a positive: `chunkedContextMapView` and `scrapeRequestMapView` keep exactly the same external types.

## Also in this sweep

- **`FileDiscoverySourceTest`** — multi-dollar raw strings (`$$"""..."""`) replace the `${'$'}` escape dance in the HOCON substitution fixtures, so the test data now reads the way the config file it stands in for actually reads.
- **`HarnessTests`** — qualifies the ambiguous `launch` receiver as `this@withTimeout.launch`.
- **`ProxyServiceImplTest`** — uses the already-imported `ScrapeRequest` instead of repeating its fully-qualified name.

## Verification

Explicit backing fields are a preview feature that historically required `-Xexplicit-backing-fields`, which this project does **not** set — so that was the first thing checked. On Kotlin 2.4.10 the syntax needs no flag: a forced clean recompile (`compileKotlin compileTestKotlin --rerun-tasks`) is warning-free.

`./gradlew build` green, detekt + kotlinter clean, coverage 96.19% (unchanged).

## Reviewer note

One naming wrinkle worth a look: inside these classes the call sites now read `scrapeRequestMapView.put(...)` / `.remove(...)`, so a name ending in `View` is being mutated. It is correct and type-safe — the `View` name describes the external contract — but a reader skimming the class body could reasonably be surprised. Renaming the property, or leaving a short comment at the declaration, would remove the double-take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)