### PR TITLE
Record the metric-filter cleanup in the as-built notes and document the attach signal

### DIFF
--- a/docs/FEATURE_PROPOSALS_JULY_2026.md
+++ b/docs/FEATURE_PROPOSALS_JULY_2026.md
@@ -495,22 +495,53 @@ rule copied from a Prometheus `relabel_config` behaves identically at the agent.
 the family name, so a histogram's `_bucket`/`_sum`/`_count` series (and OpenMetrics's `_total` /
 `_created` / `_gsum` / `_gcount` / `_info` suffixes) are kept or dropped as a unit. Deny is evaluated
 after allow. A non-text payload (e.g. protobuf) or a body that fails strict UTF-8 decoding passes
-through unfiltered and byte-exact rather than risk corrupting it — both fail open with a once-per-path
-warning, an additional guard added during review alongside the `# UNIT` handling above.
+through unfiltered and byte-exact rather than risk corrupting it — both fail open, each warning once
+per filter instance, an additional guard added during review alongside the `# UNIT` handling above. A
+fail-open scrape records no filter metrics at all, which is deliberately distinguishable from a filter
+that ran and happened to drop nothing.
 
 **Scope (unchanged from the MVP cut below).** `dropLabels`, full relabeling, and an agent-global filter
 remain unimplemented, matching the proposal's original MVP boundary and Open Questions.
 
-**Files.** New `agent/filter/MetricFilter.kt`. Modified: `AgentPathManager` (compiles and attaches a
-filter per path at registration time, keyed by path so it applies to both static `pathConfigs` and
-Feature 1 discovered paths), `AgentHttpService` (applies the filter before the gzip/chunk decision),
-`AgentMetrics` (`agent_filter_lines_dropped` / `agent_filter_bytes_saved` counters), `config/config.conf`
-and `reference.conf`.
+**Files.** New `agent/filter/MetricFilter.kt` — owns both the line filtering and the payload-level
+policy wrapped around it (`filterBytes()`: the filterable-content-type gate, the strict UTF-8 decode,
+the two fail-open branches, and their warn latches). Modified: `AgentPathManager` (compiles and
+attaches a filter per path at registration time, keyed by path so it applies to both static
+`pathConfigs` and Feature 1 discovered paths, and reports in the registration log whether one
+attached), `AgentHttpService` (calls `filterBytes()` before the gzip/chunk decision and records the
+counters), `AgentMetrics` (`agent_filter_lines_dropped` / `agent_filter_bytes_saved` counters),
+`config/config.conf` and `reference.conf`.
+
+**Post-merge cleanup (diverged from the first cut).** A quality pass after the feature landed moved
+two things and deleted a third; the descriptions above reflect the result:
+
+- **Filter policy moved behind the filter.** The content-type gate, decode, and fail-open handling
+  were originally a ~50-line branch ladder inlined in `AgentHttpService.buildScrapeResults`. They now
+  sit in `MetricFilter.filterBytes()`, so the exposition-format assumptions live in one file. The two
+  warn-once latches moved with them: they were path-keyed `ConcurrentHashMap` sets in
+  `AgentHttpService` that nothing ever removed from, so with Feature 1's reconcile loop churning paths
+  they grew without bound. They are now `AtomicBoolean`s on the filter instance, which is already 1:1
+  with a path and is reclaimed with it.
+- **`filterText()` scans by index.** The first cut split the payload on `'\n'`, materializing one
+  `String` per line plus the backing list before judging anything — on a multi-megabyte body, tens of
+  MB of garbage per scrape, per filtered path. It now scans the source string by index and appends
+  ranges directly; family membership is compared in place, so a sample line belonging to the open
+  family allocates nothing, and a family's `HELP`/`TYPE`/`UNIT` lines no longer each re-run every
+  regex.
+- **The startup filter/path cross-check was deleted.** It warned when a configured filter path matched
+  no `pathConfigs` entry, but `pathConfigs` is only the static baseline available at construction time
+  — discovered and runtime-registered paths arrive later and were reported as unmatched, which is why
+  it had to sit at debug behind a comment explaining when to ignore it. The signal now comes from
+  `doRegisterPath`, where the filter for a path is actually resolved: the registration log says whether
+  one attached. Correct for all three path sources, and visible at info.
 
 **Tests.** `MetricFilterTest` (anchoring, family scoping, HELP/TYPE/UNIT handling), filter-compilation
-and path-typo-warning cases in `AgentPathManagerTest`, filter-ordering and fail-open cases in
-`AgentHttpServiceTest`, and the Netty-transport harness test `AgentMetricFilterTest` exercising
-per-path filtering end-to-end.
+and registration-log attachment cases in `AgentPathManagerTest` (including a discovered path — the case
+no construction-time cross-check could reach), filter-ordering, fail-open, and
+`isFilterableContentType` truth-table cases in `AgentHttpServiceTest`, and the Netty-transport harness
+test `AgentMetricFilterTest` exercising per-path filtering end-to-end. The content-type cases still
+live in `AgentHttpServiceTest` for history even though the function under test moved to `MetricFilter`;
+relocating them to `MetricFilterTest` is a loose end.
 
 ### Motivation
 

--- a/website/prometheus-proxy/docs/configuration/agent.md
+++ b/website/prometheus-proxy/docs/configuration/agent.md
@@ -253,6 +253,19 @@ Filters apply by path to both statically configured paths and paths added by
 of which route registered it. An invalid regex fails agent startup rather than surfacing later at
 scrape time.
 
+!!! tip "Confirming a filter attached"
+
+    A filter whose `path` does not match a registered path is otherwise silent — it simply never runs.
+    The agent's registration log line for each path reports whether one attached:
+
+    ```text
+    Registered http://app1:9090/metrics as /app1_metrics with labels {} (static) with a metric filter
+    ```
+
+    If the line for your path does not end with `with a metric filter`, the `path` in your `filters`
+    entry does not match the registered path. The `agent_filter_*` counters below are the other way to
+    tell: they are only ever created for paths whose filter actually ran.
+
 Two counters, both labeled by `launch_id` and `path`, track filtering and are only created for paths
 that actually have a filter configured:
 


### PR DESCRIPTION
Docs-only follow-up to #221. The Feature 4 as-built notes described the first cut of the feature, before the post-merge quality pass moved things around.

## `docs/FEATURE_PROPOSALS_JULY_2026.md`

- **Files** — `MetricFilter` now owns `filterBytes()` (the content-type gate, strict UTF-8 decode, fail-open branches, and warn latches); `AgentHttpService` is reduced to calling it. `AgentPathManager` reports filter attachment in the registration log.
- **Matching** — corrected "once-per-path warning" to once per filter instance, and added that a fail-open scrape records no filter metrics at all, which is deliberately distinguishable from a filter that ran and dropped nothing.
- **New "Post-merge cleanup" subsection** recording the three divergences from the first cut and why each was made: the policy move (including why the path-keyed warn sets grew without bound under Feature 1's reconcile loop), the switch to index-based scanning in `filterText()`, and the deletion of the startup filter/path cross-check.
- **Tests** — replaced the now-inaccurate "path-typo-warning cases" with the registration-log attachment cases, and flagged that the `isFilterableContentType` tests still live in `AgentHttpServiceTest` though the function moved to `MetricFilter`.

## `website/prometheus-proxy/docs/configuration/agent.md`

Added a "Confirming a filter attached" tip — the operator-facing consequence of deleting the startup cross-check. A filter whose `path` doesn't match a registered path is otherwise silent, so the doc shows the exact registration log line and explains what its absence means. The example string was verified against the source.

## Unchanged on purpose

README and the `agent.md` fail-open note describe user-visible behavior, which did not change — "logs a warning once per path" still holds, since the filter instance the latch moved onto is 1:1 with a path. CHANGELOG and RELEASE_NOTES describe config surface and matching semantics, both untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)