### PR TITLE
Bind embedded test servers to loopback instead of the wildcard address

### DIFF
--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceHeaderTest.kt
@@ -33,6 +33,7 @@ import io.ktor.server.request.header
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.common.startAndAwaitReady
 import java.util.*
 import io.ktor.server.cio.CIO as ServerCIO
@@ -47,7 +48,7 @@ class AgentHttpServiceHeaderTest : StringSpec() {
   init {
     "per-request Accept header should vary independently of cached client" {
       val capturedHeaders: MutableList<String?> = Collections.synchronizedList([])
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             capturedHeaders.add(call.request.header(HttpHeaders.Accept))
@@ -86,7 +87,7 @@ class AgentHttpServiceHeaderTest : StringSpec() {
 
     "defaultRequest Accept header should persist across requests demonstrating old bug" {
       val capturedHeaders: MutableList<String?> = Collections.synchronizedList([])
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             capturedHeaders.add(call.request.header(HttpHeaders.Accept))

--- a/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/AgentHttpServiceTest.kt
@@ -45,6 +45,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.prometheus.Agent
 import io.prometheus.common.ConfigVals
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.grpc.registerPathResponse
 import io.prometheus.grpc.scrapeRequest
 import io.prometheus.common.startAndAwaitReady
@@ -287,7 +288,7 @@ class AgentHttpServiceTest : StringSpec() {
     // ==================== Valid Path Fetching Tests ====================
 
     "fetchScrapeUrl should fetch content from valid path" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText("test_metric{label=\"value\"} 42\n")
@@ -353,7 +354,7 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "fetchScrapeUrl should handle 404 response" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           // No route for /metrics, Ktor will return 404
         }
@@ -415,7 +416,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "fetchScrapeUrl should include query params in URL" {
       var receivedUrl = ""
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             receivedUrl = call.request.queryParameters.entries().joinToString("&") { "${it.key}=${it.value.first()}" }
@@ -456,7 +457,7 @@ class AgentHttpServiceTest : StringSpec() {
     "fetchScrapeUrl should append query params to existing query" {
       var existingParam: String? = null
       var fooParam: String? = null
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             existingParam = call.request.queryParameters["existing"]
@@ -500,7 +501,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "fetchScrapeUrl should gzip content larger than minGzipSizeBytes" {
       val largeContent = "a".repeat(2000)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText(largeContent)
@@ -543,7 +544,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "fetchScrapeUrl should not gzip content smaller than minGzipSizeBytes" {
       val smallContent = "small"
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText(smallContent)
@@ -586,7 +587,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "fetchScrapeUrl should forward accept header to target" {
       var receivedAccept = ""
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             receivedAccept = call.request.header("Accept").orEmpty()
@@ -626,7 +627,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "fetchScrapeUrl should forward authorization header to target" {
       var receivedAuth = ""
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             receivedAuth = call.request.header("Authorization").orEmpty()
@@ -667,7 +668,7 @@ class AgentHttpServiceTest : StringSpec() {
     // ==================== Timeout Tests ====================
 
     "fetchScrapeUrl should handle timeout gracefully" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             delay(5000.milliseconds) // Delay longer than timeout
@@ -712,7 +713,7 @@ class AgentHttpServiceTest : StringSpec() {
     // ==================== Counter Message Tests ====================
 
     "fetchScrapeUrl should set success counter message on successful fetch" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText("metric_value 1.0\n")
@@ -753,7 +754,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should not retry 400 Bad Request" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -786,7 +787,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should not retry 401 Unauthorized" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -819,7 +820,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should not retry 403 Forbidden" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -852,7 +853,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should retry 500 Internal Server Error" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -887,7 +888,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should retry 503 Service Unavailable" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -921,7 +922,7 @@ class AgentHttpServiceTest : StringSpec() {
 
     "retry policy should not retry 404 Not Found" {
       val requestCount = AtomicInt(0)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             requestCount.incrementAndFetch()
@@ -970,7 +971,7 @@ class AgentHttpServiceTest : StringSpec() {
       // Create content with multi-byte UTF-8 chars where charCount < threshold < byteCount
       // Each CJK char is 3 bytes in UTF-8, so 200 chars = 600 bytes
       val multiByte = "\u4e16".repeat(200) // 200 chars, 600 bytes
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText(multiByte)
@@ -1099,7 +1100,7 @@ class AgentHttpServiceTest : StringSpec() {
     // ==================== Bug #3: Retry timeout bounded by scrapeTimeoutSecs ====================
 
     "Bug #3: total fetch time should be bounded by scrapeTimeoutSecs despite retries" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.response.status(HttpStatusCode.InternalServerError)
@@ -1184,7 +1185,7 @@ class AgentHttpServiceTest : StringSpec() {
     "fetchScrapeUrl returns 413 when Content-Length header exceeds max" {
       // respondText sets a real Content-Length header. With maxContentLengthMBytes=0,
       // any positive Content-Length trips the pre-read guard before the body is fetched.
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText("ok")
@@ -1227,7 +1228,7 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "fetchScrapeUrl populates debug fields on 413 from Content-Length when debug enabled" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText("ok")
@@ -1271,7 +1272,7 @@ class AgentHttpServiceTest : StringSpec() {
     "fetchScrapeUrl returns 413 when body bytes exceed max with chunked encoding" {
       // respondTextWriter uses chunked transfer-encoding (no Content-Length header),
       // so the first guard is skipped and the post-read body-size guard fires instead.
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondTextWriter {
@@ -1315,7 +1316,7 @@ class AgentHttpServiceTest : StringSpec() {
     }
 
     "fetchScrapeUrl 413 from chunked body has empty url and reason when debug disabled" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondTextWriter {
@@ -1362,7 +1363,7 @@ class AgentHttpServiceTest : StringSpec() {
       // bounded readRemaining(maxContentLength + 1) path is exercised. The body is well under the
       // 10 MB default limit, so it must be returned intact (not truncated at the read cap).
       val content = "metric_a 1.0\nmetric_b 2.0\nmetric_c 3.0\n".repeat(50)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondTextWriter {
@@ -1408,7 +1409,7 @@ class AgentHttpServiceTest : StringSpec() {
       // Guards the switch from bodyAsText() (response charset) to contentBytes.decodeToString()
       // (always UTF-8): a multi-byte body under the gzip threshold must round-trip byte-for-byte.
       val multiByte = "café_µ_世界 42.0\n".repeat(5) // mix of 2- and 3-byte UTF-8 chars
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/metrics") {
             call.respondText(multiByte)

--- a/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
+++ b/src/test/kotlin/io/prometheus/common/BaseOptionsTest.kt
@@ -641,7 +641,7 @@ class BaseOptionsTest : StringSpec() {
     body: String,
     expectedPort: Int,
   ) {
-    val server = embeddedServer(ServerCIO, port = 0) {
+    val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
       routing {
         get("/$fileName") {
           call.respondText(body)

--- a/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
+++ b/src/test/kotlin/io/prometheus/common/EmbeddedTestServer.kt
@@ -28,6 +28,20 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource.Monotonic
 
+// Bind test servers to loopback explicitly rather than taking Ktor's default wildcard (0.0.0.0).
+//
+// With a wildcard bind, `port = 0` asks the OS for a port free on *0.0.0.0*, which does not conflict
+// with another process already listening on 127.0.0.1 at that same port -- different addresses, so
+// both binds succeed. This box routinely has a dozen-plus JVMs (Gradle daemons among them) holding
+// ephemeral loopback ports, and when the OS hands us one of those, BSD delivers every localhost
+// connection to the *more specific* listener. Our server is then live on a port it can never receive
+// traffic on: connections are accepted by the other process and dropped, so the readiness probe sees
+// a clean EOF forever and the spec fails after the full timeout.
+//
+// Binding 127.0.0.1 makes the OS pick a port free on loopback itself, so the collision cannot happen.
+// Measured over 6000 server starts on this machine: 8 failures with the wildcard bind, 0 with this.
+const val LOOPBACK_HOST = "127.0.0.1"
+
 // Start an embeddedServer with start(wait = false) and poll until it serves HTTP. A bare
 // TCP-connect probe isn't enough: CIO's listening socket can accept and immediately close
 // while the routing pipeline is still being installed, surfacing as EOFException or empty

--- a/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
+++ b/src/test/kotlin/io/prometheus/harness/InProcessHeartbeatDisabledTest.kt
@@ -34,6 +34,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.prometheus.Agent
 import io.prometheus.Proxy
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.common.agentOptions
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.common.startAndAwaitReady
@@ -58,7 +59,7 @@ class InProcessHeartbeatDisabledTest : StringSpec() {
 
       // The metrics endpoint the agent will scrape.
       val stub =
-        embeddedServer(ServerCIO, port = 0) {
+        embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
           routing {
             get("/metrics") { call.respondText("test_metric 42\n") }
           }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpConfigTest.kt
@@ -49,6 +49,7 @@ import io.ktor.server.routing.routing
 import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.Proxy
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.common.startAndAwaitReady
 import org.slf4j.event.Level
 import io.ktor.server.cio.CIO as ServerCIO
@@ -147,7 +148,7 @@ class ProxyHttpConfigTest : StringSpec() {
     "gzip should be preferred over deflate for large responses" {
       val proxy = createTestProxy()
       val largeContent = "a".repeat(2000)
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) {
           app.configureKtorServer(proxy, isTestMode = true)
@@ -175,7 +176,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
     "small responses should not be deflate-compressed" {
       val proxy = createTestProxy()
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) {
           app.configureKtorServer(proxy, isTestMode = true)
@@ -206,7 +207,7 @@ class ProxyHttpConfigTest : StringSpec() {
     // Both gzip and deflate should now skip compression for small responses.
     "Bug #6: small responses should not be gzip-compressed" {
       val proxy = createTestProxy()
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) {
           app.configureKtorServer(proxy, isTestMode = true)
@@ -238,7 +239,7 @@ class ProxyHttpConfigTest : StringSpec() {
     // ==================== StatusPages Integration Tests ====================
 
     "StatusPages NotFound handler should return correct text" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         install(StatusPages) {
           status(HttpStatusCode.NotFound) { call, cause ->
             call.respond(
@@ -271,7 +272,7 @@ class ProxyHttpConfigTest : StringSpec() {
     }
 
     "StatusPages exception handler should return InternalServerError" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         install(StatusPages) {
           exception<Throwable> { call, _ ->
             call.respond(HttpStatusCode.InternalServerError)
@@ -420,7 +421,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
     "configureKtorServer should add X-Engine default header to responses" {
       val proxy = createTestProxy()
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) { app.configureKtorServer(proxy, isTestMode = true) }
         routing {
@@ -445,7 +446,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
     "configureKtorServer should handle NotFound via StatusPages" {
       val proxy = createTestProxy()
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) { app.configureKtorServer(proxy, isTestMode = true) }
         routing { }
@@ -469,7 +470,7 @@ class ProxyHttpConfigTest : StringSpec() {
 
     "configureKtorServer should handle exceptions via StatusPages" {
       val proxy = createTestProxy()
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         val app = this
         with(ProxyHttpConfig) { app.configureKtorServer(proxy, isTestMode = true) }
         routing {

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -45,6 +45,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.prometheus.Proxy
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.common.ScrapeResults
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
 import io.prometheus.common.proxyOptions
@@ -166,7 +167,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       val configPath = "discovery"
       val normalizedPath = configPath.ensureLeadingSlash()
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get(normalizedPath) {
             call.respondText("found")
@@ -195,7 +196,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       val normalizedPath = configPath.ensureLeadingSlash()
       normalizedPath shouldBe "/discovery"
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get(normalizedPath) {
             call.respondText("found")
@@ -815,7 +816,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       val proxy = createSpyProxyForRoutes()
       every { proxy.isRunning } returns false
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -838,7 +839,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     "handleClientRequests should return NotFound for favicon request" {
       val proxy = createSpyProxyForRoutes()
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -861,7 +862,7 @@ class ProxyHttpRoutesTest : StringSpec() {
     "handleClientRequests should return NotFound for unregistered path" {
       val proxy = createSpyProxyForRoutes()
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -887,7 +888,7 @@ class ProxyHttpRoutesTest : StringSpec() {
         "-Dproxy.internal.blitz.path=blitz-test",
       )
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -914,7 +915,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       proxy.pathManager.addPath("test-metrics", "", agentContext)
       agentContext.invalidate()
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -943,7 +944,7 @@ class ProxyHttpRoutesTest : StringSpec() {
         "http://localhost:$PROXY_HTTP_PORT",
       )
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }
@@ -1431,7 +1432,7 @@ class ProxyHttpRoutesTest : StringSpec() {
       val proxy = createSpyProxyForRoutes()
       // SD is disabled by default
 
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           val r = this
           with(ProxyHttpRoutes) { r.handleRequests(proxy) }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyUtilsTest.kt
@@ -35,6 +35,7 @@ import io.ktor.server.routing.routing
 import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.Proxy
+import io.prometheus.common.LOOPBACK_HOST
 import io.prometheus.common.startAndAwaitReady
 import io.prometheus.proxy.ProxyUtils.respondWith
 import io.prometheus.proxy.ProxyUtils.unzip
@@ -153,7 +154,7 @@ class ProxyUtilsTest : StringSpec() {
     // ==================== Bug #14: respondWith no longer sets status redundantly ====================
 
     "respondWith should set CacheControl header and respond with text" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/test-respond") {
             call.respondWith("test content")
@@ -176,7 +177,7 @@ class ProxyUtilsTest : StringSpec() {
     }
 
     "respondWith should use custom content type" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/test-json") {
             call.respondWith(
@@ -202,7 +203,7 @@ class ProxyUtilsTest : StringSpec() {
     }
 
     "respondWith should use custom status code" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/test-error") {
             call.respondWith("error", status = HttpStatusCode.ServiceUnavailable)
@@ -225,7 +226,7 @@ class ProxyUtilsTest : StringSpec() {
     }
 
     "respondWith should set CacheControl header and correct status without redundant status call" {
-      val server = embeddedServer(ServerCIO, port = 0) {
+      val server = embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) {
         routing {
           get("/test-bug14") {
             call.respondWith("content", status = HttpStatusCode.NotFound)


### PR DESCRIPTION
Fixes the second of the two intermittent `AgentHttpServiceTest` failure modes — the ~1.7%-per-run `Embedded server on port N did not stably serve HTTP within 1m` timeout that survived #216. Test-only change.

## Root cause

`embeddedServer(ServerCIO, port = 0)` binds the **wildcard** address `0.0.0.0`, so `port = 0` asks the OS for a port free on `0.0.0.0`. That does **not** conflict with another process already listening on `127.0.0.1` at the same port number — different addresses, so both binds succeed.

On BSD-derived stacks (macOS included), a connection to `127.0.0.1:<port>` is then delivered to the **more specific** listener. The test server, holding only the wildcard bind, never sees it: the other process accepts the connection, fails to parse HTTP, and closes it.

The server ends up bound, connectable, and permanently unable to receive loopback traffic. `startAndAwaitReady()` polls it until the 60s ceiling and the spec fails.

**This is not a Ktor defect** — Ktor binds exactly what it was asked to. It is an OS-level allocation hazard that developer machines make likely, since Gradle daemons, IDEs and language servers all hold ephemeral loopback ports. `lsof` captured at the moment of failure shows the collision directly:

```
COMMAND   PID     USER   FD   TYPE  NAME
java    30997 pambrose   26u  IPv6  TCP *:65123 (LISTEN)          <- the test server (wildcard)
java    82873 pambrose  497u  IPv6  TCP 127.0.0.1:65123 (LISTEN)  <- a Gradle daemon
```

That machine had **13** JVMs listening on `127.0.0.1` ephemeral ports.

## Fix

Bind loopback explicitly, so the OS only hands out a port free **on loopback** and the collision cannot occur:

```kotlin
const val LOOPBACK_HOST = "127.0.0.1"
embeddedServer(ServerCIO, host = LOOPBACK_HOST, port = 0) { ... }
```

Applied to all 49 call sites across 8 spec files, with the reasoning recorded at the constant declaration.

## Evidence

Measured in a standalone harness (macOS 26.5.1 / arm64 / 18 cores, Temurin 25.0.3, Ktor 3.5.1) over 6000 server starts:

| bind | permanently-unusable servers per 6000 starts |
|---|---|
| `0.0.0.0` (Ktor default) | **8** |
| `127.0.0.1` | **0** |

At the measured ~0.13% rate, seeing zero failures in 6000 by chance is ~0.03% likely.

The arithmetic also reconciles with the observed suite behaviour: ~0.1% per start across ~24 servers per run predicts ~2.4% of runs failing, against the ~1.7% measured directly.

## How the earlier hypotheses were eliminated

Recorded so this is not re-litigated. Each was ruled out with measurement, not reasoning:

- **A CIO startup bug** — the initial and most persuasive theory. Refuted by `lsof`: the responder was a different process. Decoding the "unexpected reply" bytes `00 00 18 04 00 00 00 00` as an HTTP/2 SETTINGS frame was the tell, since CIO does not serve HTTP/2.
- **Port reuse from the previous spec's server** — the failing port never matched a recently released one; zero reuses observed across thousands of start/stop cycles.
- **Zero-grace teardown** — `stop(0, 0)` and `stop(500, 500)` gave an identical failure rate (2 per 2000 starts each).
- **Thread or dispatcher starvation** — a thread dump at the moment of failure showed 29 threads with 17 idle `DefaultDispatcher-worker` threads.
- **CPU load** — unchanged rate with all 18 cores saturated.

## Verification

`./gradlew build` green, coverage 96.19% (unchanged), detekt and kotlinter clean, all affected specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)