### PR TITLE
Fix dashboard accessibility and identify agents by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,12 @@ website/**/.cache/
 .github/hooks/
 
 # Per-machine state under .impeccable/, which is otherwise a tracked output directory:
-# config.local.json records one developer's hook consent, and live/sessions/ is an append-only
-# recovery journal for an in-progress editing session. Neither describes the project.
+# config.local.json records one developer's hook consent, live/sessions/ is an append-only
+# recovery journal for an in-progress editing session, and the hook.* files are its scratch
+# state -- keyed by session id and holding absolute paths from one machine. None of it
+# describes the project. The tooling also writes these into .git/info/exclude, but that file
+# is local to a single clone, so the rules are duplicated here to cover everyone else's.
 .impeccable/config.local.json
 .impeccable/live/sessions/
+.impeccable/hook.cache.json
+.impeccable/hook.pending.json

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ website/**/.cache/
 .claude/settings.local.json
 .github/skills/
 .github/hooks/
+
+# Per-machine state under .impeccable/, which is otherwise a tracked output directory:
+# config.local.json records one developer's hook consent, and live/sessions/ is an append-only
+# recovery journal for an in-progress editing session. Neither describes the project.
+.impeccable/config.local.json
+.impeccable/live/sessions/

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,15 @@ __pycache__/
 ### Zensical build output ###
 website/**/site/
 website/**/.cache/
+
+### Agent tooling ###
+# Vendored third-party skills and their hooks. Project-authored skills under .claude/skills/
+# (docs-site, publishing-release) ARE tracked -- they describe how to build this project.
+# Installed general-purpose tooling is not: it is upstream code that would land as a 100+ file
+# diff on every release, it is installed twice for two agent harnesses, and its hook executes
+# on every edit for anyone who clones. The durable output it produces -- DESIGN.md, PRODUCT.md,
+# .impeccable/design.json -- is tracked instead, and is what a compatible harness actually reads.
+.claude/skills/impeccable/
+.claude/settings.local.json
+.github/skills/
+.github/hooks/

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,428 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-29T04:48:00Z",
+  "title": "Design System: prometheus-proxy Dashboard",
+  "extensions": {
+    "colorMeta": {
+      "accent": {
+        "role": "primary",
+        "displayName": "Burnt Orange",
+        "canonical": "#c8461f",
+        "dark": "#ff7043",
+        "note": "Used in exactly two places: focus-visible outlines and the 3px left edge of the current row. Never fills a surface.",
+        "tonalRamp": [
+          "oklch(0.15 0.06 40)",
+          "oklch(0.26 0.10 40)",
+          "oklch(0.37 0.14 40)",
+          "oklch(0.48 0.16 40)",
+          "oklch(0.59 0.17 40)",
+          "oklch(0.70 0.15 40)",
+          "oklch(0.81 0.10 40)",
+          "oklch(0.92 0.05 40)"
+        ]
+      },
+      "ok": {
+        "role": "tertiary",
+        "displayName": "Live Green",
+        "canonical": "#1a7a42",
+        "dark": "#3fb950",
+        "note": "Valid-agent LED, healthy beacon, 2xx pill text, healthy status counters. 4.71:1 on ok-soft, 5.38:1 on surface.",
+        "tonalRamp": [
+          "oklch(0.15 0.05 152)",
+          "oklch(0.26 0.08 152)",
+          "oklch(0.37 0.11 152)",
+          "oklch(0.48 0.13 152)",
+          "oklch(0.59 0.14 152)",
+          "oklch(0.70 0.13 152)",
+          "oklch(0.81 0.09 152)",
+          "oklch(0.92 0.05 152)"
+        ]
+      },
+      "ok-soft": {
+        "role": "tertiary",
+        "displayName": "Live Green Wash",
+        "canonical": "#e3f4ea",
+        "dark": "#12251a",
+        "note": "Backs the 2xx pill and nothing else. Never a row or region background."
+      },
+      "warn": {
+        "role": "tertiary",
+        "displayName": "Drift Amber",
+        "canonical": "#8a5d08",
+        "dark": "#d29922",
+        "note": "True-but-not-yet-failing conditions: the 'failed over' tag, counters near threshold. Has no LED form. 5.07:1 on warn-soft, 5.75:1 on surface.",
+        "tonalRamp": [
+          "oklch(0.15 0.04 70)",
+          "oklch(0.26 0.07 70)",
+          "oklch(0.37 0.10 70)",
+          "oklch(0.48 0.11 70)",
+          "oklch(0.59 0.12 70)",
+          "oklch(0.70 0.12 70)",
+          "oklch(0.81 0.09 70)",
+          "oklch(0.92 0.05 70)"
+        ]
+      },
+      "warn-soft": {
+        "role": "tertiary",
+        "displayName": "Drift Amber Wash",
+        "canonical": "#f9f0da",
+        "dark": "#2a2110",
+        "note": "Backs the 'failed over' tag only."
+      },
+      "crit": {
+        "role": "tertiary",
+        "displayName": "Fault Red",
+        "canonical": "#c02a20",
+        "dark": "#f85149",
+        "note": "Invalid-agent LED, disconnected beacon, non-2xx pill, 'gone' tag, departed rows, disconnected empty state.",
+        "tonalRamp": [
+          "oklch(0.15 0.07 28)",
+          "oklch(0.26 0.11 28)",
+          "oklch(0.37 0.16 28)",
+          "oklch(0.48 0.19 28)",
+          "oklch(0.59 0.19 28)",
+          "oklch(0.70 0.16 28)",
+          "oklch(0.81 0.11 28)",
+          "oklch(0.92 0.05 28)"
+        ]
+      },
+      "crit-soft": {
+        "role": "tertiary",
+        "displayName": "Fault Red Wash",
+        "canonical": "#fbe6e4",
+        "dark": "#2d1512",
+        "note": "Backs non-2xx pills and the 'gone' tag."
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "#131820",
+        "dark": "#e7ebf1",
+        "note": "Primary text. Anchors the whole cool blue-grey neutral family — bg, surface, line and ink are all steps of this one ramp.",
+        "tonalRamp": [
+          "oklch(0.15 0.020 255)",
+          "oklch(0.26 0.020 255)",
+          "oklch(0.37 0.018 255)",
+          "oklch(0.48 0.016 255)",
+          "oklch(0.59 0.014 255)",
+          "oklch(0.70 0.012 255)",
+          "oklch(0.81 0.010 255)",
+          "oklch(0.92 0.008 255)"
+        ]
+      },
+      "ink-2": {
+        "role": "neutral",
+        "displayName": "Ink Secondary",
+        "canonical": "#48525f",
+        "dark": "#a4aebc",
+        "note": "Neutral tag text. Used sparingly."
+      },
+      "ink-3": {
+        "role": "neutral",
+        "displayName": "Ink Tertiary",
+        "canonical": "#626b77",
+        "dark": "#858f9d",
+        "note": "Metadata, timestamps, hostnames, engraved labels, dimmed table columns, empty-state copy. Measured 4.59:1 on surface-2 and 5.40:1 on surface (light); 4.88:1 / 5.37:1 dark. surface-2 is the binding ground -- it sits under every table and section header and is a full tonal step tighter than the reading plane."
+      },
+      "bg": {
+        "role": "neutral",
+        "displayName": "Cold Paper",
+        "canonical": "#f2f5f8",
+        "dark": "#0d1015",
+        "note": "Page ground. Sits just behind the reading plane in light mode; the darkest value in dark mode."
+      },
+      "surface": {
+        "role": "neutral",
+        "displayName": "Reading Plane",
+        "canonical": "#ffffff",
+        "dark": "#151a21",
+        "note": "Where content is read carefully: detail pane, table body, top bar."
+      },
+      "surface-2": {
+        "role": "neutral",
+        "displayName": "Recessed Plane",
+        "canonical": "#e9edf2",
+        "dark": "#1c222b",
+        "note": "Agent list, section headers, sticky table headers. Always away from the reading plane in contrast."
+      },
+      "surface-3": {
+        "role": "neutral",
+        "displayName": "Pressed Plane",
+        "canonical": "#dde3ea",
+        "dark": "#242c37",
+        "note": "Furthest step from the reading plane: row hover, neutral tag fill, active nav pill."
+      },
+      "line": {
+        "role": "neutral",
+        "displayName": "Structural Rule",
+        "canonical": "#cfd7e0",
+        "dark": "#2b333f",
+        "note": "1px hairline between regions — bar from body, list from detail."
+      },
+      "line-soft": {
+        "role": "neutral",
+        "displayName": "Soft Rule",
+        "canonical": "#e3e9ef",
+        "dark": "#212934",
+        "note": "1px hairline between rows within a region. Always lower contrast than line, so structure resolves before content."
+      }
+    },
+    "typographyMeta": {
+      "title": {
+        "displayName": "Title",
+        "purpose": "The agent name in the detail hero. The largest text on the surface; weight 640 sits deliberately between regular and bold."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "The base. Agent names, paths, table cells, kv labels — nearly everything."
+      },
+      "body-emphasis": {
+        "displayName": "Body Emphasis",
+        "purpose": "Brand mark and active nav link. Weight carries the difference, not size."
+      },
+      "meta": {
+        "displayName": "Meta",
+        "purpose": "Hero metadata strip, failover line, status bar, and the second line of an agent row. One role: an earlier 11px step for the agent row did the same job half a pixel apart."
+      },
+      "badge": {
+        "displayName": "Badge",
+        "purpose": "Status-code pills. The only place a number is bolded."
+      },
+      "label": {
+        "displayName": "Engraved Label",
+        "purpose": "Section, list, and table column headers. Uppercase at 0.09em — letterspacing does the work a rule or heavier weight would otherwise do."
+      },
+      "micro": {
+        "displayName": "Micro",
+        "purpose": "Tag text only. Shares the Label size but stays 400-weight, mixed case, normal spacing — a tag reports a fact about one row, not a column heading."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "beacon-pulse",
+        "value": "pulse 2.4s ease-out infinite",
+        "purpose": "Healthy connection beacon. Fades between full and 40% opacity — slow enough to read as breathing rather than flashing."
+      },
+      {
+        "name": "beacon-blink",
+        "value": "blink 1s steps(2, start) infinite",
+        "purpose": "Disconnected beacon. Snaps between full and 25% opacity; steps(2) prevents any fade, so it reads as effort rather than decay."
+      },
+      {
+        "name": "reduced-motion",
+        "value": "@media (prefers-reduced-motion: reduce) { animation: none }",
+        "purpose": "Both beacon animations disable. Color and label still carry the full signal."
+      },
+      {
+        "name": "no-transition",
+        "value": "none",
+        "purpose": "The system defines zero CSS transitions. Hover, selection, and live swaps land instantly — an assertion that nothing is being waited on."
+      },
+      {
+        "name": "ws-reconnect-backoff",
+        "value": "min(500 * 2^n, 2000) + random() * 250",
+        "purpose": "Not CSS, but a felt-timing decision: replaces htmx-ext-ws full-jitter backoff (1s→64s) so a LAN dashboard recovers in ~2s instead of sitting dead after the proxy is already back."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "stack",
+        "value": "720px"
+      },
+      {
+        "name": "touch",
+        "value": "(pointer: coarse)"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Agent Row Item",
+      "kind": "custom",
+      "refersTo": "row-item",
+      "description": "Full-width list row rendered as a real button, so it is keyboard-operable by construction. Shown at rest and in the current state.",
+      "html": "<div class=\"ds-rows\"><button class=\"ds-row\"><span><span class=\"ds-led ds-led-ok\"></span>agent-us-east-1</span><span class=\"ds-row-sub\">10.4.2.19:41022 &middot; 6 paths</span></button><button class=\"ds-row\" aria-current=\"true\"><span><span class=\"ds-led ds-led-ok\"></span>agent-eu-west-2</span><span class=\"ds-row-sub\">10.9.1.7:52880 &middot; 3 paths</span></button><button class=\"ds-row\"><span><span class=\"ds-led ds-led-crit\"></span>(registering&hellip;)</span><span class=\"ds-row-sub\">10.4.2.31:38104 &middot; 0 paths</span></button></div>",
+      "css": ".ds-rows { --surface:#fff; --surface-2:#e9edf2; --surface-3:#dde3ea; --line-soft:#e3e9ef; --ink:#131820; --ink-3:#626b77; --accent:#c8461f; --ok:#1a7a42; --crit:#c02a20; --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; background:var(--surface-2); width:262px; font-family:var(--mono); font-size:12.5px; line-height:1.5; } @media (prefers-color-scheme: dark) { .ds-rows { --surface:#151a21; --surface-2:#1c222b; --surface-3:#242c37; --line-soft:#212934; --ink:#e7ebf1; --ink-3:#858f9d; --accent:#ff7043; --ok:#3fb950; --crit:#f85149; } } .ds-row { display:block; width:100%; text-align:left; font:inherit; cursor:pointer; background:none; border:0; border-bottom:1px solid var(--line-soft); border-left:3px solid transparent; padding:10px 15px; color:var(--ink); } .ds-row:hover { background:var(--surface-3); } .ds-row:focus-visible { outline:2px solid var(--accent); outline-offset:-2px; } .ds-row[aria-current=\"true\"] { background:var(--surface); border-left-color:var(--accent); } .ds-row-sub { display:block; color:var(--ink-3); font-size:11.5px; margin-top:2px; } .ds-led { display:inline-block; width:7px; height:7px; border-radius:50%; margin-right:7px; } .ds-led-ok { background:var(--ok); } .ds-led-crit { background:var(--crit); }"
+    },
+    {
+      "name": "Status Pill — OK",
+      "kind": "chip",
+      "refersTo": "pill-ok",
+      "description": "A 2xx scrape result. Renders the literal status code — never 'Success', never an icon.",
+      "html": "<span class=\"ds-pill-ok\">200</span>",
+      "css": ".ds-pill-ok { --ok:#1a7a42; --ok-soft:#e3f4ea; font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:10.5px; font-weight:600; line-height:1.5; padding:2px 7px; border-radius:20px; background:var(--ok-soft); color:var(--ok); } @media (prefers-color-scheme: dark) { .ds-pill-ok { --ok:#3fb950; --ok-soft:#12251a; } }"
+    },
+    {
+      "name": "Status Pill — Critical",
+      "kind": "chip",
+      "refersTo": "pill-crit",
+      "description": "Any non-2xx scrape result. The only other pill variant that exists.",
+      "html": "<span class=\"ds-pill-crit\">503</span>",
+      "css": ".ds-pill-crit { --crit:#c02a20; --crit-soft:#fbe6e4; font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:10.5px; font-weight:600; line-height:1.5; padding:2px 7px; border-radius:20px; background:var(--crit-soft); color:var(--crit); } @media (prefers-color-scheme: dark) { .ds-pill-crit { --crit:#f85149; --crit-soft:#2d1512; } }"
+    },
+    {
+      "name": "Tag",
+      "kind": "chip",
+      "refersTo": "tag",
+      "description": "Micro-type capsule in three variants: neutral (consolidated), warn (failed over), crit (gone). Deliberately not the uppercase Label treatment despite the shared 10px size. Warning is a tag here rather than an LED — see The No Amber Dot Rule.",
+      "html": "<span class=\"ds-tags\"><span class=\"ds-tag\">consolidated</span><span class=\"ds-tag ds-tag-warn\">failed over</span><span class=\"ds-tag ds-tag-crit\">gone</span></span>",
+      "css": ".ds-tags { --surface-3:#dde3ea; --ink-2:#48525f; --warn:#8a5d08; --warn-soft:#f9f0da; --crit:#c02a20; --crit-soft:#fbe6e4; display:inline-flex; gap:7px; align-items:center; } @media (prefers-color-scheme: dark) { .ds-tags { --surface-3:#242c37; --ink-2:#a4aebc; --warn:#d29922; --warn-soft:#2a2110; --crit:#f85149; --crit-soft:#2d1512; } } .ds-tag { font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:10px; font-weight:400; line-height:1.5; background:var(--surface-3); color:var(--ink-2); padding:2px 7px; border-radius:20px; } .ds-tag-warn { background:var(--warn-soft); color:var(--warn); } .ds-tag-crit { background:var(--crit-soft); color:var(--crit); }"
+    },
+    {
+      "name": "Connection Beacon",
+      "kind": "custom",
+      "refersTo": "led-ok",
+      "description": "The signature component and the only animated element in the system. Severity is carried by a change of tempo — calm 2.4s pulse when live, hard 1s stepped blink when reconnecting — alongside color and a swapped label. Both states shown.",
+      "html": "<div class=\"ds-beacons\"><span class=\"ds-conn\"><span class=\"ds-beacon\"></span>live</span><span class=\"ds-conn ds-conn-down\"><span class=\"ds-beacon\"></span>reconnecting&hellip;</span></div>",
+      "css": ".ds-beacons { --surface:#fff; --ok:#1a7a42; --crit:#c02a20; display:flex; gap:24px; align-items:center; background:var(--surface); padding:11px 15px; font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:11.5px; line-height:1.5; } @media (prefers-color-scheme: dark) { .ds-beacons { --surface:#151a21; --ok:#3fb950; --crit:#f85149; } } .ds-conn { display:inline-flex; align-items:center; gap:6px; color:var(--ok); } .ds-beacon { width:7px; height:7px; border-radius:50%; background:var(--ok); animation:ds-pulse 2.4s ease-out infinite; } .ds-conn-down { color:var(--crit); } .ds-conn-down .ds-beacon { background:var(--crit); animation:ds-blink 1s steps(2, start) infinite; } @keyframes ds-pulse { 0%{opacity:1} 70%{opacity:.4} 100%{opacity:1} } @keyframes ds-blink { 0%{opacity:1} 50%{opacity:.25} 100%{opacity:1} } @media (prefers-reduced-motion: reduce) { .ds-beacon, .ds-conn-down .ds-beacon { animation:none } }"
+    },
+    {
+      "name": "Section Header",
+      "kind": "custom",
+      "refersTo": "section-label",
+      "description": "Engraved micro-label with a bare count on the right. The count is never decorated — no pill, no parentheses, no unit noun.",
+      "html": "<div class=\"ds-section\"><span>Registered paths</span><span>6</span></div>",
+      "css": ".ds-section { --surface-2:#e9edf2; --line:#cfd7e0; --ink-3:#626b77; display:flex; justify-content:space-between; padding:9px 15px; font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:10px; letter-spacing:0.09em; text-transform:uppercase; color:var(--ink-3); font-weight:600; line-height:1.5; border-bottom:1px solid var(--line); background:var(--surface-2); } @media (prefers-color-scheme: dark) { .ds-section { --surface-2:#1c222b; --line:#2b333f; --ink-3:#858f9d; } }"
+    },
+    {
+      "name": "Path Table",
+      "kind": "custom",
+      "refersTo": "table-cell",
+      "description": "The second signature component. Flat by design — no selection, no drill-in; the row is the answer. Sticky engraved header, tabular numerals, nowrap cells inside their own horizontal scroller, and a departed row that stays visible with a 'gone' tag rather than disappearing.",
+      "html": "<div class=\"ds-scroller\"><table class=\"ds-ptable\"><thead><tr><th>Path</th><th>Agent(s)</th><th>Target</th><th>Src</th><th>Last scrape</th><th class=\"ds-num\">Status</th><th class=\"ds-num\">Duration</th></tr></thead><tbody><tr><td>/checkout</td><td>agent-us-east-1</td><td class=\"ds-dim\">http://10.4.2.19:9100/metrics</td><td class=\"ds-dim\">cfg</td><td class=\"ds-dim\">14:22:07</td><td class=\"ds-num\"><span class=\"ds-pill-ok\">200</span></td><td class=\"ds-num ds-dim\">41 ms</td></tr><tr><td>/ledger</td><td>agent-eu-west-2</td><td class=\"ds-dim\">http://10.9.1.7:9100/metrics</td><td class=\"ds-dim\">disc</td><td class=\"ds-dim\">14:22:06</td><td class=\"ds-num\"><span class=\"ds-pill-crit\">503</span></td><td class=\"ds-num ds-dim\">1204 ms</td></tr><tr class=\"ds-departed\"><td>/warehouse</td><td>agent-ap-south-1<span class=\"ds-tag-crit-inline\">gone</span></td><td class=\"ds-dim\">&ndash;</td><td class=\"ds-dim\">cfg</td><td class=\"ds-dim\">14:19:52</td><td class=\"ds-num\"><span class=\"ds-pill-ok\">200</span></td><td class=\"ds-num ds-dim\">88 ms</td></tr></tbody></table></div>",
+      "css": ".ds-scroller { --surface:#fff; --surface-2:#e9edf2; --line:#cfd7e0; --line-soft:#e3e9ef; --ink:#131820; --ink-3:#626b77; --ok:#1a7a42; --ok-soft:#e3f4ea; --crit:#c02a20; --crit-soft:#fbe6e4; overflow-x:auto; background:var(--surface); font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:12.5px; line-height:1.5; color:var(--ink); } @media (prefers-color-scheme: dark) { .ds-scroller { --surface:#151a21; --surface-2:#1c222b; --line:#2b333f; --line-soft:#212934; --ink:#e7ebf1; --ink-3:#858f9d; --ok:#3fb950; --ok-soft:#12251a; --crit:#f85149; --crit-soft:#2d1512; } } .ds-ptable { width:100%; border-collapse:collapse; white-space:nowrap; } .ds-ptable th { text-align:left; font-size:10px; letter-spacing:0.09em; text-transform:uppercase; color:var(--ink-3); font-weight:600; padding:9px 15px; background:var(--surface-2); border-bottom:1px solid var(--line); position:sticky; top:0; } .ds-ptable td { padding:8px 15px; border-bottom:1px solid var(--line-soft); } .ds-ptable .ds-num { text-align:right; font-variant-numeric:tabular-nums; } .ds-ptable .ds-dim { color:var(--ink-3); } .ds-ptable tr:hover td { background:var(--surface-2); } .ds-ptable tr.ds-departed td:first-child { color:var(--crit); } .ds-tag-crit-inline { font-size:10px; font-weight:400; background:var(--crit-soft); color:var(--crit); padding:2px 7px; border-radius:20px; margin-left:7px; } .ds-ptable .ds-pill-ok { font-size:10.5px; font-weight:600; padding:2px 7px; border-radius:20px; background:var(--ok-soft); color:var(--ok); } .ds-ptable .ds-pill-crit { font-size:10.5px; font-weight:600; padding:2px 7px; border-radius:20px; background:var(--crit-soft); color:var(--crit); }"
+    },
+    {
+      "name": "Navigation",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Two pill-shaped links switching between the agent and path layouts. Real navigation, not a swap — both layouts are bookmarkable URLs. Focus ring sits outside the pill, unlike the full-bleed row.",
+      "html": "<nav class=\"ds-nav\"><a href=\"#\" class=\"ds-nav-link ds-on\" aria-current=\"page\">Agents</a><a href=\"#\" class=\"ds-nav-link\">Paths</a></nav>",
+      "css": ".ds-nav { --surface:#fff; --surface-3:#dde3ea; --ink:#131820; --ink-3:#626b77; --accent:#c8461f; display:flex; gap:4px; background:var(--surface); padding:11px 15px; font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:12.5px; line-height:1.5; } @media (prefers-color-scheme: dark) { .ds-nav { --surface:#151a21; --surface-3:#242c37; --ink:#e7ebf1; --ink-3:#858f9d; --accent:#ff7043; } } .ds-nav-link { color:var(--ink-3); text-decoration:none; padding:3px 10px; border-radius:20px; } .ds-nav-link:hover { background:var(--surface-3); color:var(--ink); } .ds-nav-link:focus-visible { outline:2px solid var(--accent); outline-offset:1px; } .ds-nav-link.ds-on { background:var(--surface-3); color:var(--ink); font-weight:600; }"
+    },
+    {
+      "name": "Empty State",
+      "kind": "custom",
+      "refersTo": "empty-state",
+      "description": "A plain sentence in ink-3 — no illustration, no icon, no call to action. The 'gone' variant renders in crit: when state disappears the interface says so rather than freezing or going blank.",
+      "html": "<div class=\"ds-empties\"><div class=\"ds-empty ds-pad\">Select an agent to see its paths and recent scrapes</div><div class=\"ds-empty ds-pad ds-gone\">Agent 7f3a91c2 is no longer connected</div></div>",
+      "css": ".ds-empties { --surface:#fff; --line-soft:#e3e9ef; --ink-3:#626b77; --crit:#c02a20; background:var(--surface); font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace; font-size:12.5px; line-height:1.5; } @media (prefers-color-scheme: dark) { .ds-empties { --surface:#151a21; --line-soft:#212934; --ink-3:#858f9d; --crit:#f85149; } } .ds-empty { color:var(--ink-3); padding:14px 15px; } .ds-empty.ds-pad { padding:22px 18px; } .ds-empty.ds-gone { color:var(--crit); } .ds-empty + .ds-empty { border-top:1px solid var(--line-soft); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Terminal, Grown Up",
+    "overview": "This is a terminal that kept its honesty and gained a spine. Monospace is not a style choice here — it is the operator's native tongue, the same face they read logs, configs, and promtool output in, and switching them out of it at the dashboard boundary would be a small act of condescension. What the terminal gained is everything a TTY never had: four real surface planes, a status palette with semantics instead of ANSI approximations, hairline structure, and full light/dark parity so the page matches whatever the operator's other windows are already doing.\n\nThe register is instrumental and factual. The interface reports; it does not interpret, reassure, or editorialize. A status code is rendered as a number, not as \"Healthy ✓\". A departed agent is labeled gone and left on screen rather than tactfully removed. Absent data gets an en dash, because an empty cell reads as a rendering bug and this surface cannot afford to be mistaken for broken — its entire job is telling an operator whether something is broken. Every visual decision is downstream of that: if the dashboard is ever wrong, or ever looks wrong, it has failed at the one thing it exists to do.\n\nThe system's discipline shows most in what it refuses. There are no shadows, anywhere. There are no transitions, anywhere — hover, selection, and live swaps all land instantly, which is itself a claim about latency the interface then has to keep. The accent color appears in exactly two places on the entire surface. The only thing that moves is a 7px dot reporting whether the socket is alive. This is a system built by subtraction, and the remaining elements are load-bearing.",
+    "keyCharacteristics": [
+      "One typeface — monospace — at 12.5px base, for every role from title to micro-label.",
+      "Zero shadows. Depth is four tonal planes plus two hairline weights.",
+      "Two radii: 0 and fully round. Rectangles hold content; circles report status.",
+      "The accent is used twice: focus rings and the current-row edge. It never fills a surface.",
+      "No CSS transitions. The only animation in the system is the connection beacon.",
+      "Full-bleed layout — no centered container, no max-width, no page margins.",
+      "Complete light/dark parity via prefers-color-scheme; neither theme is the afterthought."
+    ],
+    "rules": [
+      {
+        "name": "The Two Places Rule",
+        "body": "The accent appears on focus rings and the current-row left edge. Nowhere else. It never fills a background, never sets body type, never becomes a button, never appears in a chart. Its rarity is what makes selection findable in a field of monospace at a glance.",
+        "section": "colors"
+      },
+      {
+        "name": "The Paired Status Rule",
+        "body": "Solid status colors carry meaning on type, dots, and borders. Soft status colors have exactly one job: backing a pill or tag. A soft color never becomes a row background, a panel fill, or a section header — a status tint spread across a region would claim the whole region has that status.",
+        "section": "colors"
+      },
+      {
+        "name": "The No Amber Dot Rule",
+        "body": "LEDs and beacons are binary: ok or crit. Warning is a tag, not a lamp. An operator scanning the agent list is answering \"is anything red,\" and a third dot color turns a binary scan into a reading task.",
+        "section": "colors"
+      },
+      {
+        "name": "The Single Face Rule",
+        "body": "One monospace stack, everywhere, no exceptions. Introducing a sans for \"UI chrome\" or a serif for warmth would break the premise: the dashboard reads as an extension of the operator's terminal precisely because it never switches voice.",
+        "section": "typography"
+      },
+      {
+        "name": "The Tabular Rule",
+        "body": "Any number a reader will compare down a column carries font-variant-numeric: tabular-nums and right-alignment. Durations and status codes already do. A monospace face makes this nearly free — which is one more reason the face is monospace.",
+        "section": "typography"
+      },
+      {
+        "name": "The Engraved Label Rule",
+        "body": "Every region header is 10px, uppercase, 0.09em, weight 600, in ink-3. Small and quiet, but unmistakably a label rather than content. Region headers never get larger; if a region needs more prominence, it gets a hairline, not bigger type.",
+        "section": "typography"
+      },
+      {
+        "name": "The Full Bleed Rule",
+        "body": "No centered container, ever. This is instrumentation, not a document.",
+        "section": "layout"
+      },
+      {
+        "name": "The Contained Scroll Rule",
+        "body": "Wide content scrolls inside its own overflow-x: auto container. The page body never scrolls horizontally. If a new region can outgrow the viewport, it gets its own scroller before it ships.",
+        "section": "layout"
+      },
+      {
+        "name": "The No-Shadow Rule",
+        "body": "Zero shadows. Not for hover, not for panels, not for the \"elevated\" state of anything. If an element needs to separate from its neighbor, it gets a hairline or a tonal step.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Reading Plane Rule",
+        "body": "surface is where content is read. surface-2 and surface-3 are always away from it in contrast, never toward it. When adding a plane, ask which direction from the reading plane it belongs, not whether it is lighter or darker in absolute terms.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Square-or-Circle Rule",
+        "body": "Radius is 0 or fully round. Nothing in between ships. If a new element feels like it wants 6px, it is a container and it wants 0.",
+        "section": "shapes"
+      },
+      {
+        "name": "The Still Interface Rule",
+        "body": "No CSS transitions. Hover, selection, and live swaps land instantly. This is a truth claim: the interface is asserting that nothing is being waited on, and a 150ms ease would make a live push look like a request.",
+        "section": "components"
+      },
+      {
+        "name": "The Named Absence Rule",
+        "body": "Absent data renders as an en dash, never as an empty cell. An empty cell reads as a rendering failure; a dash reads as \"the agent never told us.\" On a surface whose job is reporting failure, the difference is the whole product.",
+        "section": "components"
+      },
+      {
+        "name": "The Say-So Rule",
+        "body": "When state disappears, the interface says so rather than going blank or freezing. A selected agent that disconnects gets a sentence, not a stale pane. A path whose agent departed stays in the table with a gone tag. A silently frozen dashboard is what makes an operator stop trusting it.",
+        "section": "components"
+      }
+    ],
+    "dos": [
+      "Do use the monospace stack for every new element. Hierarchy comes from size (15 / 12.5 / 11.5 / 11 / 10.5 / 10), weight (400 / 600 / 640), case, and color — never from a second family.",
+      "Do reach for a hairline or a tonal step when something needs to separate. line between regions, line-soft between rows.",
+      "Do give every new region header the engraved Label treatment: 10px, uppercase, 0.09em, weight 600, ink-3, with a bare count on the right if it has a count.",
+      "Do put tabular-nums and right-alignment on any number that will be compared down a column.",
+      "Do wrap any region that can outgrow the viewport in its own overflow-x: auto scroller.",
+      "Do render absent data as an en dash and departed state as visible-and-labeled.",
+      "Do pair every animation with a prefers-reduced-motion: reduce override, and make sure color and text still carry the full signal when motion is off.",
+      "Do put focus rings inside full-bleed rows (outline-offset: -2px) and outside pills (outline-offset: 1px).",
+      "Do ship every new color as a light/dark pair. Neither theme is the fallback.",
+      "Do check a new color against the worst ground it touches, not the reading plane. surface-2 is the binding case for anything quiet; a value tuned against white alone fails under the table headers.",
+      "Do name one agent the same way in every layout. The path table and the agent list are read against each other, so an internal id in one and a name in the other makes the operator translate.",
+      "Do size the content region with flex, not by subtracting a bar height.",
+      "Do give a state change that is conveyed by color or motion a text equivalent an assistive technology can reach — and keep any live region out of the pushed fragments."
+    ],
+    "donts": [
+      "Don't drift toward a consumer SaaS dashboard — no gradient hero cards, no rounded-2xl, no soft drop shadows, no illustrated empty states, no sparkline that decorates rather than informs. (User-confirmed anti-reference.)",
+      "Don't add a box-shadow. There are zero in the system and that is the elevation strategy, not an oversight.",
+      "Don't add a radius between 0 and fully round. No 4px, no 8px, no 12px.",
+      "Don't fill anything with the accent. It draws focus rings and the current-row edge; that is the complete list.",
+      "Don't use a soft status color as a region or row background. Soft colors back pills and tags only.",
+      "Don't add a third LED color. Warning is a tag, not a lamp.",
+      "Don't add CSS transitions to hover, selection, or live swaps.",
+      "Don't load a webfont, an icon font, an icon package, or any remote asset. PRODUCT.md makes self-containment binding — the proxy ships into networks where the fetch would simply fail.",
+      "Don't introduce a max-width container or center the layout.",
+      "Don't wrap table cells. Paths and target URLs truncate into the scroller; wrapping destroys the column scan.",
+      "Don't remove a departed or failing row to keep the view tidy. Those rows are the product.",
+      "Don't let ink-3 drift lighter. At #626b77 / #858f9d it clears AA on surface-2 by 0.09-0.38, and it carries every timestamp, hostname, label, and dimmed column in the system.",
+      "Don't expose an internal id in the interface. Ids address things in code; names identify them to operators."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,644 @@
+---
+name: prometheus-proxy Dashboard
+description: A monospace instrument surface for platform teams operating the proxy — flat, dense, and factual.
+colors:
+  bg: "#f2f5f8"
+  surface: "#ffffff"
+  surface-2: "#e9edf2"
+  surface-3: "#dde3ea"
+  line: "#cfd7e0"
+  line-soft: "#e3e9ef"
+  ink: "#131820"
+  ink-2: "#48525f"
+  ink-3: "#626b77"
+  accent: "#c8461f"
+  ok: "#1a7a42"
+  ok-soft: "#e3f4ea"
+  warn: "#8a5d08"
+  warn-soft: "#f9f0da"
+  crit: "#c02a20"
+  crit-soft: "#fbe6e4"
+  bg-dark: "#0d1015"
+  surface-dark: "#151a21"
+  surface-2-dark: "#1c222b"
+  surface-3-dark: "#242c37"
+  line-dark: "#2b333f"
+  line-soft-dark: "#212934"
+  ink-dark: "#e7ebf1"
+  ink-2-dark: "#a4aebc"
+  ink-3-dark: "#858f9d"
+  accent-dark: "#ff7043"
+  ok-dark: "#3fb950"
+  ok-soft-dark: "#12251a"
+  warn-dark: "#d29922"
+  warn-soft-dark: "#2a2110"
+  crit-dark: "#f85149"
+  crit-soft-dark: "#2d1512"
+typography:
+  title:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "15px"
+    fontWeight: 640
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  body:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "12.5px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  body-emphasis:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "12.5px"
+    fontWeight: 600
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  meta:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "11.5px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  badge:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "10.5px"
+    fontWeight: 600
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "10px"
+    fontWeight: 600
+    lineHeight: 1.5
+    letterSpacing: "0.09em"
+  micro:
+    fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontSize: "10px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+rounded:
+  none: "0"
+  pill: "20px"
+  dot: "50%"
+spacing:
+  micro: "2px"
+  tight: "4px"
+  snug: "7px"
+  label: "9px"
+  row: "10px"
+  gutter-list: "15px"
+  gutter-detail: "18px"
+  block: "22px"
+components:
+  row-item:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "10px 15px"
+  row-item-hover:
+    backgroundColor: "{colors.surface-3}"
+    textColor: "{colors.ink}"
+  row-item-current:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+  nav-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-3}"
+    typography: "{typography.body}"
+    rounded: "{rounded.pill}"
+    padding: "3px 10px"
+  nav-link-hover:
+    backgroundColor: "{colors.surface-3}"
+    textColor: "{colors.ink}"
+  nav-link-active:
+    backgroundColor: "{colors.surface-3}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-emphasis}"
+  pill-ok:
+    backgroundColor: "{colors.ok-soft}"
+    textColor: "{colors.ok}"
+    typography: "{typography.badge}"
+    rounded: "{rounded.pill}"
+    padding: "2px 7px"
+  pill-crit:
+    backgroundColor: "{colors.crit-soft}"
+    textColor: "{colors.crit}"
+    typography: "{typography.badge}"
+    rounded: "{rounded.pill}"
+    padding: "2px 7px"
+  tag:
+    backgroundColor: "{colors.surface-3}"
+    textColor: "{colors.ink-2}"
+    typography: "{typography.micro}"
+    rounded: "{rounded.pill}"
+    padding: "2px 7px"
+  tag-warn:
+    backgroundColor: "{colors.warn-soft}"
+    textColor: "{colors.warn}"
+  tag-crit:
+    backgroundColor: "{colors.crit-soft}"
+    textColor: "{colors.crit}"
+  led-ok:
+    backgroundColor: "{colors.ok}"
+    rounded: "{rounded.dot}"
+    width: "7px"
+    height: "7px"
+  led-crit:
+    backgroundColor: "{colors.crit}"
+    rounded: "{rounded.dot}"
+    width: "7px"
+    height: "7px"
+  section-label:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink-3}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "9px 15px"
+  table-header-cell:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink-3}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "9px 15px"
+  table-cell:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "8px 15px"
+  kv-row:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "7px 18px"
+  top-bar:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "11px 15px"
+  empty-state:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink-3}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "22px 18px"
+---
+
+# Design System: prometheus-proxy Dashboard
+
+## Overview
+
+**Creative North Star: "The Terminal, Grown Up"**
+
+This is a terminal that kept its honesty and gained a spine. Monospace is not a style choice here — it
+is the operator's native tongue, the same face they read logs, configs, and `promtool` output in, and
+switching them out of it at the dashboard boundary would be a small act of condescension. What the
+terminal gained is everything a TTY never had: four real surface planes, a status palette with
+semantics instead of ANSI approximations, hairline structure, and full light/dark parity so the page
+matches whatever the operator's other windows are already doing.
+
+The register is **instrumental and factual**. The interface reports; it does not interpret, reassure,
+or editorialize. A status code is rendered as a number, not as "Healthy ✓". A departed agent is
+labeled `gone` and left on screen rather than tactfully removed. Absent data gets an en dash, because
+an empty cell reads as a rendering bug and this surface cannot afford to be mistaken for broken — its
+entire job is telling an operator whether something is broken. Every visual decision is downstream of
+that: if the dashboard is ever wrong, or ever *looks* wrong, it has failed at the one thing it exists
+to do.
+
+The system's discipline shows most in what it refuses. There are no shadows, anywhere. There are no
+transitions, anywhere — hover, selection, and live swaps all land instantly, which is itself a claim
+about latency the interface then has to keep. The accent color appears in exactly two places on the
+entire surface. The only thing that moves is a 7px dot reporting whether the socket is alive. This is
+a system built by subtraction, and the remaining elements are load-bearing.
+
+**Key Characteristics:**
+
+- One typeface — monospace — at 12.5px base, for every role from title to micro-label.
+- Zero shadows. Depth is four tonal planes plus two hairline weights.
+- Two radii: `0` and fully round. Rectangles hold content; circles report status.
+- The accent is used twice: focus rings and the current-row edge. It never fills a surface.
+- No CSS transitions. The only animation in the system is the connection beacon.
+- Full-bleed layout — no centered container, no max-width, no page margins.
+- Complete light/dark parity via `prefers-color-scheme`; neither theme is the afterthought.
+
+## Colors
+
+A cool blue-grey neutral family carrying a single warm accent and a three-tier status palette — the
+accent is the only warm hue in the system, which is why it can be used so sparingly and still be seen.
+
+Every token exists as a light/dark pair; the frontmatter carries both (`accent` / `accent-dark`). The
+light theme is `:root`; the dark theme is a `prefers-color-scheme: dark` override. Neither is a tinted
+derivative of the other — the dark status colors are re-picked for a dark ground, not algorithmically
+dimmed.
+
+### Primary
+
+- **Burnt Orange** (`accent`): The only warm hue on the surface, and deliberately the rarest. It draws
+  the 3px left edge of the currently-selected row and the 2px focus-visible outline. That is the
+  complete list. It brightens to a coral (`accent-dark`) in dark mode, which is the one place the two
+  themes differ in character rather than only in value — against black it reads as a lit filament
+  rather than as rust.
+
+### Neutral
+
+- **Cold Paper** (`bg`): The page ground. In light mode it is *slightly* darker than the reading
+  plane, so panels sit forward on it. In dark mode it is the darkest value in the system.
+- **Reading Plane** (`surface`): Pure white in light, near-black in dark. Where content that must be
+  read carefully lives — the detail pane, the table body, the top bar.
+- **Recessed Plane** (`surface-2`): The agent list, section headers, and sticky table headers.
+  Structurally *behind* the reading plane in both themes.
+- **Pressed Plane** (`surface-3`): The furthest step from the reading plane. Row hover, neutral tag
+  backgrounds, active nav pill.
+- **Structural Rule** (`line`): 1px hairlines that separate regions — bar from body, list from detail.
+- **Soft Rule** (`line-soft`): 1px hairlines that separate rows *within* a region. Always lower
+  contrast than `line`, so the eye reads region boundaries before it reads row boundaries.
+- **Ink** (`ink`): Primary text — agent names, paths, table cells.
+- **Ink Secondary** (`ink-2`): Neutral tag text. Used sparingly.
+- **Ink Tertiary** (`ink-3`): Metadata, timestamps, hostnames, micro-labels, dimmed table columns,
+  empty-state copy.
+
+### Status
+
+Three levels, each shipping as a **solid** and a **soft** companion.
+
+- **Live Green** (`ok` / `ok-soft`): A valid agent's LED, the healthy connection beacon, 2xx scrape
+  pills, and healthy status counters.
+- **Drift Amber** (`warn` / `warn-soft`): Reserved for conditions that are true but not yet failures —
+  the `failed over` tag, and internal counters approaching their threshold. Notably it has **no LED
+  form**; there is no amber dot in the system.
+- **Fault Red** (`crit` / `crit-soft`): An invalid agent's LED, the disconnected beacon, non-2xx scrape
+  pills, the `gone` tag, departed table rows, and the "agent no longer connected" empty state.
+
+### Named Rules
+
+**The Two Places Rule.** The accent appears on focus rings and the current-row left edge. Nowhere
+else. It never fills a background, never sets body type, never becomes a button, never appears in a
+chart. Its rarity is what makes selection findable in a field of monospace at a glance.
+
+**The Paired Status Rule.** Solid status colors carry meaning on type, dots, and borders. Soft status
+colors have exactly one job: backing a pill or tag. A soft color never becomes a row background, a
+panel fill, or a section header — a status tint spread across a region would claim the whole region
+has that status.
+
+**The No Amber Dot Rule.** LEDs and beacons are binary: `ok` or `crit`. Warning is a *tag*, not a
+lamp. An operator scanning the agent list is answering "is anything red," and a third dot color turns
+a binary scan into a reading task.
+
+### Measured contrast
+
+Measured in headless Chrome against the live dashboard (both themes, both layouts, 1280px and 390px),
+not computed from the token values. **Every text pairing clears 4.5:1**, and every non-text indicator
+clears 3:1.
+
+| Combination | Light | Dark |
+|---|---|---|
+| `ink-3` on `surface-2` (table + section headers) — *the binding case* | 4.59:1 | 4.88:1 |
+| `ink-3` on `surface` | 5.40:1 | 5.37:1 |
+| `ok` on `ok-soft` (2xx pill) | 4.71:1 | 6.33:1 |
+| `ok` on `surface` (`live` label, healthy counters) | 5.38:1 | 6.88:1 |
+| `warn` on `warn-soft` (`failed over` tag) | 5.07:1 | 6.29:1 |
+| `crit` on `crit-soft` (non-2xx pill, `gone` tag) | 4.88:1 | 5.10:1 |
+| `crit` on `surface` (departed row path cell) | 5.84:1 | 5.21:1 |
+| `ink` on `surface` | 17.81:1 | 14.61:1 |
+
+Non-text: LEDs and the beacon measure 4.57–6.88:1 against every ground they sit on, and the `accent`
+current-row edge 4.83:1 light / 6.37:1 dark.
+
+**The binding constraint is `surface-2`, not `surface`.** Every quiet color lands on the recessed plane
+somewhere — `ink-3` under every table and section header — and that pairing is a full tonal step
+tighter than the reading plane. A color chosen against white alone will fail there. Check the worst
+ground a token touches, never its most flattering one.
+
+PRODUCT.md records no formal conformance commitment, so AA here is a property the system happens to
+have rather than one it claims. Keeping it is nearly free; the values above are the floor to preserve.
+
+## Typography
+
+**Display Font:** none — the system has no display face.
+**Body Font:** `ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace`
+**Label/Mono Font:** the same stack. There is exactly one.
+
+**Character:** A pure system-monospace stack, self-hosted by definition — no webfont, no CDN request,
+no FOUT. It resolves to SF Mono on Apple platforms, Consolas on Windows, and the platform default
+elsewhere, so it always matches the terminal the operator already has open. Hierarchy comes entirely
+from size, weight, case, and color — never from a second family, because there isn't one.
+
+### Hierarchy
+
+- **Title** (weight 640, 15px, lh 1.5): The agent name in the detail hero. The single largest text on
+  the surface. The unusual 640 weight sits between the stack's regular and bold — heavy enough to
+  anchor the pane, light enough not to shout.
+- **Body** (weight 400, 12.5px, lh 1.5): The base. Agent names in the list, paths, table cells, kv
+  labels. Nearly everything.
+- **Body Emphasis** (weight 600, 12.5px): The brand mark and the active nav link. Weight, not size,
+  carries the difference.
+- **Meta** (weight 400, 11.5px, `ink-3`): The hero metadata strip, failover line, status bar, and the
+  second line of an agent row (`address · N paths`) — facts that support the primary reading without
+  competing with it. One role, not two: an earlier 11px step for the agent-row line did the same job as
+  11.5px half a pixel apart, which is a distinction no reader can act on.
+- **Badge** (weight 600, 10.5px): Status-code pills. The only place a number is bolded.
+- **Label** (weight 600, 10px, `0.09em`, uppercase, `ink-3`): Section headers, list headers, table
+  column headers. Engraved rather than printed — the letterspacing does the work that a rule or a
+  heavier weight would otherwise have to.
+- **Micro** (weight 400, 10px, normal spacing, mixed case): Tag text only — `consolidated`, `failed
+  over`, `gone`. Deliberately *not* the Label treatment despite sharing its 10px size: a tag reports a
+  fact about one row, so it stays lowercase and unweighted rather than reading as a column heading.
+
+### Named Rules
+
+**The Single Face Rule.** One monospace stack, everywhere, no exceptions. Introducing a sans for "UI
+chrome" or a serif for warmth would break the premise: the dashboard reads as an extension of the
+operator's terminal precisely because it never switches voice.
+
+**The Tabular Rule.** Any number a reader will compare down a column carries
+`font-variant-numeric: tabular-nums` and right-alignment. Durations and status codes already do. A
+monospace face makes this nearly free — which is one more reason the face is monospace.
+
+**The Engraved Label Rule.** Every region header is 10px, uppercase, `0.09em`, weight 600, in `ink-3`.
+Small and quiet, but unmistakably a label rather than content. Region headers never get larger; if a
+region needs more prominence, it gets a hairline, not bigger type.
+
+## Layout
+
+**Full-bleed, no container.** There is no `max-width`, no centered column, no page padding. The
+interface occupies the entire viewport, because a dashboard on a wide monitor should use the monitor.
+
+**The master–detail grid.** `262px 1fr`. The 262px list column is sized to hold a typical agent name
+plus its address line without wrapping.
+
+**Height comes from flex, never arithmetic.** `body` is a column flex container at `min-height: 100vh`
+and the content region is `flex: 1`, so it occupies exactly the space the top bar leaves. It must not
+go back to subtracting a bar height: the bar sizes itself from its own content and grows on touch
+devices, so any hard-coded number is wrong on some viewport — the previous `calc(100vh - 44px)` was
+subtracting 44px from a bar that actually measured 48px.
+
+**The path table.** Deliberately flat — no selection, no drill-in, no per-session state. The row *is*
+the answer. Column headers are `position: sticky; top: 0`, and the whole table lives inside its own
+`overflow-x: auto` scroller so wide content never makes the page body scroll sideways. Cells are
+`white-space: nowrap`; a path or target URL is truncated by the scroller, never wrapped, because a
+wrapped path destroys the column scan the table exists for.
+
+**Two gutters, deliberately.** List and table regions use a **15px** horizontal gutter; the detail
+pane uses **18px**. This is not drift — the wider gutter marks the detail pane as the reading surface
+and the narrower one keeps the scanning surfaces dense. Vertical rhythm follows the region: 9px for
+label rows, 10px for list rows, 8px for table cells, 7px for kv rows, 11px for the top bar.
+
+**The kv row.** Inside the detail pane, key/value pairs use a fixed `220px` minimum label column so
+values align down the pane without a table.
+
+**Responsive.** One width breakpoint: **720px**. Below it the master–detail grid collapses to a single
+column and the list's right border becomes a bottom border. Nothing else changes — no hamburger, no
+drawer, no reflowed table. The table keeps its horizontal scroller, which is the correct mobile
+behavior for tabular data.
+
+**One input-mode breakpoint: `pointer: coarse`.** Nav links grow to a 44px minimum height on touch
+devices only. Target size is a property of the *input*, not the viewport — a tablet is wide and
+touch-driven, a narrow desktop window is neither — so this is deliberately not folded into the 720px
+rule, and pointer devices keep the dense 25px pill rather than paying for vertical space they cannot
+use.
+
+### Named Rules
+
+**The Full Bleed Rule.** No centered container, ever. This is instrumentation, not a document.
+
+**The Contained Scroll Rule.** Wide content scrolls inside its own `overflow-x: auto` container. The
+page body never scrolls horizontally. If a new region can outgrow the viewport, it gets its own
+scroller before it ships.
+
+## Elevation & Depth
+
+**There are no shadows in this system.** Not one `box-shadow` declaration exists. Depth is built
+entirely from two mechanisms: four tonal planes and two hairline weights.
+
+The tonal planes do not form a simple light-to-dark ramp. `surface` is the **reading plane**;
+`surface-2` and `surface-3` step *away* from it in the direction of contrast — darker in light mode,
+lighter in dark mode — while `bg` sits just behind the reading plane as the page ground. The result
+reads identically in both themes even though the absolute lightness ordering inverts.
+
+The two hairline weights are the other half. `line` separates regions; `line-soft` separates rows
+within a region. Because `line-soft` is always the lower-contrast of the pair, the eye resolves
+structure before it resolves content — you see the panes, then the rows, then the data.
+
+### Named Rules
+
+**The No-Shadow Rule.** Zero shadows. Not for hover, not for panels, not for the "elevated" state of
+anything. If an element needs to separate from its neighbor, it gets a hairline or a tonal step.
+
+**The Reading Plane Rule.** `surface` is where content is read. `surface-2` and `surface-3` are always
+*away* from it in contrast, never toward it. When adding a plane, ask which direction from the reading
+plane it belongs, not whether it is lighter or darker in absolute terms.
+
+## Shapes
+
+The form language is **two radii and nothing between them.**
+
+- **`0` — everything structural.** Panels, rows, cells, the top bar, section headers, empty states,
+  the table. No rounded corners on any container, anywhere.
+- **Fully round (`20px` on short elements, `50%` on dots) — everything that reports state.** Status
+  pills, tags, nav links, LEDs, the connection beacon.
+
+The split is semantic, not decorative: **rectangles hold content, round things report status.** A
+7px circle is a lamp. A 20px-radius capsule is a badge. Neither shape is ever used for a container,
+and no container is ever softened toward them. There is no `4px`, no `6px`, no `8px` radius in the
+system, and introducing one would blur a distinction that currently does real work.
+
+Borders carry the remaining form language: 1px hairlines for structure, and one 3px left border on the
+row item — transparent at rest, `accent` when current — which is the only border in the system thicker
+than a hairline.
+
+### Named Rules
+
+**The Square-or-Circle Rule.** Radius is `0` or fully round. Nothing in between ships. If a new
+element feels like it wants `6px`, it is a container and it wants `0`.
+
+## Components
+
+The component philosophy is **legible under pressure**: every element is optimized to be read
+correctly on the first glance by someone who is busy. Contrast, alignment, and tabular numbers outrank
+refinement, and no component earns visual weight it doesn't need to do its job.
+
+### Row Item (agent list)
+
+A `<button>` styled as a full-width list row, so it is keyboard-operable by construction.
+
+- **Shape:** square (`0`), full-bleed, `10px 15px` padding, `line-soft` bottom divider.
+- **Structure:** two lines — an LED plus the agent name, then `address · N paths` in Caption/`ink-3`.
+- **Rest:** transparent background.
+- **Hover:** background steps to `surface-3`. No transition.
+- **Focus:** `2px solid accent` outline, `outline-offset: -2px` so the ring sits *inside* the row and
+  never overlaps its neighbors.
+- **Current:** background lifts to `surface` (the reading plane, matching the detail pane it controls)
+  and the 3px left border becomes `accent`. Marked `aria-current="true"`.
+
+### Status Pill
+
+- **Style:** soft status background, solid status text, fully round, `2px 7px`, Badge type (600/10.5px).
+- **Variants:** `ok` for 2xx, `crit` for everything else. Only two.
+- **Content:** the literal status code. Never "Success" or an icon.
+
+### Tag
+
+- **Style:** fully round, `2px 7px`, Micro type (400/10px, normal spacing, mixed case) — *not* the
+  uppercase Label treatment, despite the shared 10px size.
+- **Neutral:** `surface-3` background, `ink-2` text — used for `consolidated`.
+- **Warn:** `warn-soft` / `warn` — used for `failed over`.
+- **Crit:** `crit-soft` / `crit` — used for `gone`.
+
+### Status LED
+
+A `7px` circle, `50%` radius, `ok` or `crit`. Binary by rule (see The No Amber Dot Rule). Appears
+before the agent name in both the list row and the detail hero, so the same signal sits in the same
+relative position in both panes.
+
+### Navigation
+
+- **Style:** two plain links in pill form (`20px`), `3px 10px`, `ink-3` at rest.
+- **Hover:** `surface-3` background, `ink` text.
+- **Active:** `surface-3` background, `ink` text, weight 600, plus `aria-current="page"`.
+- **Focus:** `2px solid accent`, `outline-offset: 1px` — *outside* the pill here, unlike the row item,
+  because a pill has no neighbor to collide with.
+- **Behavior:** real navigation, not a swap. The two layouts are bookmarkable URLs.
+
+### Section Header
+
+`surface-2` background, `line` bottom border, `9px 15px`, Label type. A flex pair: the section name on
+the left, a bare count on the right. The count is never decorated — no pill, no parentheses, no "items".
+
+### Key–Value Row
+
+`7px 18px`, `line-soft` divider, `220px` minimum label column. Key in `ink`, value in `ink-3`. The
+scrape variant prepends a fixed `64px` timestamp column so times align down the pane.
+
+### Path Table
+
+The signature component. Seven columns: Path, Agent(s), Target, Src, Last scrape, Status, Duration.
+
+- **Header:** `surface-2`, sticky at `top: 0`, Label type, `line` bottom border.
+- **Cells:** `8px 15px`, `line-soft` divider, `white-space: nowrap`.
+- **Numeric columns:** right-aligned with `tabular-nums`.
+- **Dimmed columns:** Target, Src, Last scrape, and Duration render in `ink-3` — supporting facts,
+  scanned only after the row is located by path or status.
+- **Row hover:** cells step to `surface-2`. No transition.
+- **Departed row:** the path cell turns `crit` and a `gone` tag follows the agent name. The row stays
+  in place — a path whose agent vanished is the single most important thing this table shows, and
+  removing it is how the old interface hid exactly that case.
+
+### Connection Beacon
+
+The other signature component, and the only animated element in the system. A `7px` dot plus a text
+label, both in the top bar.
+
+- **Live:** `ok` dot, label `live`, `pulse 2.4s ease-out infinite` fading between full and 40%
+  opacity. Slow enough to read as breathing rather than flashing.
+- **Reconnecting:** `crit` dot, label `reconnecting…`, `blink 1s steps(2, start) infinite` between
+  full and 25% opacity. The `steps(2)` timing makes it snap rather than fade.
+- **Reduced motion:** both animations set to `none`. Color and label still carry the full signal, so
+  nothing is lost.
+- **Mechanism:** driven by a `ws-down` class on `<body>` rather than by the server, because the status
+  bar is frozen precisely when the connection is down. Both labels are always in the DOM; CSS chooses.
+
+### Status Bar
+
+`surface`, `11px 15px`, Meta type in `ink-3`. Left to right: the brand mark, the layout nav, then the
+connection beacon and a run of counters — agents, paths, and the internal chunk/scrape gauges, which
+turn `warn` as they approach their thresholds.
+
+A **departed count** joins the run in `crit` whenever any path is departed (`3 departed`). It exists
+because the paths counter reports *registrations*, so a departed path is deliberately absent from it —
+which without explanation reads as the bar contradicting the table directly beneath it. Every stat
+carries `white-space: nowrap` so a narrow viewport wraps between stats rather than through one.
+
+### Connection Announcer
+
+A visually-hidden `role="status" aria-live="polite"` region, written only by the WebSocket lifecycle
+handlers: *"Connection to the proxy lost. Reconnecting."* and, on recovery from a real outage,
+*"Connection to the proxy restored."*
+
+It exists because the beacon reports connection state through color and a change of rhythm, and
+neither reaches a screen reader — without it the page simply goes silently stale, which is the exact
+failure this dashboard exists to make impossible to miss. Deliberately **outside every out-of-band
+region**: a live region the push loop rewrote would re-announce itself on every frame. Scoped to the
+connection alone for the same reason — announcing pushed counters would make it unusable.
+
+### Empty States
+
+Plain sentences in `ink-3`, no illustration, no icon, no call to action. Three variants: inline
+(`14px 15px`), padded (`22px 18px`), and the `gone` variant which renders in `crit` for "Agent X is no
+longer connected." Copy states the fact and, where useful, the next action in the same breath —
+"Select an agent to see its paths and recent scrapes."
+
+### Not yet in the system
+
+Recorded so future work doesn't assume otherwise: there are **no form inputs, no dialogs, no toasts,
+and no true action buttons** — the only `<button>` is a list row. PRODUCT.md records that control
+actions are a planned direction; when they arrive they will need a genuinely new component vocabulary
+(destructive confirmation, action button, disabled state), and inventing it is a design decision, not
+an extraction.
+
+### Named Rules
+
+**The Still Interface Rule.** No CSS transitions. Hover, selection, and live swaps land instantly.
+This is a truth claim: the interface is asserting that nothing is being waited on, and a 150ms ease
+would make a live push look like a request.
+
+**The Named Absence Rule.** Absent data renders as an en dash (`–`), never as an empty cell. An empty
+cell reads as a rendering failure; a dash reads as "the agent never told us." On a surface whose job
+is reporting failure, the difference is the whole product.
+
+**The Say-So Rule.** When state disappears, the interface says so rather than going blank or freezing.
+A selected agent that disconnects gets a sentence, not a stale pane. A path whose agent departed stays
+in the table with a `gone` tag. A silently frozen dashboard is what makes an operator stop trusting it.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** use the monospace stack for every new element. Hierarchy comes from size (15 / 12.5 / 11.5 /
+  11 / 10.5 / 10), weight (400 / 600 / 640), case, and color — never from a second family.
+- **Do** reach for a hairline or a tonal step when something needs to separate. `line` between
+  regions, `line-soft` between rows.
+- **Do** give every new region header the engraved Label treatment: 10px, uppercase, `0.09em`, weight
+  600, `ink-3`, with a bare count on the right if it has a count.
+- **Do** put `tabular-nums` and right-alignment on any number that will be compared down a column.
+- **Do** wrap any region that can outgrow the viewport in its own `overflow-x: auto` scroller.
+- **Do** render absent data as an en dash and departed state as visible-and-labeled.
+- **Do** pair every animation with a `prefers-reduced-motion: reduce` override, and make sure color
+  and text still carry the full signal when motion is off.
+- **Do** put focus rings *inside* full-bleed rows (`outline-offset: -2px`) and *outside* pills
+  (`outline-offset: 1px`).
+- **Do** ship every new color as a light/dark pair. Neither theme is the fallback.
+- **Do** check a new color against the *worst* ground it touches, not the reading plane. `surface-2` is
+  the binding case for anything quiet; a value tuned against white alone fails under the table headers.
+- **Do** name one agent the same way in every layout. The path table and the agent list are read
+  against each other, so an internal id in one and a name in the other makes the operator translate.
+- **Do** size the content region with flex, not by subtracting a bar height.
+- **Do** give a state change that is conveyed by color or motion a text equivalent an assistive
+  technology can reach — and keep any live region out of the pushed fragments.
+
+### Don't:
+
+- **Don't** drift toward a consumer SaaS dashboard — no gradient hero cards, no `rounded-2xl`, no soft
+  drop shadows, no illustrated empty states, no sparkline that decorates rather than informs. *(User-confirmed
+  anti-reference.)*
+- **Don't** add a `box-shadow`. There are zero in the system and that is the elevation strategy, not
+  an oversight.
+- **Don't** add a radius between `0` and fully round. No `4px`, no `8px`, no `12px`.
+- **Don't** fill anything with the accent. It draws focus rings and the current-row edge; that is the
+  complete list.
+- **Don't** use a soft status color as a region or row background. Soft colors back pills and tags only.
+- **Don't** add a third LED color. Warning is a tag, not a lamp.
+- **Don't** add CSS transitions to hover, selection, or live swaps.
+- **Don't** load a webfont, an icon font, an icon package, or any remote asset. PRODUCT.md makes
+  self-containment binding — the proxy ships into networks where the fetch would simply fail.
+- **Don't** introduce a `max-width` container or center the layout.
+- **Don't** wrap table cells. Paths and target URLs truncate into the scroller; wrapping destroys the
+  column scan.
+- **Don't** let `ink-3` drift lighter. At `#626b77` / `#858f9d` it clears AA on `surface-2` by
+  0.09–0.38, and it carries every timestamp, hostname, label, and dimmed column in the system.
+- **Don't** expose an internal id in the interface. Ids address things in code; names identify them
+  to operators.
+- **Don't** remove a departed or failing row to keep the view tidy. Those rows are the product.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,175 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+**Primary: a platform / infrastructure team running the proxy as shared, multi-team infrastructure.**
+Their work is routine operations rather than firefighting — day-to-day health checks, onboarding a new
+agent, confirming a team's auth scope covers the paths they registered, and verifying that a target
+that stopped reporting is a target problem and not a proxy problem. They already run Prometheus and
+already know its vocabulary; they do not need the concept of a scrape explained.
+
+Because the proxy is shared, "whose agent is this and what is it allowed to do" is a routine question,
+not an exceptional one. Design decisions favor inventory clarity and completeness over incident-speed
+triage. The on-call-mid-incident case is real but secondary.
+
+Secondary audiences that exist but do not drive decisions: solo/homelab operators running proxy plus a
+handful of agents, and developers embedding the agent inside another JVM application.
+
+## Product Purpose
+
+Prometheus's pull model breaks when a firewall separates the Prometheus server from its metrics
+endpoints. Prometheus Proxy restores it: an **agent** inside the firewall opens a persistent gRPC
+connection outward to a **proxy** outside the firewall, and Prometheus scrapes the proxy over ordinary
+HTTP. No inbound firewall rule, no push gateway, no change to Prometheus's scrape semantics.
+
+Success is that a target behind a firewall is indistinguishable, from Prometheus's point of view, from
+one in front of it — and that when it is *not*, an operator can tell why from one page.
+
+## Positioning
+
+The mechanism a neighboring product cannot truthfully copy: **the connection is initiated from inside
+the firewall, but the data flow stays pull-based.** Push gateways change scrape semantics (staleness,
+timestamps, target liveness all become the sender's problem); VPNs and tunnels solve it at the network
+layer, requiring infrastructure changes outside the monitoring team's control. Prometheus Proxy sits
+in the monitoring layer and preserves pull.
+
+Two consequences of that position are also differentiators:
+
+- **Metric filtering happens at the agent** — before the payload crosses the WAN. This is the one place
+  where dropping metric families pays the most, and the one place Prometheus's own
+  `metric_relabel_configs` cannot reach.
+- **The proxy is not a single point of failure.** Agents hold an ordered list of proxy endpoints, fail
+  over to a standby when the primary is unreachable, and return to the primary when it recovers — with
+  no external health prober and no manual step.
+
+## Operating Context
+
+**Deployment.** Two long-running services. The proxy runs outside the firewall alongside Prometheus
+(HTTP scrape port default `8080`, admin `8092`); the agent runs inside, next to the monitored
+services (admin `8093`). Both ship as standalone JARs (`agentJar` / `proxyJar`), Docker images
+(`pambrose/prometheus-proxy`, `pambrose/prometheus-agent`), and a Maven Central artifact
+(`com.pambrose:prometheus-proxy`) for embedded use. Java 17+.
+
+**Configuration.** Typesafe Config (HOCON). Precedence: CLI args → env vars → config file → built-in
+defaults. Every setting is reachable from all four, because deployment environments differ in which
+one they can control (a Kubernetes ConfigMap, a systemd unit, a `docker run` line).
+
+**Surfaces in scope for design work:**
+
+1. **The operational dashboard** — served from its own port (default `8094`, base path `/dashboard`),
+   **opt-in and disabled by default**. Two bookmarkable layouts: an agent view (master–detail: which
+   agents are connected, what each is doing) and a path view (a table of every registered path and how
+   its last scrape went, *including paths whose agent has departed* — precisely the case that used to
+   vanish from view). A status bar carries connection liveness and proxy-internal health counters.
+   Updates arrive live over a WebSocket.
+2. **A project landing page** — a surface that persuades a prospective adopter, distinct from the
+   reference documentation.
+
+Explicitly **out of scope** for now: the Zensical documentation site at
+`pambrose.github.io/prometheus-proxy`, and the Grafana dashboard JSON under `grafana/`.
+
+**Vocabulary** (used consistently in code, docs, and UI — do not invent synonyms):
+*agent*, *proxy*, *path* (the registered scrape path), *target URL* (what the agent actually scrapes),
+*scrape*, *agent id / agent name / launch id*, *consolidated* (multiple agents serving one path),
+*departed* (an agent that disconnected, leaving its paths orphaned), *chunking*, *heartbeat*,
+*failover*, *identity* (a named per-agent auth principal), `STATIC` vs `DISCOVERED` path source.
+
+## Capabilities and Constraints
+
+**Confirmed capabilities:**
+
+- Firewall-traversing scrape via persistent agent-initiated gRPC stream.
+- Chunked responses for large payloads (above ~32KB), heartbeat every 5s during inactivity.
+- Stale-agent eviction after `maxAgentInactivitySecs` (default 60s).
+- Consolidated mode: several agents register the same path for redundancy.
+- Embedded agent — runs inside another JVM app via `Agent.startAsyncAgent()`.
+- Proxy failover across an ordered `agent.proxy.endpoints` list.
+- Dynamic target discovery: the agent watches a file and reconciles paths without restarting;
+  `STATIC` entries are never touched by discovery.
+- Per-agent identities with path-glob authorization on `registerPath`; the legacy shared
+  `proxy.agentToken` maps to an allow-all identity so existing deployments keep working.
+- Per-path metric filtering (allow/deny regexes, Prometheus-compatible anchoring); whole metric
+  families are kept or dropped atomically, and filtering fails open on non-text or non-UTF-8 payloads.
+- TLS with optional mutual auth.
+
+**Binding constraint — no CDN, no external assets.** Everything the dashboard serves must be
+self-contained in the JAR. htmx ships as a vendored WebJar for exactly this reason. No Google Fonts,
+no CDN scripts, no remote images, no runtime network fetch. This is not incidental: the proxy is
+frequently deployed in restricted networks where an outbound asset fetch would simply fail, and it
+must render identically there.
+
+**Current implementation, not a constraint.** Today the dashboard is rendered server-side from Kotlin
+(`kotlinx.html`) and updated via htmx `hx-swap-oob` fragments over a WebSocket — no client-side
+templating, no build step, no JS framework. The user did **not** mark this as binding, so a future
+change of approach is permitted; it is recorded here as the incumbent reality, not a rule.
+
+**Planned direction — control actions.** The dashboard is read-only today, but this is explicitly
+temporary. Mutating operations (evicting a stale agent, triggering a discovery reload, toggling a path)
+are a real future direction. Future design should anticipate destructive-action patterns —
+confirmation, undo where possible, clear attribution of who acted — rather than assuming an
+observe-only surface.
+
+**Undecided:** the exact set of control actions and their authorization model; where the landing page
+lives relative to the docs site.
+
+## Brand Commitments
+
+- **Name:** `prometheus-proxy` (lowercase, hyphenated) is the project name and the string used as the
+  dashboard's brand mark. The two services are `proxy` and `agent`.
+- **License:** Apache 2.0. Author: Paul Ambrose. Repository: `pambrose/prometheus-proxy`.
+- **Existing assets:** the architecture diagram at `docs/prometheus-proxy.png`. There is no logo,
+  wordmark, or defined brand palette — none has been established, and none should be assumed to exist.
+- *Observed, not user-confirmed:* the existing README and docs voice is direct and problem-first —
+  it states the operational pain, then the mechanism, in concrete technical terms, without marketing
+  superlatives. Worth preserving unless the user says otherwise.
+
+## Evidence on Hand
+
+**Real and usable:**
+
+- **Repo signals only** — GitHub releases (v4.0.0, released 2026-07-25), Docker Hub pull counts for
+  both images, Maven Central presence, Apache 2.0 license, CI / Codecov / Codacy badges. All
+  independently verifiable.
+- **Working configuration and demonstration** — the config examples under `examples/`, the reference
+  schema at `config/config.conf`, the architecture diagram at `docs/prometheus-proxy.png`, and real
+  screenshots of the running dashboard. Demonstration over claims.
+
+**Explicitly absent — must not be fabricated:**
+
+- No named or describable production users, and no customer logos.
+- No benchmarks, throughput figures, latency measurements, or quantified WAN-savings numbers.
+- No testimonials, case studies, press coverage, or analyst mentions.
+- No pricing, commercial tiers, or support offering — this is an Apache 2.0 open-source project.
+
+Any future landing page must persuade using the mechanism, the working configuration, and the
+verifiable repo signals. Nothing else is available.
+
+## Product Principles
+
+1. **Preserve the pull model.** The firewall boundary is the problem; Prometheus's semantics are not.
+   Any solution that asks operators to give up pull-based scraping is off-strategy.
+2. **Answer "why isn't this target scraping?" in one place.** The failure this product exists to make
+   visible spans two machines and two log files. Collapsing that into a single legible view is the
+   dashboard's whole reason to exist — including the orphaned and departed cases that are easiest to
+   omit and most important to show.
+3. **Shared infrastructure is the default assumption.** One proxy serves multiple teams. Per-agent
+   identity, path scoping, and unambiguous attribution are first-class concerns, not add-ons.
+4. **Configuration is the interface; automation writes files, not restarts.** Anything an operator can
+   change should be changeable by writing a file or setting an env var, without a process restart and
+   without granting automation the right to restart processes.
+5. **Self-contained at the edge.** The proxy and agent are deployed into networks that may permit no
+   outbound traffic beyond what the product itself defines. Everything needed to run and to render
+   must ship inside the artifact.
+
+## Accessibility & Inclusion
+
+No formal conformance standard has been committed to, and none should be claimed. The existing
+dashboard already handles `:focus-visible` outlines and `prefers-reduced-motion`, and light/dark
+schemes via `prefers-color-scheme`; keep doing sensible things at that level. Recorded here so a
+future pass does not re-ask: this was a deliberate decision, not an oversight.

--- a/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ProxyHttpRoutes.kt
@@ -210,7 +210,7 @@ internal object ProxyHttpRoutes {
         .awaitAll()
         .also { responses ->
           agentContextInfo.agentContexts.zip(responses).forEach { (agentContext, response) ->
-            recordScrapeOutcome(path, agentContext.agentId, response, proxy)
+            recordScrapeOutcome(path, agentContext.agentId, agentContext.agentName, response, proxy)
           }
         }
         .onEach { response ->
@@ -229,6 +229,7 @@ internal object ProxyHttpRoutes {
   private fun recordScrapeOutcome(
     path: String,
     agentId: String,
+    agentName: String,
     response: ScrapeRequestResponse,
     proxy: Proxy,
   ) {
@@ -243,6 +244,7 @@ internal object ProxyHttpRoutes {
     proxy.recordScrape(
       ScrapeRecord(
         agentId = agentId,
+        agentName = agentName,
         path = path,
         statusCode = response.statusCode.value,
         outcome = response.updateMsg,

--- a/src/main/kotlin/io/prometheus/proxy/ScrapeRecord.kt
+++ b/src/main/kotlin/io/prometheus/proxy/ScrapeRecord.kt
@@ -29,6 +29,9 @@ import java.time.Instant
  * Immutable, so a snapshot can hand it to any number of WebSocket sessions without copying.
  *
  * @param agentId the agent that served the scrape, which is what makes a per-agent view possible
+ * @param agentName the agent's configured name, captured here rather than looked up later because the
+ *   record outlives the agent: a departed path's only remaining attribution is the last scrape that ran
+ *   against it, and by then the `AgentContext` holding the name is gone
  * @param path the registered path scraped, without a leading slash
  * @param statusCode the status for this agent's leg of the scrape. On a consolidated path each
  *   participating agent yields its own record, so this is not necessarily the merged status
@@ -39,6 +42,7 @@ import java.time.Instant
  */
 internal data class ScrapeRecord(
   val agentId: String,
+  val agentName: String,
   val path: String,
   val statusCode: Int,
   val outcome: String,

--- a/src/main/kotlin/io/prometheus/proxy/dashboard/ProxyDashboardHtml.kt
+++ b/src/main/kotlin/io/prometheus/proxy/dashboard/ProxyDashboardHtml.kt
@@ -21,10 +21,13 @@ import kotlinx.html.FlowContent
 import kotlinx.html.HTML
 import kotlinx.html.SPAN
 import kotlinx.html.a
+import kotlinx.html.ThScope
 import kotlinx.html.body
 import kotlinx.html.button
+import kotlinx.html.caption
 import kotlinx.html.div
 import kotlinx.html.head
+import kotlinx.html.main
 import kotlinx.html.meta
 import kotlinx.html.nav
 import kotlinx.html.script
@@ -77,6 +80,7 @@ internal object ProxyDashboardHtml {
   const val DETAIL_ID = "detail"
   const val STATUS_ID = "status-bar"
   const val PATH_TABLE_ID = "path-table"
+  const val ANNOUNCER_ID = "conn-announce"
 
   /** The full page. Only served on a real navigation; every later update arrives over the socket. */
   fun HTML.renderPage(
@@ -85,6 +89,9 @@ internal object ProxyDashboardHtml {
     dashboardPath: String,
     layout: DashboardLayout = DashboardLayout.AGENT,
   ) {
+    // Declared so assistive tech pronounces agent names, paths, and status text as English rather than
+    // falling back to the listener's system locale.
+    attributes["lang"] = "en"
     head {
       title("prometheus-proxy")
       meta(name = "viewport", content = "width=device-width, initial-scale=1")
@@ -101,16 +108,27 @@ internal object ProxyDashboardHtml {
         renderNav(dashboardPath, layout)
         renderStatus(snapshot)
       }
+      // The one live region on the page. Kept outside every out-of-band id on purpose: a region the push
+      // loop rewrites would re-announce itself on every frame, so this is written only by the socket
+      // lifecycle handlers, which fire when the state actually changes.
+      div("sr-only") {
+        attributes["id"] = ANNOUNCER_ID
+        attributes["role"] = "status"
+        attributes["aria-live"] = "polite"
+      }
+
       when (layout) {
         DashboardLayout.AGENT -> {
-          div("md") {
+          main("md") {
             renderAgentList(snapshot, selectedId, dashboardPath)
             renderDetail(snapshot, selectedId)
           }
         }
 
         DashboardLayout.PATH -> {
-          renderPathTable(snapshot)
+          main {
+            renderPathTable(snapshot)
+          }
         }
       }
       // The one piece htmx does not model: telling the server which agent THIS session is viewing, so
@@ -165,15 +183,16 @@ internal object ProxyDashboardHtml {
       return
     }
     table("ptable") {
+      caption("sr-only") { +"Registered paths and the most recent scrape against each" }
       thead {
         tr {
-          th { +"Path" }
-          th { +"Agent(s)" }
-          th { +"Target" }
-          th { +"Src" }
-          th { +"Last scrape" }
-          th(classes = "num") { +"Status" }
-          th(classes = "num") { +"Duration" }
+          th(scope = ThScope.col) { +"Path" }
+          th(scope = ThScope.col) { +"Agent(s)" }
+          th(scope = ThScope.col) { +"Target" }
+          th(scope = ThScope.col) { +"Src" }
+          th(scope = ThScope.col) { +"Last scrape" }
+          th(scope = ThScope.col, classes = "num") { +"Status" }
+          th(scope = ThScope.col, classes = "num") { +"Duration" }
         }
       }
       tbody {
@@ -182,7 +201,8 @@ internal object ProxyDashboardHtml {
             td { +"/${path.path}" }
             td {
               // A departed path still names who was serving it -- that is usually the whole answer.
-              +(path.servingAgent ?: DASH)
+              // Named the way the agent list names it, so the two layouts can be read against each other.
+              +(path.servingAgent?.let(::agentLabel) ?: DASH)
               if (path.isDeparted) span("tag crit") { +"gone" }
               if (path.additionalAgents > 0) span("dim") { +" +${path.additionalAgents}" }
             }
@@ -227,6 +247,12 @@ internal object ProxyDashboardHtml {
     }
     span { +"${snapshot.health.agentCount} agents" }
     span { +"${snapshot.health.pathCount} paths" }
+    // health.pathCount counts registrations, so a departed path is deliberately absent from it -- which
+    // read as the bar contradicting the table it sits above ("0 paths" over three visible rows). Naming
+    // the departed count separately keeps both numbers true and explains the difference.
+    val departed = snapshot.paths.count { it.isDeparted }
+    if (departed > 0)
+      span("crit") { +"$departed departed" }
     val h = snapshot.health
     span(if (h.chunkContextHealthy && h.scrapeMapHealthy) "ok" else "warn") {
       +"chunks ${h.chunkContextSize}/${h.chunkContextThreshold} · scrapes ${h.scrapeMapSize}/${h.scrapeMapThreshold}"
@@ -406,11 +432,16 @@ internal object ProxyDashboardHtml {
     selectedId: String?,
   ): String = createHTML().div("md-detail") { detailInner(snapshot, selectedId, oob = false) }
 
-  private fun AgentView.displayName(): String =
-    // Identity arrives at registerAgent, which is strictly after the transport filter created this
-    // context -- so a just-connected agent legitimately has none yet. Showing the raw placeholder
-    // would read as corruption rather than as a normal transient state.
-    if (agentName == UNASSIGNED) "(registering…)" else agentName
+  private fun AgentView.displayName(): String = agentLabel(agentName)
+
+  /**
+   * Identity arrives at `registerAgent`, which is strictly after the transport filter created the
+   * context — so a just-connected agent legitimately has none yet. Showing the raw placeholder would
+   * read as corruption rather than as a normal transient state.
+   *
+   * Shared by both layouts so one agent never appears under two different labels.
+   */
+  private fun agentLabel(name: String): String = if (name == UNASSIGNED) "(registering…)" else name
 
   private fun humanize(duration: Duration): String =
     when {
@@ -474,7 +505,24 @@ internal object ProxyDashboardHtml {
       // instant the socket reopens -- the very next push then re-renders the bar in its healthy state.
       // Deliberately not set on 'htmx:wsConnecting': that also fires for the first connect on load, and
       // reacting to it would flash the indicator red before the initial open.
-      function connected(up) { document.body.classList.toggle('ws-down', !up); }
+      //
+      // The same transition is spoken into the live region. The beacon reports this visually with colour
+      // and a change of rhythm, neither of which reaches a screen reader; without this the page goes
+      // silently stale, which is the one failure this dashboard exists to make impossible to miss.
+      // Scoped to the connection alone -- announcing every pushed counter would make the region unusable.
+      var wasDown = false;
+      function announceConn(up) {
+        var region = document.getElementById('$ANNOUNCER_ID');
+        if (!region) return;
+        // Nothing to say about the first successful connect; only a recovery from a real outage.
+        if (!up) region.textContent = 'Connection to the proxy lost. Reconnecting.';
+        else if (wasDown) region.textContent = 'Connection to the proxy restored.';
+      }
+      function connected(up) {
+        document.body.classList.toggle('ws-down', !up);
+        announceConn(up);
+        wasDown = !up;
+      }
       document.body.addEventListener('htmx:wsOpen', function () { connected(true); });
       document.body.addEventListener('htmx:wsClose', function () { connected(false); });
       document.body.addEventListener('htmx:wsError', function () { connected(false); });
@@ -486,28 +534,43 @@ internal object ProxyDashboardHtml {
 
   private val CSS =
     """
+    /* Every quiet colour is set so its *worst* pairing still clears 4.5:1, not just its pairing with
+       --surface. --ink-3 is the binding case: it lands on --surface-2 under the table and section
+       headers, which is a full step closer than the reading plane. */
     :root {
       --bg:#f2f5f8; --surface:#fff; --surface-2:#e9edf2; --surface-3:#dde3ea;
-      --line:#cfd7e0; --line-soft:#e3e9ef; --ink:#131820; --ink-2:#48525f; --ink-3:#78828f;
-      --accent:#c8461f; --ok:#1f8a4c; --ok-soft:#e3f4ea; --warn:#a8710a; --warn-soft:#f9f0da;
+      --line:#cfd7e0; --line-soft:#e3e9ef; --ink:#131820; --ink-2:#48525f; --ink-3:#626b77;
+      --accent:#c8461f; --ok:#1a7a42; --ok-soft:#e3f4ea; --warn:#8a5d08; --warn-soft:#f9f0da;
       --crit:#c02a20; --crit-soft:#fbe6e4;
       --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
     }
     @media (prefers-color-scheme: dark) {
       :root {
         --bg:#0d1015; --surface:#151a21; --surface-2:#1c222b; --surface-3:#242c37;
-        --line:#2b333f; --line-soft:#212934; --ink:#e7ebf1; --ink-2:#a4aebc; --ink-3:#6f7986;
+        --line:#2b333f; --line-soft:#212934; --ink:#e7ebf1; --ink-2:#a4aebc; --ink-3:#858f9d;
         --accent:#ff7043; --ok:#3fb950; --ok-soft:#12251a; --warn:#d29922; --warn-soft:#2a2110;
         --crit:#f85149; --crit-soft:#2d1512;
       }
     }
+    /* Visible to assistive tech, absent from the render. Used for the connection announcer and the
+       table caption, both of which duplicate something the layout already says visually. */
+    .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden;
+      clip-path:inset(50%); white-space:nowrap; border:0; }
     * { box-sizing:border-box; margin:0; padding:0; }
-    body { background:var(--bg); color:var(--ink); font-family:var(--mono); font-size:12.5px; line-height:1.5; }
+    /* Column flex rather than a `calc(100vh - 44px)` on the content: the bar's height is set by its own
+       content and changes with the touch-target rules below, so any hard-coded number is wrong on some
+       viewport. This makes the content region exactly the remaining space, whatever the bar measures. */
+    body { background:var(--bg); color:var(--ink); font-family:var(--mono); font-size:12.5px; line-height:1.5;
+           display:flex; flex-direction:column; min-height:100vh; }
+    body > main { flex:1; }
     .bar { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px;
            padding:11px 15px; border-bottom:1px solid var(--line); background:var(--surface); }
     .brand { font-weight:600; }
-    .bar-right { display:flex; align-items:center; gap:14px; color:var(--ink-3); font-size:11.5px; }
-    .bar-right .ok { color:var(--ok); } .bar-right .warn { color:var(--warn); }
+    .bar-right { display:flex; align-items:center; flex-wrap:wrap; gap:14px; color:var(--ink-3); font-size:11.5px; }
+    /* Each stat stays whole; the row wraps between them rather than mid-phrase, which at 390px was
+       splitting "0 agents" across two lines. */
+    .bar-right > span { white-space:nowrap; }
+    .bar-right .ok { color:var(--ok); } .bar-right .warn { color:var(--warn); } .bar-right .crit { color:var(--crit); }
     .conn { display:inline-flex; align-items:center; gap:6px; color:var(--ok); }
     .conn .conn-down { display:none; }
     .beacon { width:7px; height:7px; border-radius:50%; background:var(--ok); animation:pulse 2.4s ease-out infinite; }
@@ -521,7 +584,7 @@ internal object ProxyDashboardHtml {
     body.ws-down .beacon { background:var(--crit); animation:blink 1s steps(2, start) infinite; }
     @keyframes blink { 0%{opacity:1} 50%{opacity:.25} 100%{opacity:1} }
     @media (prefers-reduced-motion: reduce) { .beacon, body.ws-down .beacon { animation:none } }
-    .md { display:grid; grid-template-columns:262px 1fr; min-height:calc(100vh - 44px); }
+    .md { display:grid; grid-template-columns:262px 1fr; }
     .md-list { border-right:1px solid var(--line); background:var(--surface-2); }
     .md-head, .section { display:flex; justify-content:space-between; padding:9px 15px; font-size:10px;
       letter-spacing:.09em; text-transform:uppercase; color:var(--ink-3); font-weight:600;
@@ -532,7 +595,9 @@ internal object ProxyDashboardHtml {
     .md-row:hover { background:var(--surface-3); }
     .md-row:focus-visible { outline:2px solid var(--accent); outline-offset:-2px; }
     .md-row[aria-current="true"] { background:var(--surface); border-left-color:var(--accent); }
-    .md-row .host { display:block; color:var(--ink-3); font-size:11px; margin-top:2px; }
+    /* 11.5px, matching .bar-right and .hero-meta: this is the same job -- quiet supporting metadata --
+       and a separate 11px step for it was a size the hierarchy never used. */
+    .md-row .host { display:block; color:var(--ink-3); font-size:11.5px; margin-top:2px; }
     .md-detail { background:var(--surface); }
     .hero { padding:14px 18px; border-bottom:1px solid var(--line); }
     .hero-title { font-size:15px; font-weight:640; display:flex; align-items:center; gap:9px; }
@@ -569,5 +634,11 @@ internal object ProxyDashboardHtml {
     .ptable tr.departed td:first-child { color:var(--crit); }
     .tag.crit { background:var(--crit-soft); color:var(--crit); margin-left:7px; }
     @media (max-width:720px) { .md { grid-template-columns:1fr; } .md-list { border-right:0; border-bottom:1px solid var(--line); } }
+    /* Touch, not width: a 25px pill is a comfortable mouse target and a poor thumb one, and the two do
+       not correlate with viewport size -- a tablet is wide and touch-driven. The dense bar is kept for
+       pointer devices rather than spending vertical space everyone pays for. */
+    @media (pointer: coarse) {
+      .nav a { min-height:44px; display:inline-flex; align-items:center; padding:0 14px; }
+    }
     """.trimIndent()
 }

--- a/src/main/kotlin/io/prometheus/proxy/dashboard/ProxySnapshot.kt
+++ b/src/main/kotlin/io/prometheus/proxy/dashboard/ProxySnapshot.kt
@@ -38,9 +38,17 @@ internal data class PathView(
   val pathSource: String = "",
   val lastScrape: ScrapeRecord? = null,
   val isDeparted: Boolean = false,
+  val agentNames: List<String> = emptyList(),
 ) {
-  /** The agent that last served this path, which for a departed path is the only attribution left. */
-  val servingAgent: String? get() = agentIds.firstOrNull() ?: lastScrape?.agentId
+  /**
+   * The agent that last served this path, named the way the agent list names it.
+   *
+   * Deliberately a name and not an [agentIds] entry: the two layouts are read together — an operator
+   * finds a failing path here and then looks that agent up in the agent view — and an internal id would
+   * force them to translate between the two by hand. For a departed path the name comes from the last
+   * scrape, which is the only attribution that outlives the agent.
+   */
+  val servingAgent: String? get() = agentNames.firstOrNull() ?: lastScrape?.agentName
 
   /** How many agents beyond the first back this path, for the `+N` marker on a consolidated row. */
   val additionalAgents: Int get() = (agentIds.size - 1).coerceAtLeast(0)
@@ -140,6 +148,8 @@ internal data class ProxySnapshot(
         latestByPath
           .filterKeys { it !in registeredPaths }
           .map { (path, record) ->
+            // agentNames stays empty: the agent is gone, so servingAgent falls through to the name the
+            // scrape record captured while it was still here.
             PathView(path = path, agentIds = emptyList(), labels = "", lastScrape = record, isDeparted = true)
           }
 
@@ -185,6 +195,7 @@ internal data class ProxySnapshot(
               labels = info.labels,
               targetUrl = info.targetUrl,
               pathSource = info.pathSource,
+              agentNames = info.agentContexts.map { it.agentName },
             )
           }
           .sortedBy { it.path }

--- a/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/ProxyHttpRoutesTest.kt
@@ -81,16 +81,18 @@ class ProxyHttpRoutesTest : StringSpec() {
     response: ScrapeRequestResponse,
     proxy: Proxy,
     agentId: String = "test-agent",
+    agentName: String = "test-agent-name",
   ) {
     val method = ProxyHttpRoutes::class.java.getDeclaredMethod(
       "recordScrapeOutcome",
+      String::class.java,
       String::class.java,
       String::class.java,
       ScrapeRequestResponse::class.java,
       Proxy::class.java,
     )
     method.isAccessible = true
-    method.invoke(ProxyHttpRoutes, path, agentId, response, proxy)
+    method.invoke(ProxyHttpRoutes, path, agentId, agentName, response, proxy)
   }
 
   private fun createSpyProxyForSubmit(

--- a/src/test/kotlin/io/prometheus/proxy/dashboard/DashboardFixtures.kt
+++ b/src/test/kotlin/io/prometheus/proxy/dashboard/DashboardFixtures.kt
@@ -39,7 +39,8 @@ internal object DashboardFixtures {
     pathSource: String = "",
     lastScrape: ScrapeRecord? = null,
     isDeparted: Boolean = false,
-  ) = PathView(path, agentIds, labels, targetUrl, pathSource, lastScrape, isDeparted)
+    agentNames: List<String> = agentIds.map { "agent-$it" },
+  ) = PathView(path, agentIds, labels, targetUrl, pathSource, lastScrape, isDeparted, agentNames)
 
   fun agentView(
     agentId: String = "1",
@@ -72,7 +73,8 @@ internal object DashboardFixtures {
     durationMillis: Long = 41,
     contentLength: Int = 1800,
     at: Instant = Instant.now(),
-  ) = ScrapeRecord(agentId, path, statusCode, outcome, durationMillis, contentLength, at)
+    agentName: String = "agent-$agentId",
+  ) = ScrapeRecord(agentId, agentName, path, statusCode, outcome, durationMillis, contentLength, at)
 
   /**
    * A snapshot whose `paths` defaults to the agents' own paths, matching what

--- a/src/test/kotlin/io/prometheus/proxy/dashboard/ProxyDashboardHtmlTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/dashboard/ProxyDashboardHtmlTest.kt
@@ -55,6 +55,9 @@ class ProxyDashboardHtmlTest : StringSpec() {
     paths: List<PathView> = agents.flatMap { it.paths }.distinct(),
   ) = DashboardFixtures.snapshot(agents = agents, scrapes = scrapes, paths = paths)
 
+  private fun renderFullPage(layout: DashboardLayout = DashboardLayout.AGENT) =
+    createHTML().html { with(ProxyDashboardHtml) { renderPage(snapshot(), null, "/dashboard", layout) } }
+
   init {
     "the push fragment should carry out-of-band swaps for every live region" {
       val html = ProxyDashboardHtml.pushFragment(snapshot(), selectedId = "1", dashboardPath = "/dashboard")
@@ -106,8 +109,15 @@ class ProxyDashboardHtmlTest : StringSpec() {
     "the detail pane should show only the selected agent's scrapes" {
       val scrapes =
         [
-          ScrapeRecord("1", "app_metrics", 200, "success", 41, 1800),
-          ScrapeRecord("2", "other_metrics", 503, "agent_disconnected", 0, 0),
+          DashboardFixtures.scrapeRecord(agentId = "1", path = "app_metrics"),
+          DashboardFixtures.scrapeRecord(
+            agentId = "2",
+            path = "other_metrics",
+            statusCode = 503,
+            outcome = "agent_disconnected",
+            durationMillis = 0,
+            contentLength = 0,
+          ),
         ]
       val html = ProxyDashboardHtml.detailFragment(snapshot(scrapes = scrapes), selectedId = "1")
 
@@ -189,22 +199,57 @@ class ProxyDashboardHtmlTest : StringSpec() {
         DashboardFixtures.pathView(
           path = "redis_metrics",
           agentIds = emptyList(),
-          lastScrape = DashboardFixtures.scrapeRecord(agentId = "agent-9", path = "redis_metrics", statusCode = 503),
+          agentNames = emptyList(),
+          lastScrape =
+            DashboardFixtures.scrapeRecord(
+              agentId = "9",
+              agentName = "cache-tier-01",
+              path = "redis_metrics",
+              statusCode = 503,
+            ),
           isDeparted = true,
         )
       val html = ProxyDashboardHtml.pushFragment(snapshot(paths = [departed]), null, "/dashboard", DashboardLayout.PATH)
 
       html shouldContain "/redis_metrics"
       html shouldContain "gone"
-      html shouldContain "agent-9"
+      html shouldContain "cache-tier-01"
       html shouldContain "503"
     }
 
+    // The two layouts are read against each other -- find the failing path here, look the agent up
+    // there. Rendering the internal id in one view and the name in the other made that a manual
+    // translation step, and on a proxy with forty agents an unusable one.
+    "the path table should name its agent the way the agent list does, never by internal id" {
+      val served =
+        DashboardFixtures.pathView(path = "ledger_metrics", agentIds = ["17"], agentNames = ["edge-eu-west-2"])
+      val html = ProxyDashboardHtml.pushFragment(snapshot(paths = [served]), null, "/dashboard", DashboardLayout.PATH)
+
+      html shouldContain "edge-eu-west-2"
+      // The bare id must not appear as the cell's whole contents.
+      html shouldNotContain ">17<"
+    }
+
+    // An agent that has connected but not yet registered gets the same treatment in both layouts, so
+    // one agent never shows up under two different labels.
+    "a path served by a not-yet-registered agent should show the same placeholder as the agent list" {
+      val pending = DashboardFixtures.pathView(path = "new_metrics", agentIds = ["3"], agentNames = ["Unassigned"])
+      val html = ProxyDashboardHtml.pushFragment(snapshot(paths = [pending]), null, "/dashboard", DashboardLayout.PATH)
+
+      html shouldNotContain "Unassigned"
+      html shouldContain "registering"
+    }
+
     "a consolidated path should collapse its extra agents into a count" {
-      val shared = DashboardFixtures.pathView(path = "shared_svc", agentIds = ["a1", "a2", "a3"])
+      val shared =
+        DashboardFixtures.pathView(
+          path = "shared_svc",
+          agentIds = ["a1", "a2", "a3"],
+          agentNames = ["team-a-01", "team-a-02", "team-a-03"],
+        )
       val html = ProxyDashboardHtml.pushFragment(snapshot(paths = [shared]), null, "/dashboard", DashboardLayout.PATH)
 
-      html shouldContain "a1"
+      html shouldContain "team-a-01"
       html shouldContain "+2"
     }
 
@@ -252,6 +297,69 @@ class ProxyDashboardHtmlTest : StringSpec() {
         DashboardLayout.PATH,
       ) shouldContain
         "No paths registered"
+    }
+
+    // ==================== Status bar ====================
+
+    // health.pathCount counts registrations, so departed paths are deliberately absent from it. Left
+    // unexplained that reads as the bar contradicting the table under it -- "0 paths" above three rows.
+    "the status bar should name departed paths so its count stops contradicting the table" {
+      val departed =
+        DashboardFixtures.pathView(
+          path = "orphan_metrics",
+          agentIds = emptyList(),
+          agentNames = emptyList(),
+          lastScrape = DashboardFixtures.scrapeRecord(path = "orphan_metrics"),
+          isDeparted = true,
+        )
+      val snap = DashboardFixtures.snapshot(agents = emptyList(), paths = [departed])
+
+      ProxyDashboardHtml.pushFragment(snap, null, "/dashboard", DashboardLayout.PATH) shouldContain "1 departed"
+    }
+
+    "the status bar should stay quiet about departed paths when there are none" {
+      ProxyDashboardHtml.pushFragment(snapshot(), null, "/dashboard") shouldNotContain "departed"
+    }
+
+    // ==================== Accessibility ====================
+
+    // The beacon reports connection state with colour and a change of rhythm, neither of which reaches a
+    // screen reader. Without a live region the page just goes silently stale.
+    "the page should carry a polite live region for connection state" {
+      val html = renderFullPage()
+
+      html shouldContain """id="${ProxyDashboardHtml.ANNOUNCER_ID}""""
+      html shouldContain """aria-live="polite""""
+      html shouldContain """role="status""""
+      html shouldContain "Connection to the proxy lost"
+      html shouldContain "Connection to the proxy restored"
+    }
+
+    // A region the push loop rewrites would re-announce itself on every frame; this one is written only
+    // by the socket lifecycle handlers, so it must stay out of every out-of-band fragment.
+    "the live region must not be part of any pushed fragment" {
+      ProxyDashboardHtml.pushFragment(snapshot(), "1", "/dashboard") shouldNotContain ProxyDashboardHtml.ANNOUNCER_ID
+      ProxyDashboardHtml.pushFragment(
+        snapshot(),
+        null,
+        "/dashboard",
+        DashboardLayout.PATH,
+      ) shouldNotContain ProxyDashboardHtml.ANNOUNCER_ID
+    }
+
+    "the page should declare its language and mark its main region" {
+      val html = renderFullPage()
+
+      html shouldContain """lang="en""""
+      html shouldContain "<main"
+    }
+
+    "the path table should be captioned and its headers scoped" {
+      val html = renderFullPage(DashboardLayout.PATH)
+
+      html shouldContain """scope="col""""
+      html shouldContain "<caption"
+      html shouldContain "Registered paths"
     }
 
     // Layout is derived from the URL on both sides -- the server for the initial render, the browser for

--- a/src/test/kotlin/io/prometheus/proxy/dashboard/ProxySnapshotTest.kt
+++ b/src/test/kotlin/io/prometheus/proxy/dashboard/ProxySnapshotTest.kt
@@ -99,13 +99,27 @@ class ProxySnapshotTest : StringSpec() {
     // A departed path's only remaining attribution is the scrape record, since its agent list is empty
     // by definition -- so servingAgent has to fall through to it or the row says nothing useful.
     "a path view should name its serving agent, falling back to the last scrape" {
-      DashboardFixtures.pathView(agentIds = ["a1", "a2"]).servingAgent shouldBe "a1"
+      DashboardFixtures.pathView(
+        agentIds = ["a1", "a2"],
+        agentNames = ["team-a-01", "team-a-02"],
+      ).servingAgent shouldBe "team-a-01"
       DashboardFixtures.pathView(
         agentIds = emptyList(),
-        lastScrape = DashboardFixtures.scrapeRecord(agentId = "departed-7"),
+        agentNames = emptyList(),
+        lastScrape = DashboardFixtures.scrapeRecord(agentId = "7", agentName = "departed-07"),
         isDeparted = true,
-      ).servingAgent shouldBe "departed-7"
-      DashboardFixtures.pathView(agentIds = emptyList()).servingAgent.shouldBeNull()
+      ).servingAgent shouldBe "departed-07"
+      DashboardFixtures.pathView(agentIds = emptyList(), agentNames = emptyList()).servingAgent.shouldBeNull()
+    }
+
+    // The two layouts are read against each other: an operator finds a failing path here, then looks
+    // that agent up in the agent list. An internal id in one view and a name in the other would make
+    // that a manual translation step, which is the whole reason servingAgent is a name.
+    "a path view should identify its agent by name, never by internal id" {
+      DashboardFixtures.pathView(
+        agentIds = ["17"],
+        agentNames = ["edge-eu-west-2"],
+      ).servingAgent shouldBe "edge-eu-west-2"
     }
 
     "additional agent count should drive the consolidated marker and never go negative" {
@@ -149,7 +163,15 @@ class ProxySnapshotTest : StringSpec() {
     // The gap this whole layout exists to close. The proxy deletes a path the moment its last agent
     // disconnects, so without this union a target that stopped serving vanishes silently.
     "a scraped path that is no longer registered should appear as departed" {
-      val scrapes = [DashboardFixtures.scrapeRecord(agentId = "agent-9", path = "orphan_metrics", statusCode = 503)]
+      val scrapes =
+        [
+          DashboardFixtures.scrapeRecord(
+            agentId = "9",
+            agentName = "warehouse-01",
+            path = "orphan_metrics",
+            statusCode = 503,
+          ),
+        ]
 
       val views = ProxySnapshot.buildPathViews(emptyList(), scrapes)
 
@@ -157,8 +179,9 @@ class ProxySnapshotTest : StringSpec() {
         path shouldBe "orphan_metrics"
         isDeparted.shouldBeTrue()
         agentIds.shouldBeEmpty()
-        // The departed agent is the only attribution left, and it is what an operator needs.
-        servingAgent shouldBe "agent-9"
+        // The departed agent is the only attribution left, and it is what an operator needs -- by the
+        // name the agent list used for it, not the id, which is why ScrapeRecord captures the name.
+        servingAgent shouldBe "warehouse-01"
         lastScrape?.statusCode shouldBe 503
       }
     }


### PR DESCRIPTION
Audited the operational dashboard against a live proxy and agent in headless Chrome — both themes, both layouts, 1280px and 390px — and fixed what the measurements found. Contrast numbers here are measured from real renders, not computed by hand.

## Agent identification

`PathView` carried only `agentId`, so the path table showed `1` where the agent list showed the agent's name. The two layouts are meant to be read against each other — find a failing path here, look that agent up there — so an internal id in one view forced a manual translation, and on a proxy with forty agents an impractical one.

`ScrapeRecord` and `PathView` now carry `agentName`, and both layouts share one `agentLabel()` so a not-yet-registered agent never appears under two different labels. Ids remain for grouping; only display changed.

## Contrast: 29 AA failures to zero

Lowest ratio is now **4.59:1**. Three tokens were a step too light — `ink-3` (`#78828f`/`#6f7986`), `ok` (`#1f8a4c`) and `warn` (`#a8710a`), the last failing in a state no fixture had rendered.

Every failure traced to the same mistake: these colors were tuned against `--surface`, but each also lands on `--surface-2`, a full tonal step tighter, under every table and section header. The rule that came out of it — check a color against the worst ground it touches, not its most flattering one — is now recorded in `DESIGN.md` so the next change doesn't repeat it.

## Accessibility

Added `lang`, a `main` landmark, column scopes and a caption on the path table, and a polite live region announcing connection loss and recovery. The beacon reports connection state with colour and a change of rhythm, neither of which reaches a screen reader, so the page could go silently stale.

The live region sits outside every out-of-band id on purpose: one the push loop rewrote would re-announce itself on every frame. There's a regression test pinning that.

## Layout

- Replaced `calc(100vh - 44px)` with column flex, which also fixed a latent 4px page scroll — the bar actually measures 48px.
- Nav links reach a 44px target under `pointer: coarse` only, since target size follows the input device rather than the viewport.
- Status-bar stats no longer wrap mid-phrase at 390px.
- A departed count explains why the paths counter can read 0 above three visible rows.

## Design system

`PRODUCT.md` records product truth; `DESIGN.md` and its `.impeccable/design.json` sidecar record the visual system, including the measured contrast floor to preserve. The vendored skill tooling that produced them is gitignored — the durable output is these files, not the tool. The last two commits scope those ignores to per-machine state only, so `.impeccable/design.json` stays tracked.

## Verification

Contrast and layout were re-measured in headless Chrome after each fix. `./gradlew detekt lintKotlinMain lintKotlinTest test` passes on this branch. 8 tests added, 5 rewritten to the new agent-name contract — including one pinning the live region outside every out-of-band region, since that's the failure mode a future refactor would reintroduce silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
