### PR TITLE
Close the finding 7 registration race by invalidating before the sweep

### DIFF
--- a/docs/CODE_REVIEW_JULY_2026.md
+++ b/docs/CODE_REVIEW_JULY_2026.md
@@ -215,6 +215,15 @@ re-register the same path. For consolidated paths it is worse — a new agent *a
 `addValidatedPath` and reject registration for an invalidated context; and/or make
 `removeFromPathManager` sweep by agentId even when the context is already absent from the manager.
 
+**Follow-up (both fixes above were ordered wrong):** PR #198 landed both halves, but
+`Proxy.removeAgentContext` swept the `pathMap` *before* `removeFromContextManager` invalidated the
+context — so the in-lock re-check read a flag the remover had not set yet, and the sweep ran before
+the racing insert. A `registerPath` blocked on the `pathMap` monitor during the sweep was released
+directly into the unguarded gap. Closed by hoisting `removeFromContextManager` above
+`removeFromPathManager`, so a registration racing teardown is either rejected by the in-lock check
+or undone by the sweep. Pinned by `ProxyTest` → "removeAgentContext should invalidate the agent
+context before sweeping the path map".
+
 ### 8. [x] Zipkin tracing closed on first reconnect, then reused
 `agent/AgentGrpcService.kt:147-154, 161-201` — **resource lifecycle, medium, confirmed (code
 path); impact plausible**
@@ -239,6 +248,12 @@ remaining closes in `close()` and `getOrCreateClient`.
 
 **Fix:** wrap each `client.close()` in its own `runCatching { }` (log failures), at all three
 sites.
+
+**Follow-up (coverage gap):** PR #198's fix was correct, but its only test called `closeQuietly`
+directly — reverting the sweeper call site to `it.close()` left the whole suite green, so nothing
+pinned the wiring. Covered by `HttpClientCacheTest` → "Finding 9: a throwing close in the sweeper
+must not kill the cleanup loop", which drives a throwing close through the background loop and
+asserts a *subsequent* entry is still evicted. Verified to fail when the call site is reverted.
 
 ### 10. [x] All non-2xx upstream responses mislabeled `path_not_found`
 `proxy/ProxyHttpRoutes.kt:305-315 (312), 216-219` — **observability, medium, confirmed**

--- a/src/main/kotlin/io/prometheus/Proxy.kt
+++ b/src/main/kotlin/io/prometheus/Proxy.kt
@@ -348,6 +348,13 @@ class Proxy(
   ): AgentContext? {
     require(agentId.isNotEmpty()) { EMPTY_AGENT_ID_MSG }
 
+    // Drop the context first: removeFromContextManager invalidates it, and registerPath re-checks
+    // validity inside the pathMap lock. Invalidating before the sweep below means a registration
+    // racing this teardown is either rejected by that check (it arrives after invalidation) or
+    // undone by the sweep (it arrived before). Sweeping first leaves a window where a registration
+    // blocked on the pathMap monitor is released after the sweep but before invalidation, stranding
+    // a path pointing at a dead context that nothing later removes (finding 7).
+    val agentContext = agentContextManager.removeFromContextManager(agentId, reason)
     pathManager.removeFromPathManager(agentId, reason)
     scrapeRequestManager.failAllScrapeRequests(agentId, "Agent disconnected: $reason")
     // Proactively reclaim any in-flight chunked-transfer buffers for this agent (the requests
@@ -357,7 +364,7 @@ class Proxy(
         if (reclaimed.isNotEmpty())
           logger.info { "Reclaimed ${reclaimed.size} in-flight chunked context(s) for agentId: $agentId ($reason)" }
       }
-    return agentContextManager.removeFromContextManager(agentId, reason)
+    return agentContext
   }
 
   /**

--- a/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyPathManager.kt
@@ -205,14 +205,13 @@ internal class ProxyPathManager(
   ) {
     require(agentId.isNotEmpty()) { EMPTY_AGENT_ID_MSG }
 
-    if (proxy.agentContextManager.getAgentContext(agentId) == null)
-      logger.debug { "Agent context already removed for agentId: $agentId ($reason)" }
-    else
-      logger.info { "Removing paths for agentId: $agentId ($reason)" }
-
     // Always sweep the pathMap by agentId, even when the context is already gone from the manager: a
     // registerPath that raced this removal can strand a path pointing at an invalidated context, and
-    // skipping the sweep would leave that path 404ing forever (finding 7).
+    // skipping the sweep would leave that path 404ing forever (finding 7). The caller invalidates the
+    // context before calling this, so the context is normally already absent from the manager here —
+    // report on what the sweep actually removed rather than on a manager lookup that no longer
+    // distinguishes a live disconnect from a repeat call.
+    var removedPathCount = 0
     synchronized(pathMap) {
       // Collect map mutations in a first pass to avoid modifying the map during iteration.
       val keysToRemove: MutableList<String> = []
@@ -238,11 +237,17 @@ internal class ProxyPathManager(
       keysToRemove.forEach { k ->
         pathMap.remove(k)
           ?.also {
+            removedPathCount++
             if (!isTestMode)
               logger.info { "Removed path /$k for $it" }
           } ?: logger.warn { "Missing path /$k for agentId: $agentId" }
       }
     }
+
+    if (removedPathCount == 0)
+      logger.debug { "No paths registered for agentId: $agentId ($reason)" }
+    else
+      logger.info { "Removed $removedPathCount path(s) for agentId: $agentId ($reason)" }
   }
 
   fun toPlainText(): String =

--- a/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
+++ b/src/test/kotlin/io/prometheus/agent/HttpClientCacheTest.kt
@@ -89,6 +89,48 @@ class HttpClientCacheTest : StringSpec() {
       verify { throwing.close() }
     }
 
+    // Finding 9, wiring: the test above only proves the helper swallows a throw, not that the sweeper
+    // actually routes through it. This drives a throwing close through the background cleanup loop --
+    // the one site (clientsToClose.forEach) that sits outside runCatchingCancellable but inside
+    // while(isActive), on a scope with no exception handler, so an escaping throw kills the sweeper
+    // silently. Reverting that site to `it.close()` must fail this test.
+    "Finding 9: a throwing close in the sweeper must not kill the cleanup loop" {
+      val sweeperCache = HttpClientCache(
+        maxCacheSize = 5,
+        maxAge = 30.seconds, // Long, so eviction is driven by idle time alone.
+        maxIdleTime = 100.milliseconds,
+        cleanupInterval = 50.milliseconds,
+      )
+
+      try {
+        val throwing = mockk<HttpClient>(relaxed = true)
+        every { throwing.close() } throws RuntimeException("close boom")
+        sweeperCache.getOrCreateClient(ClientKey("bad", "pass")) { throwing }
+          .also { sweeperCache.onFinishedWithClient(it) }
+
+        // The entry is dropped from the map under the mutex and only closed after it is released, so
+        // this first eviction happens whether or not the close is guarded. It just gets the throwing
+        // close in front of the sweeper.
+        withTimeout(5.seconds) {
+          while (sweeperCache.currentCacheSize() > 0) delay(25.milliseconds)
+        }
+        verify { throwing.close() }
+
+        // The real assertion: a second entry must still be evicted, which can only happen if the
+        // sweeper coroutine survived the throw above.
+        sweeperCache.getOrCreateClient(ClientKey("good", "pass")) { createMockHttpClient() }
+          .also { sweeperCache.onFinishedWithClient(it) }
+        sweeperCache.currentCacheSize() shouldBe 1
+
+        withTimeout(5.seconds) {
+          while (sweeperCache.currentCacheSize() > 0) delay(25.milliseconds)
+        }
+        sweeperCache.currentCacheSize() shouldBe 0
+      } finally {
+        sweeperCache.close()
+      }
+    }
+
     // Item 4: once closed, the cache must reject new requests. Otherwise an in-flight scrape
     // racing shutdown could create and cache a fresh HttpClient into the dead cache (whose cleanup
     // coroutine is cancelled), leaking that client until JVM exit. The factory must not be invoked.
@@ -832,7 +874,10 @@ class HttpClientCacheTest : StringSpec() {
     // Companion to the above: verify that the cleanup coroutine still catches real
     // (non-cancellation) exceptions from cleanup operations. runCatchingCancellable
     // only rethrows CancellationException; other failures are still handled by getOrElse.
-    "cleanup should still run after a non-cancellation error" {
+    // Renamed from "cleanup should still run after a non-cancellation error": this test injects no
+    // error, it only exercises ordinary background expiry. The error path it was named for is covered
+    // by "Finding 9: a throwing close in the sweeper must not kill the cleanup loop" above.
+    "background cleanup should remove an expired entry" {
       val cleanupCache = HttpClientCache(
         maxCacheSize = 10,
         maxAge = 100.milliseconds,

--- a/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyTest.kt
@@ -28,6 +28,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.prometheus.Proxy
 import io.prometheus.common.TestPorts.PROXY_HTTP_PORT
 import io.prometheus.grpc.registerAgentRequest
@@ -354,6 +355,46 @@ class ProxyTest : StringSpec() {
       str shouldContain "proxyPort"
       str shouldContain "adminService"
       str shouldContain "metricsService"
+    }
+
+    // ==================== removeAgentContext Ordering Tests ====================
+
+    "removeAgentContext should invalidate the agent context before sweeping the path map" {
+      val proxy = createTestProxy()
+      val agentContext = spyk(createAgentContext())
+
+      // Capture how many paths were still registered at the instant invalidate() ran. The sweep in
+      // removeFromPathManager must come after invalidation, so the path is still present here.
+      var pathMapSizeAtInvalidation = -1
+      every { agentContext.invalidate() } answers {
+        pathMapSizeAtInvalidation = proxy.pathManager.pathMapSize
+        callOriginal()
+      }
+
+      proxy.agentContextManager.addAgentContext(agentContext)
+      proxy.pathManager.addPath("metrics", "", agentContext)
+      proxy.pathManager.pathMapSize shouldBe 1
+
+      proxy.removeAgentContext(agentContext.agentId, "test disconnect")
+
+      // If the sweep ran first this is 0, which leaves an unguarded window: a registerPath blocked on
+      // the pathMap monitor during the sweep is released into it and strands a path pointing at a
+      // context that is about to be invalidated, and no later sweep removes it (finding 7).
+      pathMapSizeAtInvalidation shouldBe 1
+      proxy.pathManager.pathMapSize shouldBe 0
+    }
+
+    "removeAgentContext should reject a path registered for the removed context" {
+      val proxy = createTestProxy()
+      val agentContext = createAgentContext()
+      proxy.agentContextManager.addAgentContext(agentContext)
+
+      proxy.removeAgentContext(agentContext.agentId, "test disconnect")
+      val error = proxy.pathManager.addPath("metrics", "", agentContext)
+
+      error.shouldNotBeNull()
+      error shouldContain "was invalidated during registration"
+      proxy.pathManager.pathMapSize shouldBe 0
     }
   }
 }


### PR DESCRIPTION
Follow-up to #198, from a multi-agent adversarial review of that PR. Two of its fixes were incomplete; this closes both.

## Finding 7: the fix was ordered wrong

#198 landed both halves — the in-lock `isNotValid()` re-check in `addValidatedPath`, and the unconditional sweep in `removeFromPathManager` — but `Proxy.removeAgentContext` ran them **before** the invalidation they were meant to race against:

```kotlin
pathManager.removeFromPathManager(agentId, reason)   // sweep
...
return agentContextManager.removeFromContextManager(agentId, reason)  // invalidate
```

So the re-check read a flag the remover had not set yet and let the insert through, and the sweep ran before the racing `registerPath` had inserted anything. Worse, a `registerPath` blocked on the `pathMap` monitor during the sweep is released *directly into* the unguarded gap — the bad interleaving is preferentially sampled, not a rare fluke.

**Fix:** hoist `removeFromContextManager` above `removeFromPathManager`. A registration racing teardown is now either rejected by the in-lock check (arrived after invalidation) or undone by the sweep (arrived before). Both interleavings are covered.

### Knock-on: logging

The reorder makes `removeFromPathManager`'s `agentContextManager.getAgentContext()` lookup vestigial — the context is always absent by the time it runs, so the branch would always take `debug` and every disconnect would silently lose the `Removing paths for agentId` info line. Replaced with a `removedPathCount` driven by what the sweep actually removed: same operator signal, now based on real work rather than a lookup the reorder invalidated.

## Finding 9: the fix was untested

#198's fix (routing all four `client.close()` sites through `closeQuietly`) was correct, but its only test called `closeQuietly` directly. Reverting the sweeper call site to `it.close()` left all 29 tests green — nothing pinned the wiring.

That site matters most: it sits outside `runCatchingCancellable` but inside `while (isActive)`, on a scope with no exception handler, so a throwing close kills the sweeper silently.

The new test drives a throwing close through the background loop. The load-bearing assertion is that a **subsequent** entry is still evicted — the first eviction happens under the mutex before the close, so it passes either way and proves nothing.

Also renamed `cleanup should still run after a non-cancellation error`, which injects no error, to `background cleanup should remove an expired entry`.

## Verification

- `ProxyTest` ordering test failed first with `expected:<1> but was:<0>`, then passed after the reorder.
- Sweeper test verified by mutation: reverting `HttpClientCache.kt:100` to `it.close()` makes it fail with `TimeoutCancellationException` while the old `closeQuietly` test still passes. `HttpClientCache.kt` is unchanged in this PR.
- Full `./gradlew test` — BUILD SUCCESSFUL (4m37s); `detekt` + `lintKotlinMain` + `lintKotlinTest` clean.
- Container tests not run (need Docker + `RUN_CONTAINER_TESTS=true`). `ContainersReconnectTest` exercises the reconnect path this touches and is worth running before merge.

Findings 7 and 9 in `docs/CODE_REVIEW_JULY_2026.md` get follow-up notes explaining why each ✅ was premature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)