### PR TITLE
Await application install in startAndAwaitReady, not just the engine

### DIFF
--- a/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
+++ b/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
@@ -34,14 +34,19 @@ import kotlin.time.TimeSource.Monotonic
 // bodies on the next real request. Sending a real HTTP/1.0 line and waiting for the "HTTP/"
 // reply means the request pipeline is live before we hand back the port.
 //
-// A *single* HTTP reply is still not enough under a full-suite load spike: there is a narrow
-// window where the engine answers one request and then briefly stalls or resets the next while
-// the application module finishes installing, so the first real scrape can land in that gap and
-// see a transient non-200 (e.g. a default 404 before the test's route is matchable). To close
-// that window we require [stableProbes] *consecutive* successful HTTP replies, each on a fresh
-// connection with a short gap; any failure resets the streak. This only ever delays the return
-// (never advances it), so it cannot make a healthy server look unready — it just refuses to hand
-// back the port until the server has answered cleanly several times in a row.
+// A *single* HTTP reply is still not enough under a full-suite load spike: the engine can answer
+// one request and then briefly stall or reset the next. [stableProbes] *consecutive* successful
+// replies, each on a fresh connection with a short gap, ride that out; any failure resets the
+// streak. This only ever delays the return (never advances it), so it cannot make a healthy server
+// look unready.
+//
+// Note what the streak can NOT do: detect whether routing is installed. A probe counts any HTTP
+// status line as success, and an engine that is accepting connections but has not yet installed
+// the application module answers *every* request with 404 -- byte-identical to the 404 a fully
+// configured server returns for the probe's own unrouted /__readiness__ path. Three probes against
+// an unrouted engine are three indistinguishable successes, so the streak alone let specs race the
+// module install and see a 404 with their route handler never invoked. startSuspend() above is what
+// actually closes that window.
 //
 // The deadline is generous because it is only a ceiling, not a wait: a healthy server satisfies
 // the streak in tens of milliseconds. The extra headroom absorbs CPU contention during a full
@@ -54,7 +59,17 @@ suspend fun EmbeddedServer<*, *>.startAndAwaitReady(
   timeout: Duration = 60.seconds,
   stableProbes: Int = 3,
 ): Int {
-  start(wait = false)
+  // startSuspend() -- unlike start() -- does not return until the application module has been
+  // installed, so routing is guaranteed present before the first probe below.
+  //
+  // This matters because probeServesHttp() cannot detect routing readiness on its own: it accepts any
+  // HTTP status line, and an engine that is accepting connections but has not yet installed routing
+  // answers *every* request with 404 -- indistinguishable from the 404 a fully-configured server
+  // returns for the probe's own unrouted /__readiness__ path. With start(wait = false), a spec could
+  // therefore pass readiness and still race the module install, and its first real request would 404
+  // with the route handler never invoked. That is the intermittent failure behind assertions like
+  // `requestCount shouldBe 1` seeing 0 and `srValidResponse` being false.
+  startSuspend(wait = false)
   val port = engine.resolvedConnectors().first().port
   val deadline = Monotonic.markNow() + timeout
   var consecutive = 0


### PR DESCRIPTION
Fixes the intermittent `AgentHttpServiceTest` failures. This is test-infrastructure only — no production code changes.

## Root cause

`startAndAwaitReady()` called `start(wait = false)`, which only guarantees the CIO **engine** is accepting connections — not that the application module's **routing** has been installed. The readiness probe then sends `GET /__readiness__` and accepts any HTTP status line:

```kotlin
sock.getInputStream().readNBytes(12).decodeToString().startsWith("HTTP/")
```

Those two states are indistinguishable to that probe:

| state | response to `/__readiness__` |
|---|---|
| routing installed | **404** — no such route exists |
| routing not yet installed | **404** — everything 404s |

The `stableProbes` streak does not help, because three probes against an unrouted engine are three *identical* 404s and satisfy it. So a spec could pass readiness while the module was still installing, fire its real request into an unrouted engine, and receive a 404 with its route handler never invoked.

## Symptoms this explains

At least five different specs failed intermittently at ~4–5%, always with the same signature — **no exception, no timeout, ~60–75 ms, handler never reached**:

- `fetchScrapeUrl should forward accept header to target` → `srValidResponse` false
- `fetchScrapeUrl should set success counter message on successful fetch`
- `retry policy should not retry 403 Forbidden` → `requestCount` 0
- `retry policy should not retry 401 Unauthorized` → `requestCount` 0
- `fetchScrapeUrl reads the full chunked body…` → **`expected:<200> but was:<404>`** ← the decisive capture

The 404 is the tell: the request reached the correct server (all 24 ports in that run were distinct, ruling out collision) but matched no route.

This also reframes #210, which made these counters atomic. The counters were never wrong — the request simply never arrived.

## Fix

`startSuspend(wait = false)` instead of `start(wait = false)`. Unlike `start()`, it does not return until the application module has been installed, so routing is guaranteed present before the first probe. The streak remains as the transport-level check it is actually suited to.

The existing header comment already described this window — *"a default 404 before the test's route is matchable"* — but credited the probe streak with closing it. Since that guarantee does not hold, the comment is corrected as part of this change.

## Evidence

**No regression (measured).** A 60-run A/B was identical in both arms: fast-404 `0`, 60s-timeout `1`. That specifically clears the concern that `startSuspend` might starve the accept loop by inheriting the caller's coroutine context while `probeServesHttp` blocks on socket I/O.

**Not a before/after count (stated plainly).** The fast-404 mode did not reproduce in either 60-run arm under quiet conditions — it appeared ~3 times in ~60 runs earlier when the machine was loaded, so the rate is not stationary. This change rests on the mechanism, which is provable by inspection, plus one captured instance.

**Refuted along the way:** ephemeral port reuse (400 iterations, 400 distinct ports, 0 failures), CPU load (10/10 passed under full 18-core saturation), leaked `AgentHttpService` instances (250 leaked, 0 failures), and a `registerPath` visibility race (it is `pathMutex`-guarded and awaited).

## Known remaining issue (not addressed here)

A separate pre-existing flake survives at ~1.7%: a 60-second `Embedded server on port N did not stably serve HTTP within 1m`. It appeared at the same rate in **both** A/B arms, so it is independent of this change — a different mechanism where the engine never answers at all. Worth its own investigation.

## Verification

`AgentHttpServiceTest` and the full harness suite pass; detekt and kotlinter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)