### PR TITLE
Bump version to 4.0.1 and document the changes since 4.0.0

### DIFF
--- a/.claude/skills/publishing-release/SKILL.md
+++ b/.claude/skills/publishing-release/SKILL.md
@@ -15,4 +15,4 @@ Snapshot and Maven Central release Make targets (`publish-snapshot`, `publish-ma
 
 ## Bumping the version
 
-When bumping the version, update `version` in `gradle.properties` and the `4.0.0` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.
+When bumping the version, update `version` in `gradle.properties` and the `4.0.1` literals in `README.md` and `llms.txt` (Docker tag examples + Maven Central dependency block). The release flow itself is documented in `docs/RELEASE.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## [4.0.1] - 2026-07-31
+
+### Bug Fixes
+
+- **The dashboard's path layout now identifies agents by name rather than internal id.** `PathView` carried only `agentId`, so the path table showed `1` where the agent list showed the agent's name. The two layouts are meant to be read against each other — find a failing path in one, look that agent up in the other — so an internal id in one view forced a manual translation, and on a proxy with forty agents an impractical one. `ScrapeRecord` and `PathView` now carry `agentName`, and both layouts share one `agentLabel()` helper so an agent that has not finished registering never appears under two different labels. Ids are still used for grouping; only the displayed value changed
+- **Fixed 29 WCAG AA contrast failures in the dashboard; the measured floor is now 4.59:1.** Three tokens were a step too light — `ink-3` (`#78828f` light / `#6f7986` dark), `ok` (`#1f8a4c`) and `warn` (`#a8710a`), the last failing in a state no test fixture had ever rendered. Every failure had the same cause: the colors were tuned against `--surface`, but each also lands on `--surface-2`, a full tonal step tighter, under every table and section header. Contrast was measured from real renders in headless Chrome across both themes, both layouts, and 1280px/390px viewports rather than computed by hand
+- **The dashboard was unusable with a screen reader.** Added the `lang` attribute, a `main` landmark, `scope` on the path table's column headers, and a table caption. Connection loss and recovery are now announced through a polite live region — the beacon reported that state with colour and a change of rhythm, neither of which reaches a screen reader, so the page could go silently stale while still appearing live. The live region is deliberately placed outside every out-of-band region: one the push loop rewrote would re-announce itself on every frame
+- **Fixed a latent 4px page scroll in the dashboard.** The main area sized itself with `calc(100vh - 44px)` against a status bar that actually measures 48px; it now uses column flex and derives the height instead of hard-coding it
+- Dashboard nav links now reach a 44px touch target under `pointer: coarse` only, since target size follows the input device rather than the viewport; status-bar stats no longer wrap mid-phrase at 390px; and a departed count explains why the paths counter can read `0` above three visible rows
+
+### Documentation
+
+- Add `PRODUCT.md` (product truth) and `DESIGN.md` plus its `.impeccable/design.json` sidecar (the dashboard's visual system: color tokens, typography roles, component inventory, and the named rules behind them). `DESIGN.md` records the measured contrast floor so a future color change can be checked against it
+- Fix Markdown link formatting in the documentation-links section of `README.md`
+
+### Internal
+
+- Replace the last `java.util.concurrent.atomic` holdout in the codebase with `kotlin.concurrent.atomics.AtomicBoolean` in `MetricFilter`, matching the named-argument `compareAndSet` idiom used elsewhere. No behavior change
+- Update the documentation site's Python dependency lock (`website/uv.lock`) to current releases
+
 ## [4.0.0] - 2026-07-25
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project are documented in this file.
 ### Internal
 
 - Replace the last `java.util.concurrent.atomic` holdout in the codebase with `kotlin.concurrent.atomics.AtomicBoolean` in `MetricFilter`, matching the named-argument `compareAndSet` idiom used elsewhere. No behavior change
-- Update the documentation site's Python dependency lock (`website/uv.lock`) to current releases
+- Update dependencies: gRPC 1.83.0 → 1.83.1, Ktor 3.5.1 → 3.5.2, Logback 1.6.0 → 1.6.1, common-utils 3.2.1 → 3.2.2, and the `pambrose-gradle-plugins` convention plugins 1.1.0 → 1.1.1
+- Move the Gradle versions plugin to its new coordinate (`com.github.ben-manes.versions` → `io.github.ben-manes.versions`) and update it 0.54.0 → 0.57.0
+- Update the documentation site's Python dependency lock (`website/uv.lock`): Zensical 0.0.51 → 0.0.52 and Markdown 3.10.2 → 3.10.3
 
 ## [4.0.0] - 2026-07-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,14 @@ aren't in the proto: chunked responses kick in above 32KB, and the heartbeat fir
 - **Metric filtering**: `MetricFilter` (per-path `agent.filters`) drops whole metric families in `AgentHttpService` before gzip/chunking; fails open on non-text or non-UTF-8 payloads.
 - **Dashboard**: Ktor + htmx (WebJar, no CDN) on its own port, fed by the `ProxyEvent` bus; see `proxy/dashboard/`.
 
+### Dashboard Design Constraints
+
+`DESIGN.md` is the visual contract (color tokens, typography roles, components) and `PRODUCT.md` the product one; both are tracked, while the tooling that generated them is gitignored. Three constraints in `ProxyDashboardHtml.kt` are load-bearing and easy to undo by accident:
+
+- **The live region must stay outside every `hx-swap-oob` region.** A region the push loop rewrites re-announces itself on every frame. `ProxyDashboardHtmlTest` pins this.
+- **Check a color against `--surface-2`, not `--surface`.** Every token also lands on the tighter ground under tables and section headers, which is where all 29 of the contrast failures fixed in 4.0.1 lived. The measured AA floor is 4.59:1 — `DESIGN.md` records the per-token values.
+- **Both layouts must render agent identity through `agentLabel()`.** The agent and path views are read against each other, so a divergent label (or a raw `agentId`) defeats the correlation they exist for.
+
 ## Configuration
 
 Uses Typesafe Config (HOCON). Precedence: CLI args → env vars → config file → built-in defaults. Reference schema: `config/config.conf`. Example configs in `examples/`.
@@ -95,7 +103,7 @@ The `ConfigVals` class is auto-generated from the HOCON schema using tscfg (`mak
 `group` and `version` live in `gradle.properties` (single source of truth). The version can be overridden on the command line for CI snapshot publishing:
 
 ```bash
-./gradlew build -PoverrideVersion=4.0.0-SNAPSHOT
+./gradlew build -PoverrideVersion=4.0.1-SNAPSHOT
 ```
 
 `-PoverrideVersion` keeps its `override` prefix because it intentionally only applies when supplied (so the `gradle.properties` default is never accidentally cleared).

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -133,7 +133,7 @@ lives relative to the docs site.
 
 **Real and usable:**
 
-- **Repo signals only** — GitHub releases (v4.0.0, released 2026-07-25), Docker Hub pull counts for
+- **Repo signals only** — GitHub releases (v4.0.1, released 2026-07-31), Docker Hub pull counts for
   both images, Maven Central presence, Apache 2.0 license, CI / Codecov / Codacy badges. All
   independently verifiable.
 - **Working configuration and demonstration** — the config examples under `examples/`, the reference

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ behind a firewall and preserves the native pull-based model architecture.
 
 ## ✨ New Features
 
-Version 4.0.0 (released 2026-07-25) adds five features focused on running the proxy as production
+Version 4.0.1 (released 2026-07-31) is a dashboard patch release: agents are now identified by name
+rather than internal id in the path layout, 29 WCAG AA contrast failures are fixed (measured floor
+4.59:1), and the page is usable with a screen reader — see the
+[changelog](CHANGELOG.md) for the full list. Nothing in it changes configuration, metrics, or the wire
+protocol.
+
+Version 4.0.0 (released 2026-07-25) added five features focused on running the proxy as production
 infrastructure:
 
 - **[Operational Dashboard](https://pambrose.github.io/prometheus-proxy/web-dashboard/)** — A
@@ -169,12 +175,12 @@ If you prefer to build the project from source:
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:4.0.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:4.0.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:4.0.0
+  pambrose/prometheus-agent:4.0.1
 ```
 
 ## 📋 Configuration Examples
@@ -256,8 +262,8 @@ scrape_configs:
 The docker images support multiple architectures (amd64, arm64, s390x, ppc64le):
 
 ```bash
-docker pull pambrose/prometheus-proxy:4.0.0
-docker pull pambrose/prometheus-agent:4.0.0
+docker pull pambrose/prometheus-proxy:4.0.1
+docker pull pambrose/prometheus-agent:4.0.1
 ```
 
 ### Production Docker Setup
@@ -270,7 +276,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50051:50051 -p 8080:8080 \
         --env ADMIN_ENABLED=true \
         --env METRICS_ENABLED=true \
         --restart unless-stopped \
-        pambrose/prometheus-proxy:4.0.0
+        pambrose/prometheus-proxy:4.0.1
 ```
 
 Start an agent container with:
@@ -280,7 +286,7 @@ Start an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
         --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
         --restart unless-stopped \
-        pambrose/prometheus-agent:4.0.0
+        pambrose/prometheus-agent:4.0.1
 ```
 
 Or use docker-compose: see `etc/compose/proxy.yml` for a working example.
@@ -301,7 +307,7 @@ is in your current directory, run an agent container with:
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
     --env AGENT_CONFIG=prom-agent.conf \
-    pambrose/prometheus-agent:4.0.0
+    pambrose/prometheus-agent:4.0.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -509,10 +515,15 @@ java -jar prometheus-proxy.jar --dashboard    # or DASHBOARD_ENABLED=true / prox
 ```
 
 Then open `http://proxy-host:8094/dashboard`. Two layouts share the page: **Agents** (drill into one
-agent) and **Paths** (one row per target). It runs on its own port — not the admin port — so it can be
-firewalled without cutting off Kubernetes health probes, and it loads no CDN assets, so it works in
-airgapped deployments. Like the admin and metrics endpoints it has **no authentication or TLS**: keep
-the port internal.
+agent) and **Paths** (one row per target). Both name the agent serving a path, so the two layouts can
+be read against each other. It runs on its own port — not the admin port — so it can be firewalled
+without cutting off Kubernetes health probes, and it loads no CDN assets, so it works in airgapped
+deployments. Like the admin and metrics endpoints it has **no authentication or TLS**: keep the port
+internal.
+
+Accessibility: text and UI colors clear the WCAG AA contrast thresholds with a measured floor of
+4.59:1, the path table carries proper header semantics, and connection loss and recovery are
+announced to screen readers rather than signalled by colour alone.
 
 > 📖 **Docs site:** [Dashboard guide](https://pambrose.github.io/prometheus-proxy/web-dashboard/) for both layouts, the status-bar gauges, and HA-pair behavior.
 
@@ -714,7 +725,7 @@ docker run --rm -p 8082:8082 -p 8092:8092 -p 50440:50440 -p 8080:8080 \
     --env PROXY_CONFIG=tls-no-mutual-auth.conf \
     --env ADMIN_ENABLED=true \
     --env METRICS_ENABLED=true \
-    pambrose/prometheus-proxy:4.0.0
+    pambrose/prometheus-proxy:4.0.1
 
 docker run --rm -p 8083:8083 -p 8093:8093 \
     --mount type=bind,source="$(pwd)"/testing/certs,target=/app/testing/certs \
@@ -722,7 +733,7 @@ docker run --rm -p 8083:8083 -p 8093:8093 \
     --env AGENT_CONFIG=tls-no-mutual-auth.conf \
     --env PROXY_HOSTNAME=mymachine.lan:50440 \
     --name docker-agent \
-    pambrose/prometheus-agent:4.0.0
+    pambrose/prometheus-agent:4.0.1
 ```
 
 **Note:** The `WORKDIR` of the proxy and agent images is `/app`, so make sure to use `/app` as the base directory in the
@@ -898,7 +909,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:4.0.0")
+  implementation("com.pambrose:prometheus-proxy:4.0.1")
 }
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,74 @@
 
 ---
 
+## 4.0.1
+
+_Released 2026-07-31_
+
+A patch release that fixes the operational dashboard shipped in 4.0.0. Nothing here changes
+configuration, metrics, or the wire protocol — upgrading is a drop-in replacement.
+
+### Highlights
+
+- **The path layout now names the agent instead of showing an internal id.** The dashboard's two
+  layouts are meant to be read against each other — find a failing path in the path view, look that
+  agent up in the agent view — but the path table printed `1` where the agent list printed the agent's
+  name. The correlation the two-layout design exists to support required a manual translation, and on
+  a proxy with forty agents that is not a translation anyone is going to do at 3am.
+
+- **The dashboard is now usable with a screen reader.** It previously had no `lang`, no `main`
+  landmark, no column scopes or caption on the path table, and — most consequentially — no way to
+  announce that the connection had dropped. The live indicator reports that with colour and a change
+  of rhythm, neither of which reaches assistive technology, so the page could go stale while still
+  reading as live.
+
+- **29 contrast failures are fixed; the measured floor is 4.59:1.** These were found by measuring
+  real renders rather than by reading the stylesheet, which is why the count was 29 rather than the
+  handful an eyeball audit would have produced.
+
+### What changed in the dashboard
+
+**Agent identity.** `ScrapeRecord` and `PathView` now carry `agentName` alongside `agentId`, and both
+layouts render through one shared `agentLabel()` so an agent that has not finished registering can
+never appear under two different labels in two places. Ids are still used for grouping and routing;
+only the displayed value changed.
+
+**Contrast.** Three tokens were a step too light: `ink-3` (`#78828f` light / `#6f7986` dark), `ok`
+(`#1f8a4c`), and `warn` (`#a8710a`). Every one of the 29 failures traced to the same mistake — the
+colors were tuned against `--surface`, but each also lands on `--surface-2`, a full tonal step
+tighter, underneath every table and section header. The `warn` token was failing in a state no test
+fixture had ever rendered, so no amount of reviewing the existing screenshots would have caught it.
+The rule that came out of this is recorded in `DESIGN.md`: check a color against the worst ground it
+touches, not its most flattering one.
+
+**Accessibility.** Added `lang`, a `main` landmark, `scope` on the path table's column headers, and a
+caption. Connection loss and recovery are announced through a polite live region. That region sits
+outside every out-of-band region on purpose — one the push loop rewrote would re-announce itself on
+every frame, turning a status message into a metronome. There is a test pinning that placement,
+because it is the kind of thing a later refactor breaks silently.
+
+**Layout.** The main area sized itself with `calc(100vh - 44px)` against a status bar that actually
+measures 48px, which is a latent 4px page scroll; it now uses column flex and derives the height.
+Nav links reach a 44px touch target under `pointer: coarse` only, since target size should follow the
+input device rather than the viewport — a narrow desktop window does not need finger-sized hit areas.
+Status-bar stats no longer wrap mid-phrase at 390px, and a departed count now explains why the paths
+counter can read `0` while three rows are visible.
+
+All of this was verified by driving a live proxy and agent in headless Chrome across both themes,
+both layouts, and both viewport widths, and re-measuring after each fix.
+
+### Also in this release
+
+- `PRODUCT.md` and `DESIGN.md` (with a `.impeccable/design.json` sidecar) now record the dashboard's
+  product and visual systems — color tokens, typography roles, component inventory, and the reasoning
+  behind them. `DESIGN.md` carries the measured contrast floor, so the next color change has
+  something to be checked against.
+- `MetricFilter` now uses `kotlin.concurrent.atomics.AtomicBoolean`, the last
+  `java.util.concurrent.atomic` holdout in the codebase. No behavior change.
+- Markdown link formatting fixed in the README's documentation section.
+
+---
+
 ## 4.0.0
 
 _Released 2026-07-25_

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,19 @@ both layouts, and both viewport widths, and re-measuring after each fix.
   `java.util.concurrent.atomic` holdout in the codebase. No behavior change.
 - Markdown link formatting fixed in the README's documentation section.
 
+### Dependency updates
+
+Patch-level bumps throughout, none of which change behavior: gRPC 1.83.0 → 1.83.1, Ktor 3.5.1 →
+3.5.2, Logback 1.6.0 → 1.6.1, and common-utils 3.2.1 → 3.2.2. Build-only: the shared convention
+plugins 1.1.0 → 1.1.1, and the Gradle versions plugin 0.54.0 → 0.57.0, which also moves coordinate
+from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`. The documentation site's
+Python lock picks up Zensical 0.0.51 → 0.0.52 and Markdown 3.10.2 → 3.10.3.
+
+If you consume the published artifact, none of this needs anything from you — the runtime bumps are
+transitive and the rest is build tooling. If you build from source, the plugin coordinate change is
+the only one that would announce itself, and it does so immediately: an unresolvable plugin id stops
+Gradle configuration outright rather than failing later.
+
 ---
 
 ## 4.0.0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@ by hand.
 
 1) Bump `version` in `gradle.properties` (the single source of truth).
 
-2) Update the `4.0.0` literals in `README.md` and `llms.txt` (the Docker tag examples and the Maven
+2) Update the `4.0.1` literals in `README.md` and `llms.txt` (the Docker tag examples and the Maven
    Central dependency block) to the new version.
 
 3) Update `CHANGELOG.md` and `RELEASE_NOTES.md` with the changes in this release.
@@ -24,8 +24,8 @@ by hand.
    entry it checks. To publish a snapshot instead, use `make publish-snapshot`.
 
 7) Create a release on GitHub (https://github.com/pambrose/prometheus-proxy/releases):
-   - **Tag**: the version with no `v` prefix (e.g. `4.0.0`).
-   - **Title**: the version with a `v` prefix (e.g. `v4.0.0`).
+   - **Tag**: the version with no `v` prefix (e.g. `4.0.1`).
+   - **Title**: the version with a `v` prefix (e.g. `v4.0.1`).
    - **Description**: summarize the changes and include a full-changelog link
      (e.g. `**Full Changelog**: https://github.com/pambrose/prometheus-proxy/compare/<prev>...<new>`).
    - Attach `build/libs/prometheus-agent.jar` and `build/libs/prometheus-proxy.jar`.

--- a/etc/compose/proxy.yml
+++ b/etc/compose/proxy.yml
@@ -1,6 +1,6 @@
 prometheus-proxy:
   autoredeploy: true
-  image: 'pambrose/prometheus-proxy:4.0.0'
+  image: 'pambrose/prometheus-proxy:4.0.1'
   ports:
     - '8080:8080'
     - '8082:8082'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle settings
 group=com.pambrose
-version=4.0.0
+version=4.0.1
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,16 +11,16 @@ serialization = "1.11.0"
 config = "6.0.10"
 detekt = "2.0.0-alpha.5"
 dokka = "2.2.0"
-gradle-plugins = "1.1.0"
+gradle-plugins = "1.1.1"
 kover = "0.9.9"
 maven-publish = "0.37.0"
 protobuf = "0.10.0"
 shadow = "9.6.1"
 taskinfo = "3.0.2"
-versions = "0.54.0"
+versions = "0.57.0"
 
 # gRPC / Protobuf
-grpc = "1.83.0"
+grpc = "1.83.1"
 gengrpc = "1.5.0"
 # Keep in sync with grpc
 protoc = "3.25.3"
@@ -28,7 +28,7 @@ protoc = "3.25.3"
 tcnative = "2.0.75.Final"
 
 # Ktor
-ktor = "3.5.1"
+ktor = "3.5.2"
 
 # WebJars (htmx client assets, served from the classpath -- no CDN, works airgapped)
 htmx = "2.0.10"
@@ -46,7 +46,7 @@ zipkin = "6.3.1"
 
 # Logging
 logging = "8.0.4"
-logback = "1.6.0"
+logback = "1.6.1"
 slf4j = "2.0.18"
 
 # Config / CLI
@@ -54,7 +54,7 @@ typesafe = "1.4.9"
 jcommander = "3.0"
 
 # Common Utils
-utils = "3.2.1"
+utils = "3.2.2"
 
 # Misc
 annotation = "1.3.2"
@@ -178,7 +178,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 # Build / packaging
-ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }
+ben-manes-versions = { id = "io.github.ben-manes.versions", version.ref = "versions" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "config" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/llms.txt
+++ b/llms.txt
@@ -63,7 +63,7 @@ Key RPCs:
 - **Dynamic target discovery** (4.0.0): Opt-in `agent.discovery` reconcile loop keeps registered paths in sync with a watched HOCON/JSON file (`paths` list of `{ name, path, url, labels }`), so targets change at runtime with no agent restart. Static `pathConfigs` are never touched; a read failure keeps the last-known-good set, while a valid-but-empty file removes all discovered paths
 - **Per-agent identities** (4.0.0): `proxy.auth` lists named identities (token + allowed path globs) enforced on every `registerPath`, closing the shared-token hole where any agent could register (and take over) any path. Legacy `proxy.agentToken` is honored as an allow-all identity for migration
 - **Metric filtering** (4.0.0): Optional per-path `agent.filters` (fully-anchored `metricNameAllow` / `metricNameDeny` regexes) drop whole metric families at the agent before gzip/chunking, so unwanted series never cross the WAN. Families are kept or dropped atomically (a histogram's `_bucket`/`_sum`/`_count` stay together); non-text or non-UTF-8 payloads pass through unfiltered (fails open)
-- **Operational dashboard** (4.0.0): Read-only live web UI on its own port (`--dashboard`, default port 8094, off by default, unauthenticated) showing connected agents, registered paths — including paths whose agent has gone — and recent scrape results. Two layouts: `/dashboard` (per-agent) and `/dashboard/paths` (one row per path)
+- **Operational dashboard** (4.0.0): Read-only live web UI on its own port (`--dashboard`, default port 8094, off by default, unauthenticated) showing connected agents, registered paths — including paths whose agent has gone — and recent scrape results. Two layouts: `/dashboard` (per-agent) and `/dashboard/paths` (one row per path). Both identify agents by name, not internal id, so the two layouts can be read against each other (4.0.1). The page meets WCAG AA (measured contrast floor 4.59:1) and announces connection loss and recovery through a live region (4.0.1); `DESIGN.md` records the visual system and the contrast floor
 
 ### Public API Surface
 
@@ -93,12 +93,12 @@ java -jar prometheus-agent.jar --proxy mymachine.local --config myapps.conf
 
 ```bash
 # Start proxy
-docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:4.0.0
+docker run --rm -p 8080:8080 -p 50051:50051 pambrose/prometheus-proxy:4.0.1
 
 # Start agent
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:4.0.0
+  pambrose/prometheus-agent:4.0.1
 ```
 
 ## Configuration
@@ -203,7 +203,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:4.0.0")
+  implementation("com.pambrose:prometheus-proxy:4.0.1")
 }
 ```
 

--- a/src/test/kotlin/website/DockerExamples.txt
+++ b/src/test/kotlin/website/DockerExamples.txt
@@ -1,14 +1,14 @@
 ; --8<-- [start:docker-proxy-basic]
 # Start a proxy container:
 docker run --rm -p 8080:8080 -p 50051:50051 \
-  pambrose/prometheus-proxy:4.0.0
+  pambrose/prometheus-proxy:4.0.1
 ; --8<-- [end:docker-proxy-basic]
 
 ; --8<-- [start:docker-agent-basic]
 # Start an agent with a remote config:
 docker run --rm \
   --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-  pambrose/prometheus-agent:4.0.0
+  pambrose/prometheus-agent:4.0.1
 ; --8<-- [end:docker-agent-basic]
 
 ; --8<-- [start:docker-proxy-production]
@@ -21,7 +21,7 @@ docker run --rm \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
   --restart unless-stopped \
-  pambrose/prometheus-proxy:4.0.0
+  pambrose/prometheus-proxy:4.0.1
 ; --8<-- [end:docker-proxy-production]
 
 ; --8<-- [start:docker-agent-local-config]
@@ -31,7 +31,7 @@ docker run --rm \
   -p 8093:8093 \
   --mount type=bind,source="$(pwd)"/prom-agent.conf,target=/app/prom-agent.conf \
   --env AGENT_CONFIG=prom-agent.conf \
-  pambrose/prometheus-agent:4.0.0
+  pambrose/prometheus-agent:4.0.1
 ; --8<-- [end:docker-agent-local-config]
 
 ; --8<-- [start:docker-compose-full]
@@ -39,7 +39,7 @@ version: '3.8'
 
 services:
   proxy:
-    image: pambrose/prometheus-proxy:4.0.0
+    image: pambrose/prometheus-proxy:4.0.1
     ports:
       - "8080:8080"    # HTTP scrape port
       - "50051:50051"  # gRPC agent port
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   agent:
-    image: pambrose/prometheus-agent:4.0.0
+    image: pambrose/prometheus-agent:4.0.1
     ports:
       - "8083:8083"    # Metrics port
       - "8093:8093"    # Admin port
@@ -81,7 +81,7 @@ docker run --rm \
   --env PROXY_CONFIG=tls.conf \
   --env ADMIN_ENABLED=true \
   --env METRICS_ENABLED=true \
-  pambrose/prometheus-proxy:4.0.0
+  pambrose/prometheus-proxy:4.0.1
 
 # Agent with TLS (no mutual auth):
 docker run --rm \
@@ -91,7 +91,7 @@ docker run --rm \
   --mount type=bind,source="$(pwd)"/tls.conf,target=/app/tls.conf \
   --env AGENT_CONFIG=tls.conf \
   --env PROXY_HOSTNAME=proxy-host:50440 \
-  pambrose/prometheus-agent:4.0.0
+  pambrose/prometheus-agent:4.0.1
 ; --8<-- [end:docker-tls]
 
 ; --8<-- [start:docker-env-vars]

--- a/src/test/kotlin/website/EmbeddedAgentExamples.txt
+++ b/src/test/kotlin/website/EmbeddedAgentExamples.txt
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.pambrose:prometheus-proxy:4.0.0")
+  implementation("com.pambrose:prometheus-proxy:4.0.1")
 }
 // --8<-- [end:gradle-dependency]
 
@@ -15,7 +15,7 @@ dependencies {
   <dependency>
     <groupId>com.pambrose</groupId>
     <artifactId>prometheus-proxy</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
   </dependency>
 </dependencies>
 <!-- --8<-- [end:maven-dependency] -->

--- a/src/test/kotlin/website/KubernetesExamples.txt
+++ b/src/test/kotlin/website/KubernetesExamples.txt
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: proxy
-          image: pambrose/prometheus-proxy:4.0.0
+          image: pambrose/prometheus-proxy:4.0.1
           ports:
             - { name: http, containerPort: 8080 }     # Prometheus scrapes here
             - { name: grpc, containerPort: 50051 }     # agents connect here
@@ -110,7 +110,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: pambrose/prometheus-agent:4.0.0
+          image: pambrose/prometheus-agent:4.0.1
           ports:
             - { name: metrics, containerPort: 8083 }
             - { name: admin, containerPort: 8093 }
@@ -163,7 +163,7 @@ spec:
           ports:
             - { name: metrics, containerPort: 9100 }
         - name: prometheus-agent
-          image: pambrose/prometheus-agent:4.0.0
+          image: pambrose/prometheus-agent:4.0.1
           env:
             - { name: PROXY_HOSTNAME, value: "proxy.example.com:50051" }
             - { name: AGENT_CONFIG, value: /app/agent.conf }

--- a/website/prometheus-proxy/docs/docker.md
+++ b/website/prometheus-proxy/docs/docker.md
@@ -7,8 +7,8 @@ icon: lucide/container
 Multi-platform images (amd64, arm64, s390x, ppc64le) are published on Docker Hub for every release.
 
 ```bash
-docker pull pambrose/prometheus-proxy:4.0.0
-docker pull pambrose/prometheus-agent:4.0.0
+docker pull pambrose/prometheus-proxy:4.0.1
+docker pull pambrose/prometheus-agent:4.0.1
 ```
 
 ## Basic Usage
@@ -77,4 +77,4 @@ docker pull pambrose/prometheus-agent:latest
 
 !!! tip "Pin versions in production"
 
-    Use explicit version tags (e.g., `4.0.0`) in production to avoid unexpected upgrades.
+    Use explicit version tags (e.g., `4.0.1`) in production to avoid unexpected upgrades.

--- a/website/prometheus-proxy/docs/getting-started.md
+++ b/website/prometheus-proxy/docs/getting-started.md
@@ -31,8 +31,8 @@ icon: lucide/play
     Multi-platform images (amd64, arm64, s390x) are available on Docker Hub:
 
     ```bash
-    docker pull pambrose/prometheus-proxy:4.0.0
-    docker pull pambrose/prometheus-agent:4.0.0
+    docker pull pambrose/prometheus-proxy:4.0.1
+    docker pull pambrose/prometheus-agent:4.0.1
     ```
 
 ## Start the Proxy
@@ -54,7 +54,7 @@ The proxy runs outside the firewall alongside your Prometheus server.
 
     ```bash
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:4.0.0
+      pambrose/prometheus-proxy:4.0.1
     ```
 
 ## Start the Agent
@@ -108,7 +108,7 @@ Each entry in `pathConfigs` maps:
       --mount type=bind,source="$(pwd)"/agent.conf,target=/app/agent.conf \
       --env AGENT_CONFIG=agent.conf \
       --env PROXY_HOSTNAME=proxy-host.example.com \
-      pambrose/prometheus-agent:4.0.0
+      pambrose/prometheus-agent:4.0.1
     ```
 
 === "Remote Config"

--- a/website/prometheus-proxy/docs/index.md
+++ b/website/prometheus-proxy/docs/index.md
@@ -86,12 +86,12 @@ Get running in under a minute:
     ```bash
     # Start the proxy
     docker run --rm -p 8080:8080 -p 50051:50051 \
-      pambrose/prometheus-proxy:4.0.0
+      pambrose/prometheus-proxy:4.0.1
 
     # Start the agent
     docker run --rm \
       --env AGENT_CONFIG='https://raw.githubusercontent.com/pambrose/prometheus-proxy/master/examples/simple.conf' \
-      pambrose/prometheus-agent:4.0.0
+      pambrose/prometheus-agent:4.0.1
     ```
 
 See the [Quick Start Guide](getting-started.md) for detailed instructions.

--- a/website/uv.lock
+++ b/website/uv.lock
@@ -45,11 +45,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805 }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180 },
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757 },
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ dev = [{ name = "zensical", specifier = ">=0.0.31" }]
 
 [[package]]
 name = "zensical"
-version = "0.0.51"
+version = "0.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -186,18 +186,18 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/f7/d07ffb268ca86afb26b7f32dbabe25dec03d3aa63ba4d876720c84681d33/zensical-0.0.51.tar.gz", hash = "sha256:de25de067bedfa18f916d7f366fd64a7fbf09bfcc615b44d1ddbe3b5fe02ab49", size = 3979640 }
+sdist = { url = "https://files.pythonhosted.org/packages/22/53/f3657dc0ed7666b29cededfeb424b28b8cf1f6ca75f7066af76fca8c1bcf/zensical-0.0.52.tar.gz", hash = "sha256:b11b79dd1bb7da4c1a5293cbc5a2f4394d980bf2bf1c4c326062bc5ddcf2a2e8", size = 3991761 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/21/02db3e1fb3904016bfac310037c95b9f1eaaf0ffe7b4a84f14263a7d95df/zensical-0.0.51-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:134d776afa526098e05e34713e2f577c075e57a232e01b97842bb0206716afce", size = 12791154 },
-    { url = "https://files.pythonhosted.org/packages/a2/35/b0d96f58253514cb3d08f5779020ab01ee5472334fb984b92e3fc9e9c9ac/zensical-0.0.51-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e97ab39668ae3b452c550634e921a0336443743aae5e1fe031c7bb57d049e535", size = 12692190 },
-    { url = "https://files.pythonhosted.org/packages/2e/90/7a60e126a10c37c6b789938ff17e73fe76bba707fa029cb40ac659aeaa82/zensical-0.0.51-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c9579809f88608e7aa2cff516fff9d267d74a843cf6088a5f4227de2f092bb5", size = 13139337 },
-    { url = "https://files.pythonhosted.org/packages/ae/c3/9101c97b90d4713ef2816db03366a45ae4762efebffd296737a2dd2df325/zensical-0.0.51-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296dc7a14aa28b81a58eb57df2d5c9c9a4b0de7e90c11d99c943354287952925", size = 13069851 },
-    { url = "https://files.pythonhosted.org/packages/d2/79/0474df9e15a2c18f6281a786e10177c1b6e16feac1c568e7f36ad39b339c/zensical-0.0.51-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f779d2d87b4bf228cf2e279bc0ae6bcf3b36a9335ff283a317d01f7c15ae46b2", size = 13451083 },
-    { url = "https://files.pythonhosted.org/packages/fe/6f/91bbf78f704d5fd4c0c9be27d6bce3b6e4c2c339e4dcd6e7cf19ecda643c/zensical-0.0.51-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f813a1514a90890ca86248a8d54b81b2164bcbff11a6bcf11b01e1c01a1454", size = 13110446 },
-    { url = "https://files.pythonhosted.org/packages/d9/89/aa9a95f81771614c37bdc52b8ab21fcdef4c8de7c9cedf34e9bf62674281/zensical-0.0.51-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:186ef37e0eee0e969e2cfae47b1b97775e3164e2cba95c71faa4dd6ef47ed009", size = 13315871 },
-    { url = "https://files.pythonhosted.org/packages/08/11/1bf6e9ded29d376f8c12644cc4de04676b010fee8caa17f682606b1f16d5/zensical-0.0.51-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5d91ce246ed930224603083cef02ae8947132fc7c52901d72015ea03526fa58", size = 13344382 },
-    { url = "https://files.pythonhosted.org/packages/d6/ec/663f16ff82d08b212e7c3236a88bd332f73331f94ddac1c91aaf882bbd1e/zensical-0.0.51-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:b1108eae82c6e8ffc33026f60b485c1512647a5333be4f547166b7c8877b98af", size = 13499628 },
-    { url = "https://files.pythonhosted.org/packages/60/b4/7f1b6c3cf06d9f6ff5216523168a5d6ccc693444d5ceeb911eca97b30d98/zensical-0.0.51-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6fa0ecaf14f56841bfc595fa141396350c72aafbec73a016ebe3c824ed21ac72", size = 13451420 },
-    { url = "https://files.pythonhosted.org/packages/0a/44/be4bc09ec8f69e7be1b07b875887961c4e0e478b03a10d2cc624ef28fbe6/zensical-0.0.51-cp310-abi3-win32.whl", hash = "sha256:fb7ff4946b72168759c6af0a29cf5de4c38aebe633a83292e8cd4145b5213cc2", size = 12375639 },
-    { url = "https://files.pythonhosted.org/packages/1f/85/aa827c244ed4f404e99a91c3ecf5e5adb62eca806a9e9c8e3333bbad8660/zensical-0.0.51-cp310-abi3-win_amd64.whl", hash = "sha256:12529d3d3991b63820952111dc1d1edc29b2c9b3a3abb16c243bcb649631ebf2", size = 12628965 },
+    { url = "https://files.pythonhosted.org/packages/54/32/e143d094f832d8a2de6b56f2e20c40437d06376be69117d8e725d00e22c4/zensical-0.0.52-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7e5fa1df686af8ef223d16637fd31fe2ab248a8b40556037c50af1102b05f5ed", size = 12839791 },
+    { url = "https://files.pythonhosted.org/packages/13/e6/746c00830a4149826190f99e182cf5642745978d8702372e8370c7ec8a12/zensical-0.0.52-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:20117f935e23900411e5d03ef1d15b3e5ef3f8730d9096a49eb08754fef1f2d4", size = 12723378 },
+    { url = "https://files.pythonhosted.org/packages/9c/5b/904fa8d57dd27682dcd2a8c683661f0d6e12c111d150b34c7d568ac80018/zensical-0.0.52-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d889b32121fa43061a902c49d976353a674ae566803ac0ea5d41f01aa5da131", size = 13173818 },
+    { url = "https://files.pythonhosted.org/packages/8c/28/f124a2a512ae0d5d9d158b1cf31798e3191eb9a21ac8ccfdc9cc38e09a7a/zensical-0.0.52-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:61b62d254d47e82fb687bc8a74a1f0220a900a0f3ca4bb6c93eab51ca7c8391a", size = 13111975 },
+    { url = "https://files.pythonhosted.org/packages/10/09/bdcb062263005e0430a532e72ea32a24955208ae92191f02d38abd58b793/zensical-0.0.52-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9d09e7fd0d80418639482212fbce19d09877cbef92a4122030e5d19b32dbea08", size = 13498189 },
+    { url = "https://files.pythonhosted.org/packages/5a/60/7c3d6cee180a65e06a22de8a143d9ae4791ebae5278fd1abd2977fdc69b0/zensical-0.0.52-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6df854d07f5d89a47f37f661058bc3f95efc64d45b0d5500ea46821244f69c16", size = 13145652 },
+    { url = "https://files.pythonhosted.org/packages/1d/76/e794e77745017652344463a3c4ba286073ca26a43b0c86dcb40ae0dac0b5/zensical-0.0.52-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:188e15376b3718e6e880751c4014e394b59f798329bc21e39c950cc58254a32c", size = 13349087 },
+    { url = "https://files.pythonhosted.org/packages/a2/ba/6a38f9c29392c1d5729b25d24c8526d3f86c8133bbd2d8481acf1d1bdc78/zensical-0.0.52-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:40cde85bf35901a4c14a56349502b6d3c754d4386de6b887d498cd7269757e00", size = 13385257 },
+    { url = "https://files.pythonhosted.org/packages/02/b6/c82317c747ec39e1557aeb2b762087bc22437f80a07a16df21df666ac250/zensical-0.0.52-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:d26c29272ce5bad16564a19ecdfd43bbd9b41568a57b923e8b710359de633322", size = 13550906 },
+    { url = "https://files.pythonhosted.org/packages/c6/77/b7c83ddced2887b03113c322036f74a2d519ae5599cbb2662e8d7f5c7e2c/zensical-0.0.52-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5a1e1c6c99ae50e98cac957bb48719aecec57aa47899462acd65b2fa9afcbcdd", size = 13485819 },
+    { url = "https://files.pythonhosted.org/packages/b8/88/fcaee358b7e9d380ccdeb6d3a434b24cd6df6b48ff077bdda0046d8fb6c0/zensical-0.0.52-cp310-abi3-win32.whl", hash = "sha256:4ef40c8d2e8fc84886a28704667e38b7f89663cff32a57db5e909a26cf5cf66a", size = 12410758 },
+    { url = "https://files.pythonhosted.org/packages/9d/1c/d410a93763cafb8827e4e318bad369b84068047c4d658b511c9307104a62/zensical-0.0.52-cp310-abi3-win_amd64.whl", hash = "sha256:dd904e316f1cdc4fee707febdd85d0ac13f742a8ba14da9f9a4dacb8603fe480", size = 12662400 },
 ]


### PR DESCRIPTION
Prepares the 4.0.1 patch release. Steps 1–3 of `docs/RELEASE.md`, plus dependency updates; the publish steps are not part of this PR.

## What's in 4.0.1

The four commits since the `4.0.0` tag:

| Commit | Change |
|---|---|
| `6c64192` | Dashboard accessibility + agent-name identification (#229) |
| `32225e7` | `kotlin.concurrent.atomics.AtomicBoolean` in `MetricFilter` (#228) |
| `8962679` | `website/uv.lock` package refresh |
| `1633317` | README documentation-link formatting |

Nothing here changes configuration, metrics, or the wire protocol, so the release notes state up front that upgrading is a drop-in replacement rather than leaving operators to infer that from the absence of an upgrade section.

## Changes

**Version.** `gradle.properties` → `4.0.1`. Verified: `BuildConfig.APP_VERSION` reads `4.0.1` and `APP_RELEASE_DATE` auto-populates to `07/31/2026`.

**`CHANGELOG.md` / `RELEASE_NOTES.md`.** New sections for 4.0.1 in each file's existing style — the changelog itemized by category, the release notes leading with why the dashboard fixes mattered (the two layouts are meant to be read against each other, and an internal id in one of them defeated that).

**`README.md`.** A 4.0.1 paragraph above the 4.0.0 feature list, whose intro moved to past tense; an accessibility note in the Operational Dashboard section; Docker and Maven tags.

**`llms.txt`.** Tags, plus the dashboard entry extended with the agent-naming and accessibility facts, marked `(4.0.1)`. The `(4.0.0)` markers on the other five features stay — they record when each shipped, not the current version.

**`CLAUDE.md`.** New **Dashboard Design Constraints** section. Each of the three rules is load-bearing and easy to undo by accident while making a change that looks unrelated:

- the live region must stay outside every `hx-swap-oob` region, or the push loop re-announces it every frame
- colors must be checked against `--surface-2`, not `--surface` — where all 29 of the fixed contrast failures lived
- both layouts must render identity through `agentLabel()`, or the cross-layout correlation breaks

The measured values behind them are in `DESIGN.md`.

## Version literals beyond the two files `docs/RELEASE.md` names

`docs/RELEASE.md` step 2 lists only `README.md` and `llms.txt`, but the literals have spread since that step was written. Also bumped:

- `etc/compose/proxy.yml`
- `website/prometheus-proxy/docs/{docker,getting-started,index}.md`
- `src/test/kotlin/website/{Docker,Kubernetes,EmbeddedAgent}Examples.txt` — these are `--8<--` snippet sources the website includes, so leaving them behind would publish a docs site contradicting the README
- `PRODUCT.md`'s release-evidence line
- the stale `4.0.0` examples inside `docs/RELEASE.md` and `.claude/skills/publishing-release/SKILL.md`, since those instruct the *next* bump

Worth considering separately: that list is long enough that step 2 would be better served by a script than by an enumeration of files.

## Dependency updates

Second commit. Patch-level bumps: gRPC 1.83.0 → 1.83.1, Ktor 3.5.1 → 3.5.2, Logback 1.6.0 → 1.6.1, common-utils 3.2.1 → 3.2.2, convention plugins 1.1.0 → 1.1.1, and — in the docs-site lock — Zensical 0.0.51 → 0.0.52 and Markdown 3.10.2 → 3.10.3.

One of these is not a version number: the Gradle versions plugin moves coordinate from `com.github.ben-manes.versions` to `io.github.ben-manes.versions`. It's also the one that fails loudly rather than subtly — an unresolvable plugin id stops configuration outright — and it resolves.

## Verification

`./gradlew detekt lintKotlinMain lintKotlinTest test` passes against the committed state, dependency bumps included. No test asserts on the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
