### PR TITLE
Split upstream_timed_out from timed_out and correct the metric label docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Behavior Changes
+
+- **`proxy_scrape_requests{type}` and the latency histogram's `outcome` label gained `upstream_timed_out`.** An agent-reported scrape timeout (408/504 — the agent answered promptly to say its *own* fetch of the target exceeded `agent.scrapeTimeoutSecs`) was previously labeled `timed_out`, the same value the proxy emits when the agent never answers at all within `proxy.internal.scrapeRequestTimeoutSecs`. The two have opposite remediations, and because the agent's 15s default trips well before the proxy's 90s, the agent-side leg was the dominant contributor to the merged series. **Dashboards and alerts matching `type="timed_out"` will stop counting agent-side scrape timeouts** — use `type=~"timed_out|upstream_timed_out"` to match both. This completes the label taxonomy started in 3.2.0, which split `upstream_error` / `content_too_large` out of `path_not_found`
+
+### Bug Fixes
+
+- Fix a registration race that could strand a scrape path pointing at a dead agent. `Proxy.removeAgentContext` swept the path map *before* invalidating the agent context, so a `registerPath` blocked on the path-map monitor during the sweep was released into an unguarded window — the in-lock validity re-check read a flag the remover had not set yet, and the sweep had already run. The context is now invalidated first, so a registration racing teardown is either rejected by the re-check or undone by the sweep. Symptom was a permanently inflated `proxy_scrape_requests{type="agent_disconnected"}` plus a retained dead `AgentContext`; scrape results themselves stayed correct
+- Guard the background `HttpClientCache` sweeper against a throwing `HttpClient.close()`. The 3.2.0-era fix was correct but untested at the call site, so nothing pinned it against regression
+
+### Documentation
+
+- Correct the `proxy_scrape_requests` type-label tables in `docs/metrics-and-grafana.md` and the Monitoring page, which still described `path_not_found` as "Agent returned a non-200 status for the target" and omitted `upstream_error` and `content_too_large` entirely. Both tables now document the full label set and the proxy-side/agent-side pairs operators have to tell apart (`timed_out` / `upstream_timed_out`, `payload_too_large` / `content_too_large`)
+- Rework the Troubleshooting timeout section around which timeout actually fired, and widen the `ProxyPayloadTooLarge` example alert to match `content_too_large` as well — its summary claimed to cover the size limit but only ever matched the proxy-side half
+
+---
+
 ## [3.2.0] - 2026-06-13
 
 ### New Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,40 @@
 
 ---
 
+## Unreleased
+
+### Highlights
+
+- **Agent-side scrape timeouts are now their own metric label.** `upstream_timed_out` separates "the agent told us the target was slow" from `timed_out`, "the agent never answered us." This is the one change here that needs operator attention — see the upgrade note below.
+- **A path-registration race is closed.** An agent reconnecting at exactly the wrong moment could leave a scrape path pointing at a context that was already being torn down, inflating the disconnect counter for the life of the proxy.
+
+### Upgrade Note — metric label change
+
+`proxy_scrape_requests{type}` (and the `outcome` label on `proxy_scrape_request_latency_seconds`) gained a new value, `upstream_timed_out`.
+
+Previously both timeout legs shared the `timed_out` label:
+
+| Label | Meaning | What to do about it |
+|-------|---------|---------------------|
+| `timed_out` | The agent never answered within the proxy's `scrapeRequestTimeoutSecs` (default 90s) | Check the agent is alive and reachable |
+| `upstream_timed_out` | The agent answered promptly to report that its own fetch of the target exceeded `agent.scrapeTimeoutSecs` (default 15s) | Fix the slow target, or raise the agent's timeout |
+
+Because the agent's 15s timeout trips long before the proxy's 90s, **a slow scrape target almost always lands in `upstream_timed_out` now**. Any dashboard, recording rule, or alert matching `type="timed_out"` will stop seeing the majority of what it used to count. Match `type=~"timed_out|upstream_timed_out"` to preserve the old aggregate, or split the two panels — they point at different problems.
+
+This finishes the taxonomy work started in 3.2.0, which pulled `upstream_error` and `content_too_large` out of the catch-all `path_not_found`. It also mirrors the existing `content_too_large` (agent's `maxContentLengthMBytes`) versus `payload_too_large` (proxy's unzip limit) pairing, so every proxy-side label now has a distinctly-named agent-side counterpart.
+
+### Bug Fixes
+
+- **A `registerPath` racing an agent disconnect could strand a dead path.** `Proxy.removeAgentContext` swept the path map before invalidating the agent context, so the in-lock validity re-check added in 3.2.0 was reading a flag the remover had not set yet, and the compensating sweep ran before the racing insert. Worse, a registration blocked on the path-map monitor *during* the sweep was released directly into the unguarded window, so the bad interleaving was sampled preferentially rather than rarely. Invalidating first closes it: a registration racing teardown is now either rejected by the re-check or undone by the sweep. Scrape results were never wrong — consolidated merging masked the dead leg — but the proxy kept a dead `AgentContext` and logged a spurious `agent_disconnected` outcome on every scrape of that path.
+- **The `HttpClientCache` sweeper is now pinned against a throwing `close()`.** The 3.2.0 fix routed every `HttpClient.close()` through a swallowing helper, but its test called that helper directly — reverting the sweeper's own call site left the whole suite green. A regression test now drives a throwing close through the background loop and asserts a *subsequent* entry is still evicted, which only holds if the sweeper coroutine survived.
+
+### Documentation
+
+- **The metric label tables were stale.** Both `docs/metrics-and-grafana.md` and the Monitoring page still described `path_not_found` as "Agent returned a non-200 status for the target" — untrue for every status except 404 since 3.2.0 — and `upstream_error` and `content_too_large` appeared in no operator-facing documentation at all. Both tables now carry the full label set plus an explicit note on the proxy-side/agent-side pairs.
+- The Troubleshooting timeout section is reorganized around *which* timeout fired, since that determines whether to look at the agent or the target. The example `ProxyPayloadTooLarge` alerting rule now matches `content_too_large` as well; its summary claimed to cover the size limit but it only ever matched the proxy-side half.
+
+---
+
 ## 3.2.0
 
 _Released 2026-06-13_

--- a/docs/CODE_REVIEW_JULY_2026.md
+++ b/docs/CODE_REVIEW_JULY_2026.md
@@ -266,6 +266,17 @@ activity log. Operators cannot distinguish a genuinely unknown path from a down 
 **Fix:** derive the label from the status code (e.g. `upstream_error`, `timed_out`,
 `content_too_large`, with `path_not_found` reserved for the actual 404-unknown-path case).
 
+**Follow-up (label collision + stale docs):** the 408/504 case reused `timed_out`, the same string
+the proxy emits when the agent never answers at all — two faults with opposite remediations in one
+series, and since `agent.scrapeTimeoutSecs` (15s) trips well before the proxy's
+`scrapeRequestTimeoutSecs` (90s), the agent-side leg was the dominant contributor. Split out as
+`upstream_timed_out`, matching the `content_too_large` / `payload_too_large` convention this
+finding already established. The proxy-side literal is now the `PROXY_TIMEOUT_LABEL` constant so
+the two can't silently converge again. The label tables in `docs/metrics-and-grafana.md` and
+`website/prometheus-proxy/docs/monitoring.md` were never updated when this finding landed — they
+still described `path_not_found` as "Agent returned a non-200 status" and omitted `upstream_error`
+and `content_too_large` entirely; both are now correct and document the proxy/agent pairs.
+
 ### 11. [x] Config-value validation gaps for values used in arithmetic/capacity
 `Agent.kt:204, 265` · `proxy/ProxyServiceImpl.kt:241` vs `proxy/ProxyOptions.kt:267-271` ·
 `agent/AgentOptions.kt:317-319` — **input validation, medium, confirmed**

--- a/docs/metrics-and-grafana.md
+++ b/docs/metrics-and-grafana.md
@@ -77,19 +77,31 @@ The same options are available under `agent.metrics`.
 
 **`proxy_scrape_requests` type labels:**
 
-| Value                   | Meaning                                                  |
-|-------------------------|----------------------------------------------------------|
-| `success`               | Scrape completed successfully                            |
-| `timed_out`             | Agent did not respond within `scrapeRequestTimeoutSecs`  |
-| `no_agents`             | No agents registered for the requested path              |
-| `invalid_path`          | Requested path is empty or unrecognized                  |
-| `agent_disconnected`    | Agent stream closed before response was received         |
-| `missing_results`       | Internal error: results object was null                  |
-| `path_not_found`        | Agent returned a non-200 status for the target           |
-| `payload_too_large`     | Unzipped content exceeded `maxUnzippedContentSizeMBytes` |
-| `invalid_gzip`          | Gzip decompression failed                                |
-| `proxy_not_running`     | Proxy is shutting down                                   |
-| `invalid_agent_context` | All agents for the path are in an invalid state          |
+| Value                   | Meaning                                                                      |
+|-------------------------|------------------------------------------------------------------------------|
+| `success`               | Scrape completed successfully                                                |
+| `timed_out`             | Agent did not answer within the proxy's `scrapeRequestTimeoutSecs`           |
+| `upstream_timed_out`    | Agent answered, but its own fetch exceeded `agent.scrapeTimeoutSecs` (408/504) |
+| `no_agents`             | No agents registered for the requested path                                  |
+| `invalid_path`          | Requested path is empty or unrecognized                                      |
+| `agent_disconnected`    | Agent stream closed before response was received                             |
+| `missing_results`       | Internal error: results object was null                                      |
+| `path_not_found`        | Agent has no registration for the target path (404)                          |
+| `upstream_error`        | Target returned a non-2xx status not covered above, e.g. 5xx                 |
+| `content_too_large`     | Target response exceeded `agent.http.maxContentLengthMBytes` (413)           |
+| `payload_too_large`     | Unzipped content exceeded `maxUnzippedContentSizeMBytes`                     |
+| `invalid_gzip`          | Gzip decompression failed                                                    |
+| `proxy_not_running`     | Proxy is shutting down                                                       |
+| `invalid_agent_context` | All agents for the path are in an invalid state                              |
+
+Several values come in proxy-side / agent-side pairs, and the distinction determines where to look:
+
+- `timed_out` is the proxy giving up on an unresponsive agent; `upstream_timed_out` is the agent
+  reporting promptly that the *target* was slow. Under stock config the agent's 15s timeout trips
+  well before the proxy's 90s, so `upstream_timed_out` is the common case — raise
+  `agent.scrapeTimeoutSecs` or fix the slow target, rather than touching the proxy timeout.
+- `content_too_large` is the agent's own `maxContentLengthMBytes` limit rejecting the target
+  response; `payload_too_large` is the proxy's unzip limit. Both surface as HTTP 413.
 
 ### Histograms
 

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -71,6 +71,11 @@ internal object ProxyHttpRoutes {
   // OpenMetrics end-of-stream marker, stripped from each consolidated agent's body and re-appended once.
   private const val EOF_MARKER = "# EOF"
 
+  // The proxy waited out scrapeRequestTimeoutSecs without the agent answering. Distinct from
+  // upstream_timed_out, which is the agent answering promptly to report that its own fetch of the
+  // target exceeded agent.scrapeTimeoutSecs -- see upstreamErrorLabel.
+  internal const val PROXY_TIMEOUT_LABEL = "timed_out"
+
   fun Routing.handleRequests(proxy: Proxy) {
     handleServiceDiscoveryEndpoint(proxy)
     handleClientRequests(proxy)
@@ -293,7 +298,7 @@ internal object ProxyHttpRoutes {
       if (!scrapeRequest.awaitCompleted(timeoutTime))
         return ScrapeRequestResponse(
           statusCode = HttpStatusCode.ServiceUnavailable,
-          updateMsg = "timed_out",
+          updateMsg = PROXY_TIMEOUT_LABEL,
           fetchDuration = scrapeRequest.ageDuration(),
         )
 
@@ -380,10 +385,17 @@ internal object ProxyHttpRoutes {
   // metric/activity label, so operators can tell a down target (5xx), a scrape timeout (408/504), an
   // oversized payload (413), and a path not registered on the agent (404) apart -- instead of every
   // failure reading as path_not_found (finding 10).
+  //
+  // Each label names the agent-side leg, distinct from the proxy-side label for the same fault:
+  // upstream_timed_out vs PROXY_TIMEOUT_LABEL (the agent's own scrapeTimeoutSecs elapsed, versus the
+  // proxy's scrapeRequestTimeoutSecs elapsed with no answer at all), and content_too_large vs
+  // payload_too_large (the agent's maxContentLengthMBytes, versus the proxy's unzip limit). Under
+  // stock config the agent's 15s timeout trips well before the proxy's 90s, so collapsing the two
+  // timeout legs would have hidden the common case behind the rare one (finding 4).
   internal fun upstreamErrorLabel(statusCode: HttpStatusCode): String =
     when (statusCode) {
       HttpStatusCode.NotFound -> "path_not_found"
-      HttpStatusCode.RequestTimeout, HttpStatusCode.GatewayTimeout -> "timed_out"
+      HttpStatusCode.RequestTimeout, HttpStatusCode.GatewayTimeout -> "upstream_timed_out"
       HttpStatusCode.PayloadTooLarge -> "content_too_large"
       else -> "upstream_error"
     }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -24,6 +24,7 @@ import com.pambrose.common.util.zip
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeEmpty
 import io.kotest.matchers.string.shouldNotContain
@@ -736,12 +737,26 @@ class ProxyHttpRoutesTest : StringSpec() {
     // of every failure being labeled path_not_found.
     "Finding 10: upstreamErrorLabel maps status codes to distinct labels" {
       ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.NotFound) shouldBe "path_not_found"
-      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.RequestTimeout) shouldBe "timed_out"
-      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.GatewayTimeout) shouldBe "timed_out"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.RequestTimeout) shouldBe "upstream_timed_out"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.GatewayTimeout) shouldBe "upstream_timed_out"
       ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.PayloadTooLarge) shouldBe "content_too_large"
       ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.InternalServerError) shouldBe "upstream_error"
       ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.BadGateway) shouldBe "upstream_error"
       ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.ServiceUnavailable) shouldBe "upstream_error"
+    }
+
+    // The agent's own scrapeTimeoutSecs (default 15) is well below the proxy's
+    // scrapeRequestTimeoutSecs (default 90), so a slow target trips the agent first and the upstream
+    // leg is the dominant contributor to timeout metrics. Labeling both legs "timed_out" collapsed
+    // them into one series even though they have opposite remediations: raise the proxy timeout / fix
+    // the agent link, versus raise the agent scrape timeout / fix the slow target.
+    "upstreamErrorLabel should not reuse the proxy-side timed_out label for an upstream timeout" {
+      val upstream = ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.RequestTimeout)
+
+      upstream shouldNotBe ProxyHttpRoutes.PROXY_TIMEOUT_LABEL
+      upstream shouldBe "upstream_timed_out"
+      ProxyHttpRoutes.upstreamErrorLabel(HttpStatusCode.GatewayTimeout) shouldNotBe
+        ProxyHttpRoutes.PROXY_TIMEOUT_LABEL
     }
 
     "Finding 10: submitScrapeRequest labels a 500 upstream response upstream_error" {

--- a/website/prometheus-proxy/docs/grafana.md
+++ b/website/prometheus-proxy/docs/grafana.md
@@ -81,12 +81,14 @@ groups:
         annotations:
           summary: "Proxy agent scrape backlog is large ({{ $value }} queued)"
 
+      # Covers both size limits: content_too_large is the agent's maxContentLengthMBytes rejecting
+      # the target response, payload_too_large is the proxy's unzipped-size guard.
       - alert: ProxyPayloadTooLarge
-        expr: rate(proxy_scrape_requests{type="payload_too_large"}[5m]) > 0
+        expr: rate(proxy_scrape_requests{type=~"payload_too_large|content_too_large"}[5m]) > 0
         for: 5m
         labels: { severity: warning }
         annotations:
-          summary: "Scrapes are being rejected for exceeding the size limit"
+          summary: "Scrapes are being rejected for exceeding the size limit ({{ $labels.type }})"
 
       - alert: ProxyFrequentEvictions
         expr: rate(proxy_eviction_count[5m]) > 0

--- a/website/prometheus-proxy/docs/monitoring.md
+++ b/website/prometheus-proxy/docs/monitoring.md
@@ -66,19 +66,32 @@ The same options are available under `agent.metrics`.
 
 **`proxy_scrape_requests` type labels:**
 
-| Value                   | Meaning                                          |
-|:------------------------|:-------------------------------------------------|
-| `success`               | Scrape completed successfully                    |
-| `timed_out`             | Agent did not respond within timeout             |
-| `no_agents`             | No agents registered for the requested path      |
-| `invalid_path`          | Requested path is empty or unrecognized          |
-| `agent_disconnected`    | Agent stream closed before response was received |
-| `missing_results`       | Internal error: results object was null          |
-| `path_not_found`        | Agent returned a non-200 status for the target   |
-| `payload_too_large`     | Unzipped content exceeded size limit             |
-| `invalid_gzip`          | Gzip decompression failed                        |
-| `proxy_not_running`     | Proxy is shutting down                           |
-| `invalid_agent_context` | All agents for the path are in an invalid state  |
+| Value                   | Meaning                                                             |
+|:------------------------|:---------------------------------------------------------------------|
+| `success`               | Scrape completed successfully                                       |
+| `timed_out`             | Agent did not answer within the proxy's `scrapeRequestTimeoutSecs`  |
+| `upstream_timed_out`    | Agent answered, but its own fetch of the target timed out (408/504) |
+| `no_agents`             | No agents registered for the requested path                         |
+| `invalid_path`          | Requested path is empty or unrecognized                             |
+| `agent_disconnected`    | Agent stream closed before response was received                    |
+| `missing_results`       | Internal error: results object was null                             |
+| `path_not_found`        | Agent has no registration for the target path (404)                 |
+| `upstream_error`        | Target returned a non-2xx status not covered above, e.g. 5xx        |
+| `content_too_large`     | Target response exceeded the agent's content-length limit (413)     |
+| `payload_too_large`     | Unzipped content exceeded the proxy's size limit                    |
+| `invalid_gzip`          | Gzip decompression failed                                           |
+| `proxy_not_running`     | Proxy is shutting down                                              |
+| `invalid_agent_context` | All agents for the path are in an invalid state                     |
+
+!!! tip "Proxy-side and agent-side pairs"
+
+    `timed_out` means the proxy gave up waiting on the agent; `upstream_timed_out` means the agent
+    answered promptly to report that the *target* was slow. Since `agent.scrapeTimeoutSecs` (15s)
+    is well under the proxy's `scrapeRequestTimeoutSecs` (90s), `upstream_timed_out` is the one you
+    will usually see for a slow endpoint.
+
+    Likewise `content_too_large` is the agent's `maxContentLengthMBytes` limit, while
+    `payload_too_large` is the proxy's unzip limit. Both surface as HTTP 413.
 
 ### Histograms
 

--- a/website/prometheus-proxy/docs/troubleshooting.md
+++ b/website/prometheus-proxy/docs/troubleshooting.md
@@ -20,8 +20,9 @@ Before diving into a specific symptom, gather signal:
    `curl -i http://<proxy-host>:8080/<path>` — the HTTP status code tells you a lot (see
    below).
 4. **Watch the outcome metric**: `proxy_scrape_requests` is labeled by `type`
-   (`success`, `timed_out`, `no_agents`, `path_not_found`, `payload_too_large`, …). Whichever
-   `type` is incrementing names the failure mode.
+   (`success`, `timed_out`, `upstream_timed_out`, `no_agents`, `path_not_found`, `upstream_error`,
+   `content_too_large`, `payload_too_large`, …). Whichever `type` is incrementing names the failure
+   mode; see [Monitoring](monitoring.md) for the full table.
 5. **Read the logs.** The proxy and agent log the reason for most rejections at WARN/INFO.
 
 ---
@@ -88,19 +89,27 @@ The path is known but cannot be served right now.
 
 The scrape body exceeded a configured size limit.
 
-- **Agent side:** raise `agent.http.maxContentLengthMBytes` (default `10`).
+- **Agent side:** raise `agent.http.maxContentLengthMBytes` (default `10`). Outcome label
+  `content_too_large`.
 - **Proxy side:** raise `proxy.internal.maxUnzippedContentSizeMBytes` (the decompressed-size
-  guard; `0` means "reject all").
-- The proxy outcome label for this is `payload_too_large`.
+  guard; `0` means "reject all"). Outcome label `payload_too_large`.
+- The two limits are independent and both surface as HTTP 413 — the outcome label tells you which
+  one rejected the scrape.
 
-### Scrape hangs, then `timed_out`
+### Scrape hangs, then times out
 
-The agent didn't return a response within the timeout.
+Check which timeout fired: `upstream_timed_out` means the agent answered promptly to report that
+the *target* was slow, while `timed_out` means the agent never answered the proxy at all. Because
+`scrapeTimeoutSecs` (15s) is well below the proxy's `scrapeRequestTimeoutSecs` (90s), a slow target
+normally shows up as `upstream_timed_out`.
 
-- The target endpoint is slow — raise the agent's `scrapeTimeoutSecs` (default `15`) and/or
-  `clientTimeoutSecs` (default `90`).
-- The agent is saturated — raise `maxConcurrentClients` (default `1`) so scrapes run in
-  parallel; watch `agent_scrape_backlog_size` and `proxy_cumulative_agent_backlog_size`.
+- **`upstream_timed_out`** — the target endpoint is slow. Raise the agent's `scrapeTimeoutSecs`
+  (default `15`) and/or `clientTimeoutSecs` (default `90`), or fix the target.
+- **`timed_out`** — the agent is unresponsive or the link to it is broken. Check the agent is still
+  connected (`proxy_connected_agents`) and raise `proxy.internal.scrapeRequestTimeoutSecs` only if
+  the agent legitimately needs longer than 90s.
+- Either can mean the agent is saturated — raise `maxConcurrentClients` (default `1`) so scrapes
+  run in parallel; watch `agent_scrape_backlog_size` and `proxy_cumulative_agent_backlog_size`.
 - See [Performance Tuning](advanced.md#performance-tuning).
 
 ---


### PR DESCRIPTION
Findings 3 and 4 from the multi-agent review of #198. They pair because #4 adds a label value that #3's tables need documenting anyway.

## Finding 4: two different faults shared one label

`upstreamErrorLabel` mapped an agent-reported 408/504 to `timed_out` — the same string `dispatchScrapeRequest` emits when the agent never answers the proxy at all:

| | Meaning | Remediation |
|---|---|---|
| proxy-side `timed_out` | agent never answered within `scrapeRequestTimeoutSecs` | raise proxy timeout / fix the agent link |
| agent-side 408/504 | agent answered promptly; its *own* fetch exceeded `scrapeTimeoutSecs` | raise agent scrape timeout / fix the slow target |

Both fed `proxy_scrape_requests{type}` and the latency histogram's outcome label with nothing else to separate them. This isn't an edge case: stock config is `agent.scrapeTimeoutSecs = 15` vs `proxy.internal.scrapeRequestTimeoutSecs = 90`, so a slow target always trips the agent first — the agent-side leg was the *dominant* contributor, and the common case was hidden behind the rare one.

**Fix:** 408/504 now map to `upstream_timed_out`, matching the `content_too_large` / `payload_too_large` convention finding 10 already established for the two halves of a 413.

The proxy-side literal became the `PROXY_TIMEOUT_LABEL` constant, and the new test asserts the two labels differ *by referencing that constant* rather than a duplicated string — so they can't silently converge again if someone edits one side.

Note this is an improvement, not a regression fix: pre-#198 the agent-side 408 was labeled `path_not_found`, which was actively misleading, so #198 already improved the signal. This finishes the job.

## Finding 3: the label tables were never updated

When finding 10 landed in #198 it changed the `type` label for every non-2xx upstream response but left the docs untouched:

- `docs/metrics-and-grafana.md` and `website/prometheus-proxy/docs/monitoring.md` both still read `path_not_found | Agent returned a non-200 status for the target` — false for every status except 404.
- `upstream_error` and `content_too_large` appeared in **no** operator-facing doc; a repo-wide grep found them only in the internal review file.
- `timed_out`'s description covered only the proxy-side half.
- `troubleshooting.md` enumerated the old label set.

Both tables are now correct and gained the new values, plus an explicit note on the proxy-side/agent-side pairs (`timed_out`/`upstream_timed_out`, `payload_too_large`/`content_too_large`) since that distinction is what tells an operator where to look. The troubleshooting timeout section is reworked along the same split.

### One extra change worth reviewing

I widened the `ProxyPayloadTooLarge` alert in `grafana.md` to `type=~"payload_too_large|content_too_large"`. Its summary claims to cover "exceeding the size limit" but it only ever matched the proxy-side half — the agent-side rejection was never alerted on. Strictly this is beyond the two findings; it was inconsistent to document the pair and leave the alert covering one. Easy to drop if you'd rather keep this PR narrow.

## Verification

- Both label assertions failed first (`expected:<upstream_timed_out> but was:<timed_out>`), then passed after the mapping change.
- Full `./gradlew test` — BUILD SUCCESSFUL (5m17s); `detekt` + `lintKotlinMain` + `lintKotlinTest` clean.
- Audited every remaining `timed_out` reference in `src/`: all refer to the proxy-side path and are still correct.
- No inbound links to the renamed troubleshooting heading.
- `CHANGELOG.md` / `RELEASE_NOTES.md` mention the old taxonomy but are historical records of shipped releases, so left alone.

## Operator impact

`upstream_timed_out` is a new label value. Dashboards or alerts matching `type="timed_out"` will stop counting agent-side scrape timeouts, which in a typical deployment is most of them. Anything wanting both should use `type=~"timed_out|upstream_timed_out"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)