### PR TITLE
Use kotlin.concurrent.atomics.AtomicBoolean in MetricFilter

### DIFF
--- a/src/main/kotlin/io/prometheus/agent/filter/MetricFilter.kt
+++ b/src/main/kotlin/io/prometheus/agent/filter/MetricFilter.kt
@@ -18,7 +18,7 @@ package io.prometheus.agent.filter
 
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import java.nio.charset.CharacterCodingException
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
 
 /**
  * Outcome of filtering one scraped payload.
@@ -92,7 +92,7 @@ internal class MetricFilter private constructor(
     contentType: String,
   ): FilterOutcome? {
     if (!isFilterableContentType(contentType)) {
-      if (contentTypeWarned.compareAndSet(false, true))
+      if (contentTypeWarned.compareAndSet(expectedValue = false, newValue = true))
         logger.warn { "Skipping metric filter for /$path: content type \"$contentType\" is not text" }
       return null
     }
@@ -109,7 +109,7 @@ internal class MetricFilter private constructor(
         null
       }
     if (decoded == null) {
-      if (invalidUtf8Warned.compareAndSet(false, true))
+      if (invalidUtf8Warned.compareAndSet(expectedValue = false, newValue = true))
         logger.warn { "Skipping metric filter for /$path: response body is not valid UTF-8" }
       return null
     }


### PR DESCRIPTION
## Summary

Replaces the last direct `java.util.concurrent.atomic` usage in production code with the Kotlin equivalent, so `MetricFilter` matches the atomics idiom used everywhere else in the codebase.

- Import swapped from `java.util.concurrent.atomic.AtomicBoolean` to `kotlin.concurrent.atomics.AtomicBoolean`
- Both fail-open latches now call `compareAndSet(expectedValue = false, newValue = true)`, matching the named-argument style already used in `ProxyHttpRoutes.kt`

Semantics are unchanged — the Kotlin `compareAndSet` returns the same boolean-success signal, so the content-type and invalid-UTF-8 warnings still latch on first trip. The `ExperimentalAtomicApi` opt-in was already set project-wide in `build.gradle.kts`.

The one remaining `java.util.concurrent.atomic` reference in the repo is an intentional interop cast in `AgentGrpcServiceTest`, which reflects into the `AtomicDelegates` library's internal field and must match that library's Java type.

## Test plan

- `./gradlew detekt lintKotlinMain build -x test` — passes
- `./gradlew test --tests "*MetricFilter*"` — `MetricFilterTest` and `AgentMetricFilterTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)